### PR TITLE
Decode general web exceptions

### DIFF
--- a/http-clients/src/test/java/com/palantir/remoting/http/errors/SerializableErrorErrorDecoderTests.java
+++ b/http-clients/src/test/java/com/palantir/remoting/http/errors/SerializableErrorErrorDecoderTests.java
@@ -18,6 +18,7 @@ package com.palantir.remoting.http.errors;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,25 +26,35 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import feign.Response;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Collections;
 import javax.annotation.CheckForNull;
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
 import org.junit.Test;
 
 public final class SerializableErrorErrorDecoderTests {
 
     private static final SerializableErrorErrorDecoder decoder = SerializableErrorErrorDecoder.INSTANCE;
+    private static final String message = "hello";
 
     @Test
-    public void testJsonException() throws JsonProcessingException {
-        Object error = SerializableError.of("msg", IllegalArgumentException.class, null);
-        String json = new ObjectMapper().writeValueAsString(error);
-        Response response = getResponse(MediaType.APPLICATION_JSON, json);
-        Exception decode = decoder.decode("ignored", response);
-        assertThat(decode, is(instanceOf(IllegalArgumentException.class)));
-        assertThat(decode.getMessage(), is("msg"));
+    public void testWebApplicationExceptions() {
+        testEncodingAndDecodingWebException(ClientErrorException.class, Status.NOT_ACCEPTABLE);
+        testEncodingAndDecodingWebException(ServerErrorException.class, Status.BAD_GATEWAY);
+        testEncodingAndDecodingWebException(WebApplicationException.class, Status.NOT_MODIFIED);
+    }
+
+    @Test
+    public void testSpecificException() {
+        Exception exception = encodeAndDecode(new IllegalArgumentException("msg"));
+        assertThat(exception, is(instanceOf(IllegalArgumentException.class)));
+        assertThat(exception.getMessage(), is("msg"));
     }
 
     @Test
@@ -106,9 +117,51 @@ public final class SerializableErrorErrorDecoderTests {
         assertThat(decode.getCause().getStackTrace()[0].getMethodName(), is("testClientExceptionWrapsServerException"));
     }
 
+    private static Exception encodeAndDecode(Exception exception) {
+        Object error = SerializableError.of(exception.getMessage(), exception.getClass(), null);
+        String json;
+        try {
+            json = new ObjectMapper().writeValueAsString(error);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        int status = (exception instanceof WebApplicationException)
+                ? ((WebApplicationException) exception).getResponse().getStatus()
+                : 400;
+        Response response = getResponse(MediaType.APPLICATION_JSON, json, status);
+        return decoder.decode("ignored", response);
+    }
+
     private static Response getResponse(String contentType, @CheckForNull String body) {
-        return Response.create(400, "reason", ImmutableMap.<String, Collection<String>>of(HttpHeaders.CONTENT_TYPE,
+        return getResponse(contentType, body, 400);
+    }
+
+    private static Response getResponse(String contentType, @CheckForNull String body, int status) {
+        return Response.create(status, "reason", ImmutableMap.<String, Collection<String>>of(HttpHeaders.CONTENT_TYPE,
                 Collections.singletonList(contentType)), body, feign.Util.UTF_8);
+    }
+
+    private static void testEncodingAndDecodingWebException(Class<? extends WebApplicationException> exceptionClass,
+            Status status) {
+        WebApplicationException exceptionToProcess;
+        try {
+            exceptionToProcess = exceptionClass.getConstructor(String.class, Status.class).newInstance(message, status);
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException | SecurityException e) {
+            throw new RuntimeException(e);
+        }
+
+        Exception exception = encodeAndDecode(exceptionToProcess);
+        assertThat(exception.getCause(), is(instanceOf(exceptionClass)));
+        assertEquals(status, ((WebApplicationException) exception.getCause()).getResponse()
+                .getStatusInfo());
+        assertEquals(message, exception.getCause().getMessage());
+
+        assertThat(exception, is(instanceOf(exceptionClass)));
+        assertEquals(status, ((WebApplicationException) exception).getResponse()
+                .getStatusInfo());
+        assertEquals(message, exception.getMessage());
     }
 
 }


### PR DESCRIPTION
Previously, exceptions corresponding to specific HTTP error codes (e.g. BadRequestException) would be properly decoded, but more general exceptions that just hold a status value (e.g. ClientErrorException) would fail to decode.

We now handle:
- WebApplicationException
- ServerErrorException
- ClientErrorException

Fixes #24 
