### PR TITLE
Simplify FeignClients methods

### DIFF
--- a/http-clients/src/main/java/feign/Chain.java
+++ b/http-clients/src/main/java/feign/Chain.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package feign;
+
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+import jersey.repackaged.com.google.common.collect.ImmutableList;
+
+public final class Chain {
+
+    public static Decoder firstHandler(Decoder baseDecoder, HandlerDecoder... handlers) {
+        return new ChainDecoder(baseDecoder, handlers);
+    }
+
+    private static final class ChainDecoder implements Decoder {
+        private final Decoder valueDecoder;
+        private final List<HandlerDecoder> handlers;
+
+        ChainDecoder(Decoder valueDecoder, HandlerDecoder... handlers) {
+            this.valueDecoder = valueDecoder;
+            this.handlers = ImmutableList.copyOf(handlers);
+        }
+
+        @Override
+        public Object decode(Response response, Type type) throws IOException, DecodeException, FeignException {
+            for (HandlerDecoder currHandler : handlers) {
+                if (currHandler.canHandle(response, type)) {
+                    return currHandler.decode(response, type, valueDecoder);
+                }
+            }
+
+            return valueDecoder.decode(response, type);
+        }
+    }
+
+    private Chain() {}
+
+}

--- a/http-clients/src/main/java/feign/HandlerDecoder.java
+++ b/http-clients/src/main/java/feign/HandlerDecoder.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package feign;
+
+import feign.codec.Decoder;
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+public interface HandlerDecoder {
+
+    boolean canHandle(Response response, Type type);
+
+    Object decode(Response response, Type type, Decoder valueDecoder) throws IOException;
+
+}

--- a/http-clients/src/main/java/feign/InputStreamDecoder.java
+++ b/http-clients/src/main/java/feign/InputStreamDecoder.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package feign;
+
+import feign.codec.Decoder;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+
+public final class InputStreamDecoder implements HandlerDecoder {
+
+    @Override
+    public boolean canHandle(Response response, Type type) {
+        return type.equals(InputStream.class);
+    }
+
+    @Override
+    public Object decode(Response response, Type type, Decoder valueDecoder) throws IOException {
+        byte[] body = Util.toByteArray(response.body().asInputStream());
+        return new ByteArrayInputStream(body);
+    }
+
+}

--- a/http-clients/src/main/java/feign/OptionalDecoder.java
+++ b/http-clients/src/main/java/feign/OptionalDecoder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package feign;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Optional;
+import feign.codec.Decoder;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+
+public final class OptionalDecoder implements HandlerDecoder {
+
+    @Override
+    public boolean canHandle(Response response, Type type) {
+        return Types.getRawType(type).equals(Optional.class);
+    }
+
+    @Override
+    public Object decode(Response response, Type type, Decoder valueDecoder) throws IOException {
+        if (response.status() == 204) {
+            return Optional.absent();
+        } else {
+            Object decoded = checkNotNull(valueDecoder.decode(response, getInnerType(type)),
+                    "Unexpected null content for response status %d", response.status());
+            return Optional.of(decoded);
+        }
+    }
+
+    private static Type getInnerType(Type type) {
+        ParameterizedType paramType = (ParameterizedType) type;
+        return paramType.getActualTypeArguments()[0];
+    }
+}

--- a/http-clients/src/main/java/feign/TextDecoder.java
+++ b/http-clients/src/main/java/feign/TextDecoder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package feign;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.net.HttpHeaders;
+import feign.codec.Decoder;
+import feign.codec.StringDecoder;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import javax.ws.rs.core.MediaType;
+
+public final class TextDecoder implements HandlerDecoder {
+    private static final Decoder stringDecoder = new StringDecoder();
+
+    @Override
+    public boolean canHandle(Response response, Type type) {
+        Collection<String> contentTypes = response.headers().get(HttpHeaders.CONTENT_TYPE);
+        if (contentTypes == null) {
+            contentTypes = ImmutableSet.of();
+        }
+        // In the case of multiple content types, or an unknown content type, we'll use the delegate instead.
+        return contentTypes.size() == 1
+                && Iterables.getOnlyElement(contentTypes, "").equals(MediaType.TEXT_PLAIN);
+    }
+
+    @Override
+    public Object decode(Response response, Type type, Decoder valueDecoder) throws IOException {
+        return stringDecoder.decode(response, type);
+    }
+}


### PR DESCRIPTION
Use methods to get default contract,
encoder and decoder and use a declarative
framework for decorators.
