### PR TITLE
User agent not forced

### DIFF
--- a/http-clients/src/main/java/com/palantir/remoting/http/FeignClients.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/FeignClients.java
@@ -49,11 +49,31 @@ public final class FeignClients {
     private FeignClients() {}
 
     /**
+     * @deprecated Clients should specify a user agent. This method will be removed when clients have updated.
+     * Provides a {@link FeignClientFactory} with an {@link ObjectMapper} configured with {@link
+     * com.fasterxml.jackson.datatype.guava.GuavaModule} and {@link com.fasterxml.jackson.datatype.jdk7.Jdk7Module}.
+     */
+    @Deprecated
+    public static FeignClientFactory standard() {
+        return standard(DEFAULT_TIMEOUT_OPTIONS);
+    }
+
+    /**
      * Provides a {@link FeignClientFactory} with an {@link ObjectMapper} configured with {@link
      * com.fasterxml.jackson.datatype.guava.GuavaModule} and {@link com.fasterxml.jackson.datatype.jdk7.Jdk7Module}.
      */
     public static FeignClientFactory standard(String userAgent) {
         return standard(DEFAULT_TIMEOUT_OPTIONS, userAgent);
+    }
+
+    /**
+     * @deprecated Clients should specify a user agent. This method will be removed when clients have updated.
+     * Provides a {@link FeignClientFactory} with an {@link ObjectMapper} configured with {@link
+     * com.fasterxml.jackson.datatype.guava.GuavaModule} and {@link com.fasterxml.jackson.datatype.jdk7.Jdk7Module}.
+     */
+    @Deprecated
+    public static FeignClientFactory standard(Request.Options timeoutOptions) {
+        return withMapper(ObjectMappers.guavaJdk7(), timeoutOptions);
     }
 
     /**
@@ -65,10 +85,31 @@ public final class FeignClients {
     }
 
     /**
+     * @deprecated Clients should specify a user agent. This method will be removed when clients have updated.
+     * Provides a {@link FeignClientFactory} compatible with jackson 2.4.
+     */
+    @Deprecated
+    public static FeignClientFactory standardJackson24() {
+        return standardJackson24(DEFAULT_TIMEOUT_OPTIONS);
+    }
+
+    /**
      * Provides a {@link FeignClientFactory} compatible with jackson 2.4.
      */
     public static FeignClientFactory standardJackson24(String userAgent) {
         return standardJackson24(DEFAULT_TIMEOUT_OPTIONS, userAgent);
+    }
+
+    /**
+     * @deprecated Clients should specify a user agent. This method will be removed when clients have updated.
+     * Provides a {@link FeignClientFactory} compatible with jackson 2.4.
+     */
+    @Deprecated
+    public static FeignClientFactory standardJackson24(Request.Options timeoutOptions) {
+        return withEncoderAndDecoder(
+                new Jackson24Encoder(ObjectMappers.guavaJdk7()),
+                new JacksonDecoder(ObjectMappers.guavaJdk7()),
+                timeoutOptions);
     }
 
     /**
@@ -83,10 +124,28 @@ public final class FeignClients {
     }
 
     /**
+     * @deprecated Clients should specify a user agent. This method will be removed when clients have updated.
+     * Provides a {@link FeignClientFactory} with an unmodified {@link ObjectMapper}.
+     */
+    @Deprecated
+    public static FeignClientFactory vanilla() {
+        return vanilla(DEFAULT_TIMEOUT_OPTIONS);
+    }
+
+    /**
      * Provides a {@link FeignClientFactory} with an unmodified {@link ObjectMapper}.
      */
     public static FeignClientFactory vanilla(String userAgent) {
         return vanilla(DEFAULT_TIMEOUT_OPTIONS, userAgent);
+    }
+
+    /**
+     * @deprecated Clients should specify a user agent. This method will be removed when clients have updated.
+     * Provides a {@link FeignClientFactory} with an unmodified {@link ObjectMapper}.
+     */
+    @Deprecated
+    public static FeignClientFactory vanilla(Request.Options timeoutOptions) {
+        return withMapper(ObjectMappers.vanilla(), timeoutOptions);
     }
 
     /**
@@ -97,6 +156,15 @@ public final class FeignClients {
     }
 
     /**
+     * @deprecated Clients should specify a user agent. This method will be removed when clients have updated.
+     * Provides a {@link FeignClientFactory} with the specified {@link ObjectMapper}.
+     */
+    @Deprecated
+    public static FeignClientFactory withMapper(ObjectMapper mapper) {
+        return withMapper(mapper, DEFAULT_TIMEOUT_OPTIONS);
+    }
+
+    /**
      * Provides a {@link FeignClientFactory} with the specified {@link ObjectMapper}.
      */
     public static FeignClientFactory withMapper(ObjectMapper mapper, String userAgent) {
@@ -104,10 +172,29 @@ public final class FeignClients {
     }
 
     /**
+     * @deprecated Clients should specify a user agent. This method will be removed when clients have updated.
+     * Provides a {@link FeignClientFactory} with the specified {@link ObjectMapper}.
+     */
+    @Deprecated
+    public static FeignClientFactory withMapper(ObjectMapper mapper, Request.Options timeoutOptions) {
+        return withEncoderAndDecoder(new JacksonEncoder(mapper), new JacksonDecoder(mapper), timeoutOptions);
+    }
+
+    /**
      * Provides a {@link FeignClientFactory} with the specified {@link ObjectMapper}.
      */
     public static FeignClientFactory withMapper(ObjectMapper mapper, Request.Options timeoutOptions, String userAgent) {
         return withEncoderAndDecoder(new JacksonEncoder(mapper), new JacksonDecoder(mapper), timeoutOptions, userAgent);
+    }
+
+    /**
+     * @deprecated Clients should specify a user agent. This method will be removed when clients have updated.
+     * Provides a {@link FeignClientFactory} with the specified {@link Encoder} and {@link Decoder}.
+     */
+    @Deprecated
+    private static FeignClientFactory withEncoderAndDecoder(Encoder encoder, Decoder decoder,
+            Request.Options timeoutOptions) {
+        return withEncoderAndDecoder(encoder, decoder, timeoutOptions, "UnspecifiedUserAgent");
     }
 
     /**

--- a/http-clients/src/test/java/com/palantir/remoting/http/UserAgentTest.java
+++ b/http-clients/src/test/java/com/palantir/remoting/http/UserAgentTest.java
@@ -39,28 +39,41 @@ public final class UserAgentTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    private TestService service;
+    private String endpointUri;
 
     private static final String USER_AGENT = "TestSuite/1 (0.0.0)";
 
     @Before
     public void before() {
-        String endpointUri = "http://localhost:" + server.getPort();
-
-        service = FeignClients.standard(USER_AGENT).createProxy(
-                Optional.<SSLSocketFactory>absent(),
-                endpointUri,
-                TestService.class);
+        endpointUri = "http://localhost:" + server.getPort();
 
         server.enqueue(new MockResponse().setBody("{}"));
     }
 
     @Test
     public void testUserAgent_default() throws InterruptedException {
+        TestService service = FeignClients.standard(USER_AGENT).createProxy(
+                Optional.<SSLSocketFactory>absent(),
+                endpointUri,
+                TestService.class);
+
         service.get();
 
         RecordedRequest request = server.takeRequest();
         assertThat(request.getHeader("User-Agent"), is(USER_AGENT));
+    }
+
+    @Test
+    public void testUserAgent_deprecatedDefaultIsUnspecified() throws InterruptedException {
+        TestService service = FeignClients.standard().createProxy(
+                Optional.<SSLSocketFactory>absent(),
+                endpointUri,
+                TestService.class);
+
+        service.get();
+
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getHeader("User-Agent"), is("UnspecifiedUserAgent"));
     }
 
     @Test

--- a/retrofit-clients/src/main/java/com/palantir/remoting/retrofit/RetrofitClientFactory.java
+++ b/retrofit-clients/src/main/java/com/palantir/remoting/retrofit/RetrofitClientFactory.java
@@ -65,6 +65,15 @@ public final class RetrofitClientFactory {
         return new OkClient(okClient);
     }
 
+    /**
+     * @deprecated Clients should specify a user agent. This method will be removed when clients have updated.
+     */
+    @Deprecated
+    public static <T> T createProxy(Optional<SSLSocketFactory> sslSocketFactoryOptional, String uri, Class<T> type,
+            OkHttpClientOptions options) {
+        return createProxy(sslSocketFactoryOptional, uri, type, options, "UnspecifiedUserAgent");
+    }
+
     public static <T> T createProxy(Optional<SSLSocketFactory> sslSocketFactoryOptional, String uri, Class<T> type,
             OkHttpClientOptions options, String userAgent) {
         Client client = newHttpClient(sslSocketFactoryOptional, options, userAgent);

--- a/retrofit-clients/src/test/java/com/palantir/remoting/retrofit/UserAgentTest.java
+++ b/retrofit-clients/src/test/java/com/palantir/remoting/retrofit/UserAgentTest.java
@@ -51,7 +51,7 @@ public final class UserAgentTest {
     @Rule
     public final MockWebServer server = new MockWebServer();
 
-    private TestService service;
+    private String endpointUri;
     private UserAgentInterceptor userAgentInterceptor;
     private Interceptor.Chain chain;
     private Request request;
@@ -67,15 +67,7 @@ public final class UserAgentTest {
 
         when(chain.request()).thenReturn(request);
 
-        String endpointUri = "http://localhost:" + server.getPort();
-
-        service = RetrofitClientFactory.createProxy(
-                Optional.<SSLSocketFactory>absent(),
-                endpointUri,
-                TestService.class,
-                OkHttpClientOptions.builder().build(),
-                USER_AGENT
-                );
+        endpointUri = "http://localhost:" + server.getPort();
 
         server.enqueue(new MockResponse().setBody("{}"));
     }
@@ -97,10 +89,17 @@ public final class UserAgentTest {
 
     @Test
     public void  testUserAgent_defaultHeaderIsSent() throws InterruptedException {
+        TestService service = RetrofitClientFactory.createProxy(
+                Optional.<SSLSocketFactory>absent(),
+                endpointUri,
+                TestService.class,
+                OkHttpClientOptions.builder().build()
+        );
+
         service.get();
 
         RecordedRequest capturedRequest = server.takeRequest();
-        assertThat(capturedRequest.getHeader("User-Agent"), is(USER_AGENT));
+        assertThat(capturedRequest.getHeader("User-Agent"), is("UnspecifiedUserAgent"));
     }
 
 

--- a/retrofit-clients/src/test/java/com/palantir/remoting/retrofit/UserAgentTest.java
+++ b/retrofit-clients/src/test/java/com/palantir/remoting/retrofit/UserAgentTest.java
@@ -74,7 +74,7 @@ public final class UserAgentTest {
 
 
     @Test
-    public void  testUserAgent_default() throws IOException {
+    public void testUserAgent_default() throws IOException {
         when(chain.proceed(Matchers.any(Request.class))).thenReturn(responseSuccess);
         Response response = userAgentInterceptor.intercept(chain);
 
@@ -88,7 +88,23 @@ public final class UserAgentTest {
     }
 
     @Test
-    public void  testUserAgent_defaultHeaderIsSent() throws InterruptedException {
+    public void testUserAgent_defaultHeaderIsSent() throws InterruptedException {
+        TestService service = RetrofitClientFactory.createProxy(
+                Optional.<SSLSocketFactory>absent(),
+                endpointUri,
+                TestService.class,
+                OkHttpClientOptions.builder().build(),
+                USER_AGENT
+        );
+
+        service.get();
+
+        RecordedRequest capturedRequest = server.takeRequest();
+        assertThat(capturedRequest.getHeader("User-Agent"), is(USER_AGENT));
+    }
+
+    @Test
+    public void testUserAgent_deprecatedDefaultIsUnspecified() throws InterruptedException {
         TestService service = RetrofitClientFactory.createProxy(
                 Optional.<SSLSocketFactory>absent(),
                 endpointUri,
@@ -101,7 +117,6 @@ public final class UserAgentTest {
         RecordedRequest capturedRequest = server.takeRequest();
         assertThat(capturedRequest.getHeader("User-Agent"), is("UnspecifiedUserAgent"));
     }
-
 
     @Test
     public void testUserAgent_invalidUserAgentThrows() throws InterruptedException {


### PR DESCRIPTION
Bring back the old methods (marked as deprecated) to allow for diamond dependencies to get updated.
