### PR TITLE
Allow endpoints to return InputStreams

### DIFF
--- a/http-clients/src/main/java/com/palantir/remoting/http/FeignClients.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/FeignClients.java
@@ -19,6 +19,8 @@ package com.palantir.remoting.http;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.palantir.remoting.http.errors.SerializableErrorErrorDecoder;
+import feign.InputStreamDelegateDecoder;
+import feign.InputStreamDelegateEncoder;
 import feign.OptionalAwareDecoder;
 import feign.TextDelegateDecoder;
 import feign.jackson.JacksonDecoder;
@@ -41,8 +43,11 @@ public final class FeignClients {
     public static FeignClientFactory standard() {
         return FeignClientFactory.of(
                 new GuavaOptionalAwareContract(new JAXRSContract()),
-                new JacksonEncoder(ObjectMappers.guavaJdk7()),
-                new OptionalAwareDecoder(new TextDelegateDecoder(new JacksonDecoder(ObjectMappers.guavaJdk7()))),
+                new InputStreamDelegateEncoder(new JacksonEncoder(ObjectMappers.guavaJdk7())),
+                new OptionalAwareDecoder(
+                        new InputStreamDelegateDecoder(
+                                new TextDelegateDecoder(
+                                        new JacksonDecoder(ObjectMappers.guavaJdk7())))),
                 SerializableErrorErrorDecoder.INSTANCE,
                 FeignClientFactory.okHttpClient());
     }
@@ -53,8 +58,11 @@ public final class FeignClients {
     public static FeignClientFactory vanilla() {
         return FeignClientFactory.of(
                 new GuavaOptionalAwareContract(new JAXRSContract()),
-                new JacksonEncoder(ObjectMappers.vanilla()),
-                new OptionalAwareDecoder(new TextDelegateDecoder(new JacksonDecoder(ObjectMappers.vanilla()))),
+                new InputStreamDelegateEncoder(new JacksonEncoder(ObjectMappers.vanilla())),
+                new OptionalAwareDecoder(
+                        new InputStreamDelegateDecoder(
+                                new TextDelegateDecoder(
+                                        new JacksonDecoder(ObjectMappers.vanilla())))),
                 SerializableErrorErrorDecoder.INSTANCE,
                 FeignClientFactory.okHttpClient());
     }
@@ -65,8 +73,11 @@ public final class FeignClients {
     public static FeignClientFactory withMapper(ObjectMapper mapper) {
         return FeignClientFactory.of(
                 new GuavaOptionalAwareContract(new JAXRSContract()),
-                new JacksonEncoder(mapper),
-                new OptionalAwareDecoder(new TextDelegateDecoder(new JacksonDecoder(mapper))),
+                new InputStreamDelegateEncoder(new JacksonEncoder(mapper)),
+                new OptionalAwareDecoder(
+                        new InputStreamDelegateDecoder(
+                                new TextDelegateDecoder(
+                                        new JacksonDecoder(mapper)))),
                 SerializableErrorErrorDecoder.INSTANCE,
                 FeignClientFactory.okHttpClient());
     }

--- a/http-clients/src/main/java/feign/InputStreamDelegateDecoder.java
+++ b/http-clients/src/main/java/feign/InputStreamDelegateDecoder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign;
+
+import feign.codec.Decoder;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+
+/**
+ * If the return type is InputStream, return it, otherwise delegate to provided decoder.
+ */
+public final class InputStreamDelegateDecoder implements Decoder {
+    private final Decoder delegate;
+
+    public InputStreamDelegateDecoder(Decoder delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object decode(Response response, Type type) throws IOException, FeignException {
+        if (type.equals(InputStream.class)) {
+            byte[] body = Util.toByteArray(response.body().asInputStream());
+            return new ByteArrayInputStream(body);
+        } else {
+            return delegate.decode(response, type);
+        }
+    }
+}

--- a/http-clients/src/main/java/feign/InputStreamDelegateEncoder.java
+++ b/http-clients/src/main/java/feign/InputStreamDelegateEncoder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign;
+
+import com.google.common.base.Charsets;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+
+/**
+ * If the body type is an InputStream, write it into the body, otherwise pass to delegate.
+ */
+public final class InputStreamDelegateEncoder implements Encoder {
+    private final Encoder delegate;
+
+    public InputStreamDelegateEncoder(Encoder delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
+        if (bodyType.equals(InputStream.class)) {
+            try {
+                template.body(Util.toByteArray((InputStream) object), Charsets.UTF_8);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            delegate.encode(object, bodyType, template);
+        }
+    }
+}

--- a/http-clients/src/test/java/feign/InputStreamDelegateDecoderTest.java
+++ b/http-clients/src/test/java/feign/InputStreamDelegateDecoderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.remoting.http.FeignClients;
+import feign.codec.Decoder;
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public final class InputStreamDelegateDecoderTest {
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> APP = new DropwizardAppRule<>(TestServer.class,
+            "src/test/resources/test-server.yml");
+
+    private TestServer.TestService service;
+    private Decoder delegate;
+    private Decoder inputStreamDelegateDecoder;
+
+    @Before
+    public void before() {
+        delegate = mock(Decoder.class);
+        inputStreamDelegateDecoder = new InputStreamDelegateDecoder(delegate);
+
+        String endpointUri = "http://localhost:" + APP.getLocalPort();
+        service = FeignClients.standard().createProxy(Optional.<SSLSocketFactory>absent(), endpointUri,
+                TestServer.TestService.class);
+    }
+
+    @Test
+    public void testDecodesAsInputStream() throws Exception {
+        String data = "data";
+
+        Response response =
+                Response.create(200, "OK", ImmutableMap.<String, Collection<String>>of(), data, Charsets.UTF_8);
+
+        InputStream decoded = (InputStream) inputStreamDelegateDecoder.decode(response, InputStream.class);
+
+        assertThat(new String(Util.toByteArray(decoded), Charsets.UTF_8), is(data));
+    }
+
+    @Test
+    public void testUsesDelegateWhenReturnTypeNotInputStream() throws Exception {
+        String returned = "string";
+
+        when(delegate.decode((Response) any(), (Type) any())).thenReturn(returned);
+        Response response =
+                Response.create(200, "OK", ImmutableMap.<String, Collection<String>>of(), returned, Charsets.UTF_8);
+        String decodedObject = (String) inputStreamDelegateDecoder.decode(response, String.class);
+        assertEquals(returned, decodedObject);
+    }
+
+    @Test
+    public void testStandardClientsUseInputStreamDelegateDecoder() throws IOException {
+        String data = "bytes";
+        assertThat(Util.toByteArray(service.writeInputStream(data)), is(bytes(data)));
+    }
+
+    private static byte[] bytes(String text) {
+        return text.getBytes(Charsets.UTF_8);
+    }
+}

--- a/http-clients/src/test/java/feign/InputStreamDelegateEncoderTest.java
+++ b/http-clients/src/test/java/feign/InputStreamDelegateEncoderTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Optional;
+import com.palantir.remoting.http.FeignClients;
+import feign.codec.Encoder;
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class InputStreamDelegateEncoderTest {
+    @Mock
+    private Encoder delegate;
+
+    private final RequestTemplate requestTemplate = new RequestTemplate();
+
+    private Encoder inputStreamDelegateEncoder;
+
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> APP = new DropwizardAppRule<>(TestServer.class,
+            "src/test/resources/test-server.yml");
+
+    private TestServer.TestService service;
+
+    @Before
+    public void before() {
+        inputStreamDelegateEncoder = new InputStreamDelegateEncoder(delegate);
+
+        String endpointUri = "http://localhost:" + APP.getLocalPort();
+        service = FeignClients.standard().createProxy(Optional.<SSLSocketFactory>absent(), endpointUri,
+                TestServer.TestService.class);
+    }
+
+    @Test
+    public void testEncodesAsInputStream() throws Exception {
+        byte[] object = bytes("data");
+
+        inputStreamDelegateEncoder.encode(new ByteArrayInputStream(object), InputStream.class, requestTemplate);
+
+        assertThat(requestTemplate.body(), is(object));
+    }
+
+    @Test
+    public void testUsesDelegateWithNonInputStreamBodyType() throws Exception {
+        String data = "data";
+
+        inputStreamDelegateEncoder.encode(data, String.class, requestTemplate);
+
+        verify(delegate).encode(data, String.class, requestTemplate);
+    }
+
+    @Test
+    public void testStandardClientsUseByteArrayDelegateEncoder() {
+        String data = "bytes";
+        assertThat(service.readInputStream(new ByteArrayInputStream(bytes(data))), is(data));
+    }
+
+    private static byte[] bytes(String text) {
+        return text.getBytes(Charsets.UTF_8);
+    }
+}

--- a/http-clients/src/test/java/feign/TestServer.java
+++ b/http-clients/src/test/java/feign/TestServer.java
@@ -4,6 +4,7 @@
 
 package feign;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.remoting.http.server.ForbiddenExceptionMapper;
@@ -13,12 +14,16 @@ import com.palantir.remoting.http.server.OptionalAsNoContentMessageBodyWriter;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Environment;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -107,6 +112,20 @@ public class TestServer extends Application<Configuration> {
         }
 
         @Override
+        public InputStream writeInputStream(String bytes) {
+            return new ByteArrayInputStream(bytes.getBytes(Charsets.UTF_8));
+        }
+
+        @Override
+        public String readInputStream(InputStream data) {
+            try {
+                return new String(Util.toByteArray(data), Charsets.UTF_8);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
         public Optional<String> getOptionalString(@Nullable String value) {
             return Optional.fromNullable(value);
         }
@@ -164,6 +183,18 @@ public class TestServer extends Application<Configuration> {
         @Consumes(MediaType.TEXT_PLAIN)
         @Produces(MediaType.TEXT_PLAIN)
         String getString(@QueryParam("value") @Nullable String value);
+
+        @GET
+        @Path("/writeInputStream")
+        @Consumes(MediaType.TEXT_PLAIN)
+        @Produces(MediaType.TEXT_PLAIN)
+        InputStream writeInputStream(@QueryParam("value") @Nullable String bytes);
+
+        @POST
+        @Path("/readInputStream")
+        @Consumes(MediaType.TEXT_PLAIN)
+        @Produces(MediaType.TEXT_PLAIN)
+        String readInputStream(InputStream data);
 
         @GET
         @Path("/optionalString")


### PR DESCRIPTION
At present, Jackson attempts to decode application/octet-stream bodies,
even though they are not JSON. Instead, decode application/octet-stream
responses with return type byte[] to a byte array, and
application/octet-stream requests with body type byte[] as a byte array
also.
