### PR TITLE
Move SerializableError to separate subproject

### DIFF
--- a/error-handling/build.gradle
+++ b/error-handling/build.gradle
@@ -1,0 +1,14 @@
+apply from: "${rootDir}/gradle/libs.gradle"
+apply from: "${rootDir}/gradle/publish.gradle"
+
+group 'com.palantir.remoting.error'
+
+dependencies {
+    compile libs.feign.jackson
+    compile libs.jackson.databind
+    compile libs.jsr305
+
+    processor libs.immutables
+}
+
+tasks.check.dependsOn(javadoc)

--- a/error-handling/src/main/java/com/palantir/remoting/http/errors/SerializableError.java
+++ b/error-handling/src/main/java/com/palantir/remoting/http/errors/SerializableError.java
@@ -22,6 +22,11 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
+/**
+ * A JSON-serializable representation of a generic Java exception, represented by its exception message, exception
+ * class, and stacktrace. Intended to transport exceptions through non-Java channels such as HTTP responses in order to
+ * be de-serialized and potentially rethrown on the other end.
+ */
 @JsonDeserialize(as = ImmutableSerializableError.class)
 @JsonSerialize(as = ImmutableSerializableError.class)
 @Value.Immutable

--- a/remote-clients/build.gradle
+++ b/remote-clients/build.gradle
@@ -4,6 +4,8 @@ apply from: "${rootDir}/gradle/publish.gradle"
 group 'com.palantir.remoting.http'
 
 dependencies {
+    compile project(':error-handling')
+
     compile libs.feign.jackson
     compile libs.feign.jaxrs
     compile libs.feign.okhttp

--- a/remote-clients/src/main/java/com/palantir/remoting/http/errors/SerializableErrorErrorDecoder.java
+++ b/remote-clients/src/main/java/com/palantir/remoting/http/errors/SerializableErrorErrorDecoder.java
@@ -31,6 +31,12 @@ import javax.ws.rs.core.MediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A feign {@link ErrorDecoder} that attempts to interpret the {@link Response}'s body as a JSON representation of a
+ * {@link SerializableError} and re-throws the encoded exception including exception type, message, and stacktrace.
+ * Throws a {@link RuntimeException} if the body cannot be interpreted as a {@link SerializableError}, or if the
+ * exception fails to get re-thrown.
+ */
 public final class SerializableErrorErrorDecoder implements ErrorDecoder {
     private static final Logger log = LoggerFactory.getLogger(SerializableErrorErrorDecoder.class);
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,4 +2,5 @@ rootProject.name = 'http-remoting'
 
 include 'remote-clients'
 include 'trust-stores'
+include 'error-handling'
 


### PR DESCRIPTION
This is to prepare for a future 'server' subproject that will use the SerializableError server-side.
