### PR TITLE
remove unused dependency versions in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,4 @@
 baselineVersion=0.2.2
 bintrayPlugin=1.4
 
-# compile
-guavaVersion=18.0
-feignVersion=8.10.0
-jacksonVersion=2.6.1
-jaxRsVersion=2.0.1
-jsr305Version=3.0.0
-slf4jVersion=1.7.12
-
-# processors
-immutablesVersion=2.0.21
+# other dependency versions are specified in gradle/libs.gradle


### PR DESCRIPTION
Fixes #20: Reduces confusion especially when the versions don't match between
gradle.properties and lib.gradle.
