### PR TITLE
add builder to service config and improve APIs

### DIFF
--- a/http-clients/src/main/java/com/palantir/remoting/http/FeignClientFactory.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/FeignClientFactory.java
@@ -143,7 +143,7 @@ public final class FeignClientFactory {
      * Constructs a dynamic proxy for the specified type using the {@link ServiceConfiguration} obtained from the
      * supplied {@link ServiceDiscoveryConfiguration} for the specified service name.
      */
-    public <T> T createProxies(
+    public <T> T createProxy(
             ServiceDiscoveryConfiguration discoveryConfig, String serviceName, Class<T> serviceClass) {
 
         ServiceConfiguration serviceConfig = Preconditions.checkNotNull(
@@ -151,7 +151,7 @@ public final class FeignClientFactory {
                 "Unable to find the configuration for " + serviceName + ".");
 
         Optional<SSLSocketFactory> socketFactory = Optional.absent();
-        Optional<SslConfiguration> sslConfig = discoveryConfig.getSslConfiguration(serviceName);
+        Optional<SslConfiguration> sslConfig = discoveryConfig.getSecurity(serviceName);
 
         if (sslConfig.isPresent()) {
             socketFactory = Optional.of(SslSocketFactories.createSslSocketFactory(sslConfig.get()));

--- a/http-clients/src/test/java/com/palantir/remoting/http/ServiceConfigTest.java
+++ b/http-clients/src/test/java/com/palantir/remoting/http/ServiceConfigTest.java
@@ -43,9 +43,9 @@ public final class ServiceConfigTest {
                 rule.getConfiguration().getServiceDiscoveryConfiguration();
 
         HelloService helloClient =
-                FeignClients.standard().createProxies(discoveryConfiguration, "hello", HelloService.class);
+                FeignClients.standard().createProxy(discoveryConfiguration, "hello", HelloService.class);
         GoodbyeService goodbyeClient =
-                FeignClients.standard().createProxies(discoveryConfiguration, "goodbye", GoodbyeService.class);
+                FeignClients.standard().createProxy(discoveryConfiguration, "goodbye", GoodbyeService.class);
 
         ServiceConfiguration authConfig = rule.getConfiguration().getAuthConfiguration();
         Optional<SSLSocketFactory> socketFactory =

--- a/service-config/src/main/java/com/palantir/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/config/service/ServiceConfiguration.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value.Style;
 
 @Immutable
 @JsonDeserialize(as = ImmutableServiceConfiguration.class)
-@Style(allParameters = true, visibility = Style.ImplementationVisibility.PACKAGE)
+@Style(visibility = Style.ImplementationVisibility.PACKAGE)
 public abstract class ServiceConfiguration {
 
     /**
@@ -43,4 +43,23 @@ public abstract class ServiceConfiguration {
      * A list of service URIs.
      */
     public abstract List<String> uris();
+
+    // hides implementation details
+    public static Builder builder() {
+        return ImmutableServiceConfiguration.builder();
+    }
+
+    // hides implementation details
+    public interface Builder {
+
+        Builder apiToken(BearerToken apiToken);
+
+        Builder security(SslConfiguration security);
+
+        Builder uris(Iterable<String> uris);
+
+        Builder from(ServiceConfiguration otherConfig);
+
+        ServiceConfiguration build();
+    }
 }

--- a/service-config/src/test/java/com/palantir/config/service/ServiceDiscoveryConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/config/service/ServiceDiscoveryConfigurationTests.java
@@ -20,14 +20,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
+import com.palantir.remoting.ssl.SslConfiguration;
 import com.palantir.tokens.auth.BearerToken;
 import io.dropwizard.jackson.Jackson;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Path;
 import org.junit.Test;
 
 /**
@@ -44,14 +49,15 @@ public final class ServiceDiscoveryConfigurationTests {
                 mapper.readValue(resource.openStream(), ServiceDiscoveryConfiguration.class);
 
         // testing fallback properties
-        assertFalse(discoveryConfig.getDefaultSecurity().isPresent());
-        assertFalse(discoveryConfig.getDefaultApiToken().isPresent());
+        assertFalse(discoveryConfig.defaultSecurity().isPresent());
+        assertFalse(discoveryConfig.defaultApiToken().isPresent());
 
         // testing service api token property
         // 1) with token
         // 2) without token
         assertEquals(BearerToken.valueOf("service1ApiToken"), discoveryConfig.getApiToken("service1").get());
         assertEquals(BearerToken.valueOf("service2ApiToken"), discoveryConfig.getApiToken("service2").get());
+        assertEquals(ImmutableList.of("https://some.internal.url:8443/thirdservice/api"), discoveryConfig.getUris("service3"));
         assertFalse(discoveryConfig.getApiToken("service3").isPresent());
 
         // testing getter for services that don't exist
@@ -70,8 +76,8 @@ public final class ServiceDiscoveryConfigurationTests {
                 mapper.readValue(resource.openStream(), ServiceDiscoveryConfiguration.class);
 
         // testing fallback properties
-        assertTrue(discoveryConfig.getDefaultSecurity().isPresent());
-        assertEquals(BearerToken.valueOf("defaultApiToken"), discoveryConfig.getDefaultApiToken().get());
+        assertTrue(discoveryConfig.defaultSecurity().isPresent());
+        assertEquals(BearerToken.valueOf("defaultApiToken"), discoveryConfig.defaultApiToken().get());
 
         // testing service api token property
         // 1) with token
@@ -80,5 +86,27 @@ public final class ServiceDiscoveryConfigurationTests {
         assertEquals(BearerToken.valueOf("defaultApiToken"), discoveryConfig.getApiToken("service3").get());
         assertEquals(BearerToken.valueOf("defaultApiToken"),
                 discoveryConfig.getServices().get("service3").apiToken().get());
+    }
+
+    @Test
+    public void testBuilder() {
+        BearerToken defaultApiToken = BearerToken.valueOf("someToken");
+        SslConfiguration security = SslConfiguration.of(mock(Path.class));
+
+        ServiceConfiguration service = ServiceConfiguration.builder()
+                .security(security)
+                .uris(ImmutableList.of("https://localhost:8443"))
+                .build();
+        ServiceDiscoveryConfiguration services = ServiceDiscoveryConfiguration.builder()
+                .defaultApiToken(defaultApiToken)
+                .originalServices(ImmutableMap.of("service1", service))
+                .build();
+
+        assertEquals(defaultApiToken, services.defaultApiToken().get());
+        assertEquals(defaultApiToken, services.getApiToken("service1").get());
+        assertEquals(defaultApiToken, services.getServices().get("service1").apiToken().get());
+        assertFalse(services.defaultSecurity().isPresent());
+        assertEquals(security, services.getSecurity("service1").get());
+        assertEquals(security, services.getServices().get("service1").security().get());
     }
 }


### PR DESCRIPTION
- added builder to both ServiceConfiguration and ServiceDiscoveryConfiguration classes for tests
- renamed createProxies to createProxy for building feign client with service config
- removed get prefix for variables be consistent with the other class
- renamed getSslConfiguration to getSecurity for consistency
- removed @Value.Parameter in favor of Builder since `of()` requires all class variables 
