### PR TITLE
Add QueryMap class and encoder

### DIFF
--- a/http-clients/src/main/java/com/palantir/remoting/http/QueryMap.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/QueryMap.java
@@ -4,14 +4,10 @@
 
 package com.palantir.remoting.http;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Multimap;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Style.ImplementationVisibility;
 
-@JsonDeserialize(as = ImmutableQueryMap.class)
-@JsonSerialize(as = ImmutableQueryMap.class)
 @Value.Immutable
 @Value.Style(visibility = ImplementationVisibility.PACKAGE)
 public abstract class QueryMap {

--- a/http-clients/src/main/java/com/palantir/remoting/http/QueryMap.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/QueryMap.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.remoting.http;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.Multimap;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Style.ImplementationVisibility;
+
+@JsonDeserialize(as = ImmutableQueryMap.class)
+@JsonSerialize(as = ImmutableQueryMap.class)
+@Value.Immutable
+@Value.Style(visibility = ImplementationVisibility.PACKAGE)
+public abstract class QueryMap {
+    public abstract Multimap<String, String> queryMap();
+
+    public static QueryMap of(Multimap<String, String> queryMap) {
+        return ImmutableQueryMap.builder().queryMap(queryMap).build();
+    }
+}

--- a/http-clients/src/main/java/feign/QueryMapEncoder.java
+++ b/http-clients/src/main/java/feign/QueryMapEncoder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package feign;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.palantir.remoting.http.QueryMap;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Map.Entry;
+
+/**
+ * Encoder for {@link QueryMap} that takes the contents of the
+ * map and encodes them as query parameters in the request.
+ */
+public final class QueryMapEncoder implements Encoder {
+    private final Encoder delegate;
+
+    public QueryMapEncoder(Encoder delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
+        if (bodyType == QueryMap.class) {
+            QueryMap queryParams = (QueryMap) object;
+
+            Multimap<String, String> existing = ArrayListMultimap.create();
+            for (Entry<String, Collection<String>> currEntry : template.queries().entrySet()) {
+                existing.putAll(currEntry.getKey(), currEntry.getValue());
+            }
+            existing.putAll(queryParams.queryMap());
+
+            template.queries(existing.asMap());
+        } else {
+            delegate.encode(object, bodyType, template);
+        }
+    }
+}

--- a/http-clients/src/test/java/feign/QueryMapTestServer.java
+++ b/http-clients/src/test/java/feign/QueryMapTestServer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package feign;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableMultimap.Builder;
+import com.palantir.remoting.http.QueryMap;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import java.util.List;
+import java.util.Map.Entry;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+public final class QueryMapTestServer {
+
+    /**
+     * Example server implementation that uses a {@link UriInfo} provided by a
+     * {@link Context} annotation to retrieve all of the query parameters for
+     * a call on the server side.
+     */
+    public static final class WithContext extends Application<Configuration> {
+        @Override
+        public void run(Configuration config, final Environment env) throws Exception {
+            // register class so that context is injected on each request
+            env.jersey().register(TestResourceWithContext.class);
+        }
+
+        public static final class TestResourceWithContext implements TestService {
+            @Context
+            private UriInfo uriInfo;
+
+            @Override
+            public ImmutableMultimap<String, String> getUsingParamMap(String foo) {
+                return getAllQueryParamsFromContext();
+            }
+
+            @Override
+            public ImmutableMultimap<String, String> getUsingParamList(List<String> namedParamList) {
+                return getAllQueryParamsFromContext();
+            }
+
+            private ImmutableMultimap<String, String> getAllQueryParamsFromContext() {
+                MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
+
+                Builder<String, String> builder = ImmutableMultimap.builder();
+                for (Entry<String, List<String>> currEntry : params.entrySet()) {
+                    builder.putAll(currEntry.getKey(), currEntry.getValue());
+                }
+
+                return builder.build();
+            }
+        }
+    }
+
+    /**
+     * Example server implementation that returns only the query parameters that are
+     * explicitly annotated.
+     */
+    public static final class WithoutContext extends Application<Configuration> {
+        @Override
+        public void run(Configuration config, final Environment env) throws Exception {
+            env.jersey().register(new TestResourceWithoutContext());
+        }
+
+        public static final class TestResourceWithoutContext implements TestService {
+            @Override
+            public ImmutableMultimap<String, String> getUsingParamMap(String namedParam) {
+                return ImmutableMultimap.of(MAP_PARAM_NAME, namedParam);
+            }
+
+            @Override
+            public ImmutableMultimap<String, String> getUsingParamList(List<String> namedParamList) {
+                Builder<String, String> builder = ImmutableMultimap.builder();
+                builder.putAll(LIST_PARAM_NAME, namedParamList);
+                return builder.build();
+            }
+        }
+    }
+
+    @Path("/")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public interface TestService {
+        String MAP_PARAM_NAME = "namedParam";
+        String MAP_PARAM_PATH = "/getUsingParamMap";
+
+        String LIST_PARAM_NAME = "namedParamList";
+        String LIST_PARAM_PATH = "/getUsingParamList";
+
+        @GET
+        @Path(MAP_PARAM_PATH)
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        ImmutableMultimap<String, String> getUsingParamMap(@QueryParam(MAP_PARAM_NAME) String namedParam);
+
+        @GET
+        @Path(LIST_PARAM_PATH)
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        ImmutableMultimap<String, String> getUsingParamList(@QueryParam(LIST_PARAM_NAME) List<String> namedParamList);
+    }
+
+    /**
+     * Example of a client-specific service interface. Extends {@link TestService}, which is
+     * the shared service interface. Provides additional methods that accept a {@link QueryMap}
+     * that allow the client to provide arbitrary query parameters (rather than just those that are
+     * explicitly defined and annotated in {@link TestService}).
+     */
+    @Path("/")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public interface TestClientService extends TestService {
+        @GET
+        @Path(MAP_PARAM_PATH)
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        ImmutableMultimap<String, String> getUsingParamMap(@Param(value = "queryParams") QueryMap queryParams);
+
+        @GET
+        @Path(LIST_PARAM_PATH)
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        ImmutableMultimap<String, String> getUsingParamList(@Param(value = "queryParams") QueryMap queryParams);
+    }
+
+    private QueryMapTestServer() {}
+}

--- a/http-clients/src/test/java/feign/QueryMapUsingServerWithContextTests.java
+++ b/http-clients/src/test/java/feign/QueryMapUsingServerWithContextTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package feign;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMultimap;
+import com.palantir.remoting.http.FeignClientFactory;
+import com.palantir.remoting.http.ObjectMappers;
+import com.palantir.remoting.http.QueryMap;
+import com.palantir.remoting.http.errors.SerializableErrorErrorDecoder;
+import feign.QueryMapTestServer.TestService;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import feign.jaxrs.JAXRSContract;
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import javax.net.ssl.SSLSocketFactory;
+import jersey.repackaged.com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public final class QueryMapUsingServerWithContextTests {
+
+    /**
+     * Creates a {@link QueryMapTestServer.WithContext} Dropwizard server.
+     * The Java implementation of this server uses the context to read all
+     * query parameters from a map and returns them.
+     */
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> APP = new DropwizardAppRule<>(
+            QueryMapTestServer.WithContext.class,
+            "src/test/resources/test-server.yml");
+
+    private QueryMapTestServer.TestClientService service;
+
+    @Before
+    public void before() {
+        String endpointUri = "http://localhost:" + APP.getLocalPort();
+
+        FeignClientFactory factory = FeignClientFactory.of(
+                new JAXRSContract(),
+                // register query map encoder
+                new QueryMapEncoder(new JacksonEncoder(ObjectMappers.guavaJdk7())),
+                new OptionalAwareDecoder(new TextDelegateDecoder(new JacksonDecoder(ObjectMappers.guavaJdk7()))),
+                SerializableErrorErrorDecoder.INSTANCE,
+                FeignClientFactory.okHttpClient());
+
+        service = factory.createProxy(
+                Optional.<SSLSocketFactory>absent(),
+                endpointUri,
+                QueryMapTestServer.TestClientService.class);
+    }
+
+    @Test
+    public void testGetUsingParamMapWithQueryMap() {
+        ImmutableMultimap<String, String> requestMultiMap = ImmutableMultimap.of(
+                "fooParam", "fooVal",
+                "fooParam", "foo value 2",
+                "fooParam", "",
+                "barParam", "barVal");
+
+        QueryMap queryMap = QueryMap.of(requestMultiMap);
+        assertThat(service.getUsingParamMap(queryMap), is(requestMultiMap));
+    }
+
+    @Test
+    public void testGetUsingParamMapWithString() {
+        assertThat(service.getUsingParamMap("fooVal"), is(ImmutableMultimap.of(TestService.MAP_PARAM_NAME, "fooVal")));
+    }
+
+    @Test
+    public void testGetUsingParamListWithQueryMap() {
+        ImmutableMultimap<String, String> requestMultiMap = ImmutableMultimap.of(
+                "fooParam", "fooVal",
+                "fooParam", "foo value 2",
+                "fooParam", "",
+                "barParam", "barVal");
+
+        QueryMap queryMap = QueryMap.of(requestMultiMap);
+        assertThat(service.getUsingParamList(queryMap), is(requestMultiMap));
+    }
+
+    @Test
+    public void testGetUsingParamListWithList() {
+        assertThat(
+                service.getUsingParamList(ImmutableList.of("foo", "bar")),
+                is(ImmutableMultimap.of(
+                        TestService.LIST_PARAM_NAME, "foo",
+                        TestService.LIST_PARAM_NAME, "bar")));
+    }
+
+}

--- a/http-clients/src/test/java/feign/QueryMapUsingServerWithoutContextTests.java
+++ b/http-clients/src/test/java/feign/QueryMapUsingServerWithoutContextTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package feign;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMultimap;
+import com.palantir.remoting.http.FeignClientFactory;
+import com.palantir.remoting.http.ObjectMappers;
+import com.palantir.remoting.http.QueryMap;
+import com.palantir.remoting.http.errors.SerializableErrorErrorDecoder;
+import feign.QueryMapTestServer.TestService;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import feign.jaxrs.JAXRSContract;
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import javax.net.ssl.SSLSocketFactory;
+import jersey.repackaged.com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public final class QueryMapUsingServerWithoutContextTests {
+
+    /**
+     * Creates a {@link QueryMapTestServer.WithoutContext} Dropwizard server.
+     * The Java implementation of this server uses strongly typed methods that
+     * will only process the query parameters that are declared as part of the
+     * method parameters.
+     */
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> APP = new DropwizardAppRule<>(
+            QueryMapTestServer.WithoutContext.class,
+            "src/test/resources/test-server.yml");
+
+    private QueryMapTestServer.TestClientService service;
+
+    @Before
+    public void before() {
+        String endpointUri = "http://localhost:" + APP.getLocalPort();
+
+        FeignClientFactory factory = FeignClientFactory.of(
+                new JAXRSContract(),
+                // register query map encoder
+                new QueryMapEncoder(new JacksonEncoder(ObjectMappers.guavaJdk7())),
+                new OptionalAwareDecoder(new TextDelegateDecoder(new JacksonDecoder(ObjectMappers.guavaJdk7()))),
+                SerializableErrorErrorDecoder.INSTANCE,
+                FeignClientFactory.okHttpClient());
+
+        service = factory.createProxy(
+                Optional.<SSLSocketFactory>absent(),
+                endpointUri,
+                QueryMapTestServer.TestClientService.class);
+    }
+
+    @Test
+    public void testGetUsingParamMapWithQueryMap() {
+        QueryMap queryMap = QueryMap.of(ImmutableMultimap.of(
+                TestService.MAP_PARAM_NAME, "namedVal 1",
+                TestService.MAP_PARAM_NAME, "namedVal 2",
+                "fooParam", "fooVal"));
+
+        // client GET call contains all of the query parameters in queryMap,
+        // but Java server implementation is such that only first value of
+        // TestService.MAP_PARAM_NAME query parameter is processed
+        assertThat(
+                service.getUsingParamMap(queryMap),
+                is(ImmutableMultimap.of(TestService.MAP_PARAM_NAME, "namedVal 1")));
+    }
+
+    @Test
+    public void testGetUsingParamMapWithString() {
+        assertThat(service.getUsingParamMap("fooVal"), is(ImmutableMultimap.of(TestService.MAP_PARAM_NAME, "fooVal")));
+    }
+
+    @Test
+    public void testGetUsingParamListWithQueryMap() {
+        QueryMap queryMap = QueryMap.of(ImmutableMultimap.of(
+                TestService.LIST_PARAM_NAME, "list val 1",
+                TestService.LIST_PARAM_NAME, "list val 2",
+                "fooParam", "foo value",
+                TestService.MAP_PARAM_NAME, "bar value"));
+
+        // client GET call contains all of the query parameters in queryMap,
+        // but Java server implementation is such that only values of
+        // TestService.LIST_PARAM_NAME query parameter are processed
+        assertThat(
+                service.getUsingParamList(queryMap),
+                is(ImmutableMultimap.of(
+                        TestService.LIST_PARAM_NAME, "list val 1",
+                        TestService.LIST_PARAM_NAME, "list val 2")));
+    }
+
+    @Test
+    public void testGetUsingParamListWithList() {
+        assertThat(
+                service.getUsingParamList(ImmutableList.of("foo", "bar")),
+                is(ImmutableMultimap.of(
+                        TestService.LIST_PARAM_NAME, "foo",
+                        TestService.LIST_PARAM_NAME, "bar")));
+    }
+
+}


### PR DESCRIPTION
Allow Feign clients to use a QueryMap to send GET
requests that have arbitrary query parameter keys
and values. Analogous to the functionality provided
by the @QueryMap annotation in Retrofit.
