### PR TITLE
Remove unit test that was system-dependent

### DIFF
--- a/ssl-config/src/test/java/com/palantir/ssl/SslSocketFactoriesConnectionTests.java
+++ b/ssl-config/src/test/java/com/palantir/ssl/SslSocketFactoriesConnectionTests.java
@@ -117,29 +117,6 @@ public final class SslSocketFactoriesConnectionTests {
     }
 
     @Test
-    public void testSslNoClientAuthenticationFailsWithMultipleKeyStoreUnspecified() {
-        TrustStoreConfiguration serverTrustStoreConfig = TrustStoreConfiguration.of(TestConstants.CA_TRUST_STORE_PATH);
-        // bad configuration: specified key store has multiple key entries and first
-        // one that is returned is not the correct key
-        KeyStoreConfiguration serverKeyStoreConfig = KeyStoreConfiguration.of(
-                TestConstants.MULTIPLE_KEY_STORE_JKS_PATH,
-                TestConstants.MULTIPLE_KEY_STORE_JKS_PASSWORD);
-        SslConfiguration serverConfig = SslConfiguration.of(serverTrustStoreConfig, serverKeyStoreConfig);
-
-        TrustStoreConfiguration clientTrustStoreConfig = TrustStoreConfiguration.of(
-                TestConstants.SERVER_KEY_STORE_JKS_PATH);
-        SslConfiguration clientConfig = SslConfiguration.of(clientTrustStoreConfig);
-
-        try {
-            runSslConnectionTest(serverConfig, clientConfig, ClientAuth.NO_CLIENT_AUTH);
-            fail();
-        } catch (RuntimeException ex) {
-            assertThat(ex.getCause(), is(instanceOf(SSLHandshakeException.class)));
-            assertThat(ex.getMessage(), containsString("PKIX path building failed"));
-        }
-    }
-
-    @Test
     public void testSslNoClientAuthenticationFailsWithMultipleKeyStoreSpecified() {
         TrustStoreConfiguration serverTrustStoreConfig = TrustStoreConfiguration.of(TestConstants.CA_TRUST_STORE_PATH);
 


### PR DESCRIPTION
Fixes issue #50. The test in question assumed
that a JKS key store would return its entries
in a deterministic order when an alias was not
specified, but this may not be true. Removing
the test entirely since there is already a test
that verifies that the functionality is correct
when an alias is explicitly specified.
