### PR TITLE
added discoverable subtype resolver to standard object mapper

### DIFF
--- a/gradle/libs.gradle
+++ b/gradle/libs.gradle
@@ -1,7 +1,8 @@
 project.ext.libs = [
     'dropwizard': [
         'testing': 'io.dropwizard:dropwizard-testing:0.8.2',
-        'core': 'io.dropwizard:dropwizard-core:0.8.2'
+        'core': 'io.dropwizard:dropwizard-core:0.8.2',
+        'jackson': 'io.dropwizard:dropwizard-jackson:0.8.2'
     ],
     'feign': [
         'jackson': 'com.netflix.feign:feign-jackson:8.11.0',

--- a/http-clients/build.gradle
+++ b/http-clients/build.gradle
@@ -4,6 +4,7 @@ apply from: "${rootDir}/gradle/publish.gradle"
 dependencies {
     compile project(':error-handling')
 
+    compile libs.dropwizard.jackson
     compile libs.feign.jackson
     compile(libs.feign.jaxrs){
         // the shipped version clashes with the newer javax.ws.rs:javax.ws.rs-api used by (e.g.) dropwizard

--- a/http-clients/src/main/java/com/palantir/remoting/http/FeignClients.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/FeignClients.java
@@ -43,11 +43,11 @@ public final class FeignClients {
     public static FeignClientFactory standard() {
         return FeignClientFactory.of(
                 new GuavaOptionalAwareContract(new JAXRSContract()),
-                new InputStreamDelegateEncoder(new JacksonEncoder(ObjectMappers.guavaJdk7())),
+                new InputStreamDelegateEncoder(new JacksonEncoder(ObjectMappers.discoverableGuavaJdk7())),
                 new OptionalAwareDecoder(
                         new InputStreamDelegateDecoder(
                                 new TextDelegateDecoder(
-                                        new JacksonDecoder(ObjectMappers.guavaJdk7())))),
+                                        new JacksonDecoder(ObjectMappers.discoverableGuavaJdk7())))),
                 SerializableErrorErrorDecoder.INSTANCE,
                 FeignClientFactory.okHttpClient());
     }
@@ -58,11 +58,11 @@ public final class FeignClients {
     public static FeignClientFactory standardJackson24() {
         return FeignClientFactory.of(
                 new GuavaOptionalAwareContract(new JAXRSContract()),
-                new InputStreamDelegateEncoder(new Jackson24Encoder(ObjectMappers.guavaJdk7())),
+                new InputStreamDelegateEncoder(new Jackson24Encoder(ObjectMappers.discoverableGuavaJdk7())),
                 new OptionalAwareDecoder(
                         new InputStreamDelegateDecoder(
                                 new TextDelegateDecoder(
-                                        new JacksonDecoder(ObjectMappers.guavaJdk7())))),
+                                        new JacksonDecoder(ObjectMappers.discoverableGuavaJdk7())))),
                 SerializableErrorErrorDecoder.INSTANCE,
                 FeignClientFactory.okHttpClient());
     }

--- a/http-clients/src/main/java/com/palantir/remoting/http/ObjectMappers.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/ObjectMappers.java
@@ -19,14 +19,16 @@ package com.palantir.remoting.http;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk7.Jdk7Module;
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 
 public final class ObjectMappers {
 
     private static final ObjectMapper VANILLA_MAPPER = new ObjectMapper();
 
-    private static final ObjectMapper GUAVA_JDK7_MAPPER = new ObjectMapper()
+    private static final ObjectMapper DISCOVERABLE_GUAVA_JDK7_MAPPER = new ObjectMapper()
             .registerModule(new GuavaModule())
-            .registerModule(new Jdk7Module());
+            .registerModule(new Jdk7Module())
+            .setSubtypeResolver(new DiscoverableSubtypeResolver());
 
     private ObjectMappers() {}
 
@@ -34,8 +36,8 @@ public final class ObjectMappers {
         return VANILLA_MAPPER;
     }
 
-    public static ObjectMapper guavaJdk7() {
-        return GUAVA_JDK7_MAPPER;
+    public static ObjectMapper discoverableGuavaJdk7() {
+        return DISCOVERABLE_GUAVA_JDK7_MAPPER;
     }
 
 }

--- a/http-clients/src/test/java/com/palantir/remoting/http/FailoverFeignTargetTest.java
+++ b/http-clients/src/test/java/com/palantir/remoting/http/FailoverFeignTargetTest.java
@@ -95,8 +95,8 @@ public final class FailoverFeignTargetTest {
 
         FakeoInterface proxy = FeignClientFactory.of(
                 new JAXRSContract(),
-                new JacksonEncoder(ObjectMappers.guavaJdk7()),
-                new JacksonDecoder(ObjectMappers.guavaJdk7()),
+                new JacksonEncoder(ObjectMappers.discoverableGuavaJdk7()),
+                new JacksonDecoder(ObjectMappers.discoverableGuavaJdk7()),
                 SerializableErrorErrorDecoder.INSTANCE,
                 FeignClientFactory.okHttpClient(),
                 backoffStrategy,


### PR DESCRIPTION
gatekeeper relies on discoverability for dynamic subtype resolving, we could omit it but people's client will break unless they explicitly modify the om.
