### PR TITLE
Add documentation and tests for OptionalAwareDecoder

### DIFF
--- a/http-clients/src/main/java/feign/OptionalAwareDecoder.java
+++ b/http-clients/src/main/java/feign/OptionalAwareDecoder.java
@@ -26,7 +26,10 @@ import java.lang.reflect.Type;
 
 /**
  * Decorates a Feign {@link Decoder} such that it returns {@link Optional#absent} when observing an HTTP 204 error code
- * for a method with {@link Type} {@link Optional}.
+ * for a method with {@link Type} {@link Optional}. This decoder only handles the case where the response object itself
+ * is an {@link Optional}, and does not handle any occurrences of {@link Optional} objects that do not wrap the
+ * top-level response. For example, if a method returns Map&lt;String, Optional&gt;, the inner Optional&lt;String&gt;
+ * will not receive any special handling from this decoder (it will fall through to the delegated decoder).
  */
 public final class OptionalAwareDecoder implements Decoder {
 

--- a/http-clients/src/test/java/feign/OptionalAwareDecoderTest.java
+++ b/http-clients/src/test/java/feign/OptionalAwareDecoderTest.java
@@ -19,10 +19,12 @@ package feign;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.remoting.http.FeignClients;
+import feign.codec.DecodeException;
 import io.dropwizard.Configuration;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.net.ssl.SSLSocketFactory;
@@ -56,6 +58,18 @@ public final class OptionalAwareDecoderTest {
     public void testOptional() {
         assertThat(service.getOptional("something"), is(Optional.of(ImmutableMap.of("something", "something"))));
         assertThat(service.getOptional(null), is(Optional.<ImmutableMap<String, String>>absent()));
+    }
+
+    @Test
+    public void testNestedOptional() {
+        try {
+            service.getNestedOptional("something");
+            fail();
+        } catch (DecodeException ex) {
+            // OptionalAwareDecoder only handles top-level Optional objects so Optional.absent()
+            // value in map is decoded as null by the delegate decoder
+            assertThat(ex.getMessage(), containsString("null value in entry: something=null"));
+        }
     }
 
     @Test

--- a/http-clients/src/test/java/feign/TestServer.java
+++ b/http-clients/src/test/java/feign/TestServer.java
@@ -51,6 +51,11 @@ public class TestServer extends Application<Configuration> {
         }
 
         @Override
+        public ImmutableMap<String, Optional<String>> getNestedOptional(String value) {
+            return ImmutableMap.of(value, Optional.<String>absent());
+        }
+
+        @Override
         public ImmutableMap<String, String> getNonOptional(@Nullable String value) {
             if (Strings.isNullOrEmpty(value)) {
                 return ImmutableMap.of();
@@ -138,6 +143,13 @@ public class TestServer extends Application<Configuration> {
         @Consumes(MediaType.APPLICATION_JSON)
         @Produces(MediaType.APPLICATION_JSON)
         Optional<ImmutableMap<String, String>> getOptional(@QueryParam("value") @Nullable String value);
+
+        // not valid: OptionalAwareDecoder only handles top-level Optional objects
+        @GET
+        @Path("/nestedOptional")
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        ImmutableMap<String, Optional<String>> getNestedOptional(@QueryParam("value") @Nullable String value);
 
         @GET
         @Path("/nonOptional")


### PR DESCRIPTION
Explicitly document that decoder only applies to the
outer-most Optional object on a response body that is
declared as an Optional and add test to demonstrate.
