### PR TITLE
Throw when UserAgents can't find title or version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Gradle
 *.class
-*.jar
 .gradle
 build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Gradle
 *.class
+*.jar
+!gradle/wrapper/gradle-wrapper.jar
+!http-clients/lib/VersionTest.jar
 .gradle
 build/
 

--- a/http-clients/src/main/java/com/palantir/remoting/http/UserAgents.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/UserAgents.java
@@ -16,11 +16,9 @@
 
 package com.palantir.remoting.http;
 
-import com.google.common.base.Optional;
+import static com.google.common.base.Preconditions.checkArgument;
 
 public final class UserAgents {
-
-    public static final String DEFAULT_VALUE = "unknown";
 
     private UserAgents() {}
 
@@ -30,13 +28,20 @@ public final class UserAgents {
 
     /**
      * Constructs a user agent from the {@link java.util.jar.Attributes.Name#IMPLEMENTATION_TITLE} and {@link
-     * java.util.jar.Attributes.Name#IMPLEMENTATION_VERSION} of the package of the provided class. The default value for
-     * both properties is "{@value DEFAULT_VALUE}".
+     * java.util.jar.Attributes.Name#IMPLEMENTATION_VERSION} of the package of the provided class.
+     * <p>
+     * Typically, the title and version are extracted from {@code MANIFEST.MF} entries of the Jar package containing the
+     * given class.
+     *
+     * @throws IllegalArgumentException if the implementation title or version are not provided in the class's {@link
+     * Package}
      */
     public static String fromClass(Class<?> clazz) {
         Package classPackage = clazz.getPackage();
-        String userAgent = Optional.fromNullable(classPackage.getImplementationTitle()).or(DEFAULT_VALUE);
-        String version = Optional.fromNullable(classPackage.getImplementationVersion()).or(DEFAULT_VALUE);
+        String userAgent = classPackage.getImplementationTitle();
+        String version = classPackage.getImplementationVersion();
+        checkArgument(userAgent != null, "Cannot load user agent from implementation title for class: %s", clazz);
+        checkArgument(version != null, "Cannot load version from implementation version for class: %s", clazz);
         return getUserAgent(userAgent, version);
     }
 

--- a/http-clients/src/test/java/com/palantir/remoting/http/UserAgentsTest.java
+++ b/http-clients/src/test/java/com/palantir/remoting/http/UserAgentsTest.java
@@ -21,9 +21,14 @@ import static org.junit.Assert.assertThat;
 
 import com.palantir.VersionTest;
 import java.io.IOException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public final class UserAgentsTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testGetUserAgent_format() {
@@ -33,6 +38,13 @@ public final class UserAgentsTest {
     @Test
     public void testGetUserAgent_fromExternalVersionTestJar() throws IOException {
         assertThat(UserAgents.fromClass(VersionTest.class), is("test-name (test-version)"));
+    }
+
+    @Test
+    public void testGetUserAgent_fromExternalVersionWithoutManifestTestJar() throws IOException {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Cannot load user agent from implementation title");
+        UserAgents.fromClass(UserAgentsTest.class);
     }
 
 }


### PR DESCRIPTION
Modifies UserAgents in http-remoting to throw an exception if it can’t find a project name + version instead of the current behaviour of saying “unknown”. The reasoning behind this change is that in the world in which UserAgents returns unknown I have to write an integration test to capture the case in which my build stops putting the information in the manifest file. If, instead, UserAgents throws an exception, then any integration test will capture this issue.
