### PR TITLE
Fix immutable style warning

### DIFF
--- a/service-config/src/main/java/com/palantir/config/service/PackageVisibilityImmutableStyle.java
+++ b/service-config/src/main/java/com/palantir/config/service/PackageVisibilityImmutableStyle.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.config.service;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.immutables.value.Value.Style;
+
+/**
+ * Sets the style to be used by the Immutables library.
+ */
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Style(
+    visibility = Style.ImplementationVisibility.PACKAGE)
+@interface PackageVisibilityImmutableStyle {}

--- a/service-config/src/main/java/com/palantir/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/config/service/ServiceConfiguration.java
@@ -23,11 +23,10 @@ import com.palantir.tokens.auth.BearerToken;
 import io.dropwizard.util.Duration;
 import java.util.List;
 import org.immutables.value.Value.Immutable;
-import org.immutables.value.Value.Style;
 
 @Immutable
 @JsonDeserialize(as = ImmutableServiceConfiguration.class)
-@Style(visibility = Style.ImplementationVisibility.PACKAGE)
+@PackageVisibilityImmutableStyle
 public abstract class ServiceConfiguration {
 
     /**

--- a/service-config/src/main/java/com/palantir/config/service/ServiceDiscoveryConfiguration.java
+++ b/service-config/src/main/java/com/palantir/config/service/ServiceDiscoveryConfiguration.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Lazy;
-import org.immutables.value.Value.Style;
 
 /**
  * Configuration class that contains a map of {@code serviceName}s and their respective {@link ServiceConfiguration}s
@@ -38,7 +37,7 @@ import org.immutables.value.Value.Style;
  */
 @Immutable
 @JsonDeserialize(as = ImmutableServiceDiscoveryConfiguration.class)
-@Style(visibility = Style.ImplementationVisibility.PACKAGE)
+@PackageVisibilityImmutableStyle
 public abstract class ServiceDiscoveryConfiguration {
 
     /**


### PR DESCRIPTION
Inline style causes the following warning

```
warning: unknown enum constant ImplementationVisibility.PACKAGE
  reason: class file for org.immutables.value.Value$Style$ImplementationVisibility not found
```

See this pr as an example, https://github.com/qinfchen/dropwizard-example-app/pull/3

I created an issue for Immutables, https://github.com/immutables/immutables/issues/291. Here is the summary of the issue:

> I've investigated that in a detail. It's a native javac warning issued when -Xlint is enabled. There is no category for it so it cannot be disabled, unlike other categorized warnings such as "unchecked" etc. Once you're linting, it's always enabled. Of course it would be no issues if we use source only annotation retention. But we use class-file retention for the annotations so incremental compilation and advanced discovery works during annotation processing.

@uschi2000 @nmiyake it seems that ssl-config has the same issue. Is there a plan to create -commons project to include common classes? so we can move the custom style to there and share it across other projects.
