### PR TITLE
Add ext.feign-okhttp3 package

### DIFF
--- a/ext/feign-okhttp3-compat-test/build.gradle
+++ b/ext/feign-okhttp3-compat-test/build.gradle
@@ -1,0 +1,10 @@
+apply from: "${rootDir}/gradle/libs.gradle"
+
+dependencies {
+    testCompile project(':ext:feign-okhttp3')
+    testCompile project(':http-clients')
+    testCompile 'com.netflix.feign:feign-okhttp:8.10.0'
+    testCompile libs.hamcrest
+    testCompile libs.junit
+    testCompile libs.mockwebserver
+}

--- a/ext/feign-okhttp3-compat-test/src/test/java/com/palantir/remoting/TestOkhttpFeignCompatibility.java
+++ b/ext/feign-okhttp3-compat-test/src/test/java/com/palantir/remoting/TestOkhttpFeignCompatibility.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.base.Optional;
+import com.palantir.remoting.http.ClientSupplier;
+import com.palantir.remoting.http.FeignClientFactory;
+import com.palantir.remoting.http.FeignClients;
+import com.palantir.remoting.http.GuavaOptionalAwareContract;
+import com.palantir.remoting.http.NeverRetryingBackoffStrategy;
+import com.palantir.remoting.http.ObjectMappers;
+import com.palantir.remoting.http.SlashEncodingContract;
+import com.palantir.remoting.http.errors.FeignSerializableErrorErrorDecoder;
+import feign.Client;
+import feign.InputStreamDelegateDecoder;
+import feign.InputStreamDelegateEncoder;
+import feign.OptionalAwareDecoder;
+import feign.Request;
+import feign.TextDelegateDecoder;
+import feign.TextDelegateEncoder;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import feign.jaxrs.JaxRsWithHeaderAndQueryMapContract;
+import javax.net.ssl.SSLSocketFactory;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+// Verifies that Feign can be used simultaneously with OkHttp 2.x and 3.x.
+// TODO(rfink) Remove this when OkHttpClient gets removed.
+public final class TestOkhttpFeignCompatibility {
+
+    @Rule
+    public final MockWebServer server = new MockWebServer();
+
+    private String endpointUri;
+
+    @Before
+    public void before() {
+        endpointUri = "http://localhost:" + server.getPort();
+        server.enqueue(new MockResponse().setBody("\"foo\""));
+    }
+
+    @Test
+    public void testOkHttp3_usingStandardFeignClientsFactory() throws Exception {
+        TestService service = FeignClients.standard("agent").createProxy(
+                Optional.<SSLSocketFactory>absent(),
+                endpointUri,
+                TestService.class);
+        assertThat(service.get(), is("foo"));
+    }
+
+    @Test
+    public void testOkHttp2_usingCustomClientSupplier() throws Exception {
+        FeignClientFactory okHttp2Factory = FeignClientFactory.of(
+                new SlashEncodingContract(new GuavaOptionalAwareContract(new JaxRsWithHeaderAndQueryMapContract())),
+                new InputStreamDelegateEncoder(new TextDelegateEncoder(new JacksonEncoder(ObjectMappers.guavaJdk7()))),
+                new OptionalAwareDecoder(new InputStreamDelegateDecoder(
+                        new TextDelegateDecoder(new JacksonDecoder(ObjectMappers.guavaJdk7())))),
+                FeignSerializableErrorErrorDecoder.INSTANCE,
+                new ClientSupplier() {
+                    @Override
+                    public Client createClient(Optional<SSLSocketFactory> sslSocketFactory, String userAgent) {
+                        return new feign.okhttp.OkHttpClient();
+                    }
+                },
+                NeverRetryingBackoffStrategy.INSTANCE,
+                new Request.Options(),
+                "agent");
+        TestService service = okHttp2Factory.createProxy(
+                Optional.<SSLSocketFactory>absent(),
+                endpointUri,
+                TestService.class);
+        assertThat(service.get(), is("foo"));
+    }
+
+    @Path("/")
+    public interface TestService {
+        @GET
+        String get();
+    }
+}

--- a/ext/feign-okhttp3/build.gradle
+++ b/ext/feign-okhttp3/build.gradle
@@ -1,7 +1,7 @@
 apply from: "${rootDir}/gradle/libs.gradle"
 apply from: "${rootDir}/gradle/publish.gradle"
 
-tasks.checkstyleMain.onlyIf { false }
+tasks.checkstyleMain.enabled = false
 dependencies {
     compile libs.feign.core
     compile libs.okhttp3

--- a/ext/feign-okhttp3/build.gradle
+++ b/ext/feign-okhttp3/build.gradle
@@ -1,0 +1,8 @@
+apply from: "${rootDir}/gradle/libs.gradle"
+apply from: "${rootDir}/gradle/publish.gradle"
+
+tasks.checkstyleMain.onlyIf { false }
+dependencies {
+    compile libs.feign.core
+    compile libs.okhttp3
+}

--- a/ext/feign-okhttp3/src/main/java/feign/okhttp3/OkHttpClient.java
+++ b/ext/feign-okhttp3/src/main/java/feign/okhttp3/OkHttpClient.java
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
  * This file was copied verbatim from
- * https://github.com/Netflix/feign/blob/master/okhttp/src/main/java/feign/okhttp/OkHttpClient.java into the
- * feign.okhttp3 package in order to avoid binary incompatibility between Feign <=8.16 and >=8.17.
+ * https://github.com/Netflix/feign/blob/6717142afc42b6bec35e008fc9a0f41a8268a204/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
+ * into the feign.okhttp3 package in order to avoid binary incompatibility between Feign <=8.16 and >=8.17.
  */
 package feign.okhttp3;
 

--- a/ext/feign-okhttp3/src/main/java/feign/okhttp3/OkHttpClient.java
+++ b/ext/feign-okhttp3/src/main/java/feign/okhttp3/OkHttpClient.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file was copied verbatim from
+ * https://github.com/Netflix/feign/blob/master/okhttp/src/main/java/feign/okhttp/OkHttpClient.java into the
+ * feign.okhttp3 package in order to avoid binary incompatibility between Feign <=8.16 and >=8.17.
+ */
+package feign.okhttp3;
+
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import feign.Client;
+
+/**
+ * This module directs Feign's http requests to <a href="http://square.github.io/okhttp/">OkHttp</a>,
+ * which enables SPDY and better network control. Ex.
+ * <pre>
+ * GitHub github = Feign.builder().client(new OkHttpClient()).target(GitHub.class,
+ * "https://api.github.com");
+ */
+public final class OkHttpClient implements Client {
+
+    private final okhttp3.OkHttpClient delegate;
+
+    public OkHttpClient() {
+        this(new okhttp3.OkHttpClient());
+    }
+
+    public OkHttpClient(okhttp3.OkHttpClient delegate) {
+        this.delegate = delegate;
+    }
+
+    static Request toOkHttpRequest(feign.Request input) {
+        Request.Builder requestBuilder = new Request.Builder();
+        requestBuilder.url(input.url());
+
+        MediaType mediaType = null;
+        boolean hasAcceptHeader = false;
+        for (String field : input.headers().keySet()) {
+            if (field.equalsIgnoreCase("Accept")) {
+                hasAcceptHeader = true;
+            }
+
+            for (String value : input.headers().get(field)) {
+                if (field.equalsIgnoreCase("Content-Type")) {
+                    mediaType = MediaType.parse(value);
+                    if (input.charset() != null) {
+                        mediaType.charset(input.charset());
+                    }
+                } else {
+                    requestBuilder.addHeader(field, value);
+                }
+            }
+        }
+        // Some servers choke on the default accept string.
+        if (!hasAcceptHeader) {
+            requestBuilder.addHeader("Accept", "*/*");
+        }
+
+        byte[] inputBody = input.body();
+        boolean isMethodWithBody = "POST".equals(input.method()) || "PUT".equals(input.method());
+        if (isMethodWithBody && inputBody == null) {
+            // write an empty BODY to conform with okhttp 2.4.0+
+            // http://johnfeng.github.io/blog/2015/06/30/okhttp-updates-post-wouldnt-be-allowed-to-have-null-body/
+            inputBody = new byte[0];
+        }
+
+        RequestBody body = inputBody != null ? RequestBody.create(mediaType, inputBody) : null;
+        requestBuilder.method(input.method(), body);
+        return requestBuilder.build();
+    }
+
+    private static feign.Response toFeignResponse(Response input) throws IOException {
+        return feign.Response
+                .create(input.code(), input.message(), toMap(input.headers()), toBody(input.body()));
+    }
+
+    private static Map<String, Collection<String>> toMap(Headers headers) {
+        return (Map) headers.toMultimap();
+    }
+
+    private static feign.Response.Body toBody(final ResponseBody input) throws IOException {
+        if (input == null || input.contentLength() == 0) {
+            return null;
+        }
+        if (input.contentLength() > Integer.MAX_VALUE) {
+            throw new UnsupportedOperationException("Length too long " + input.contentLength());
+        }
+        final Integer length = input.contentLength() != -1 ? (int) input.contentLength() : null;
+
+        return new feign.Response.Body() {
+
+            @Override
+            public void close() throws IOException {
+                input.close();
+            }
+
+            @Override
+            public Integer length() {
+                return length;
+            }
+
+            @Override
+            public boolean isRepeatable() {
+                return false;
+            }
+
+            @Override
+            public InputStream asInputStream() throws IOException {
+                return input.byteStream();
+            }
+
+            @Override
+            public Reader asReader() throws IOException {
+                return input.charStream();
+            }
+        };
+    }
+
+    @Override
+    public feign.Response execute(feign.Request input, feign.Request.Options options)
+            throws IOException {
+        okhttp3.OkHttpClient requestScoped;
+        if (delegate.connectTimeoutMillis() != options.connectTimeoutMillis()
+                || delegate.readTimeoutMillis() != options.readTimeoutMillis()) {
+            requestScoped = delegate.newBuilder()
+                    .connectTimeout(options.connectTimeoutMillis(), TimeUnit.MILLISECONDS)
+                    .readTimeout(options.readTimeoutMillis(), TimeUnit.MILLISECONDS)
+                    .build();
+        } else {
+            requestScoped = delegate;
+        }
+        Request request = toOkHttpRequest(input);
+        Response response = requestScoped.newCall(request).execute();
+        return toFeignResponse(response);
+    }
+}

--- a/gradle/libs.gradle
+++ b/gradle/libs.gradle
@@ -10,6 +10,7 @@ project.ext.libs = [
         'utils': 'io.dropwizard:dropwizard-util:0.8.2'
     ],
     'feign': [
+        'core': 'com.netflix.feign:feign-core:8.17.0',
         'jackson': 'com.netflix.feign:feign-jackson:8.17.0',
         'jaxrs': 'com.netflix.feign:feign-jaxrs:8.17.0',
         'okhttp': 'com.netflix.feign:feign-okhttp:8.17.0',
@@ -28,6 +29,7 @@ project.ext.libs = [
     'mockito': 'org.mockito:mockito-core:1.10.19',
     'mockwebserver': 'com.squareup.okhttp3:mockwebserver:3.2.0',
     'okhttp2': 'com.squareup.okhttp:okhttp:2.7.5',
+    'okhttp3': 'com.squareup.okhttp3:okhttp:3.2.0',
     'retrofit': 'com.squareup.retrofit:retrofit:1.9.0',
     'retrofit2': [
         'retrofit': 'com.squareup.retrofit2:retrofit:2.1.0',

--- a/http-clients/build.gradle
+++ b/http-clients/build.gradle
@@ -12,7 +12,7 @@ dependencies {
         // the shipped version clashes with the newer javax.ws.rs:javax.ws.rs-api used by (e.g.) dropwizard
         exclude group: 'javax.ws.rs', module: 'jsr311-api'
     }
-    compile libs.feign.okhttp
+    compile project(':ext:feign-okhttp3')
     compile libs.feign.slf4j
     compile libs.guava
     compile libs.jackson.databind

--- a/http-clients/src/main/java/com/palantir/remoting/http/FeignClientFactory.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/FeignClientFactory.java
@@ -41,7 +41,7 @@ import feign.Request;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
-import feign.okhttp.OkHttpClient;
+import feign.okhttp3.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 import io.dropwizard.util.Duration;
 import java.net.InetAddress;

--- a/service-config/build.gradle
+++ b/service-config/build.gradle
@@ -13,7 +13,7 @@ dependencies {
         // the shipped version clashes with the newer javax.ws.rs:javax.ws.rs-api used by (e.g.) dropwizard
         exclude group: 'javax.ws.rs', module: 'jsr311-api'
     }
-    testCompile libs.feign.okhttp
+    testCompile project(':ext:feign-okhttp3')
     testCompile libs.junit
 
     processor libs.immutables

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,6 @@
 include ':ext:brave-extensions'
+include ':ext:feign-okhttp3'
+include ':ext:feign-okhttp3-compat-test'
 include 'error-handling'
 include 'http-clients'
 include 'http-servers'

--- a/ssl-config/build.gradle
+++ b/ssl-config/build.gradle
@@ -13,7 +13,7 @@ dependencies {
         // the shipped version clashes with the newer javax.ws.rs:javax.ws.rs-api used by (e.g.) dropwizard
         exclude group: 'javax.ws.rs', module: 'jsr311-api'
     }
-    testCompile libs.feign.okhttp
+    testCompile project(':ext:feign-okhttp3')
     testCompile libs.hamcrest
     testCompile libs.junit
 

--- a/ssl-config/src/test/java/com/palantir/remoting/ssl/DropwizardSslClientAuthTests.java
+++ b/ssl-config/src/test/java/com/palantir/remoting/ssl/DropwizardSslClientAuthTests.java
@@ -100,7 +100,7 @@ public final class DropwizardSslClientAuthTests {
         String endpointUri = "https://localhost:" + APP.getLocalPort();
         OkHttpClient okHttpClient = new OkHttpClient.Builder().sslSocketFactory(factory).build();
         return Feign.builder()
-                .client(new feign.okhttp.OkHttpClient(okHttpClient))
+                .client(new feign.okhttp3.OkHttpClient(okHttpClient))
                 .contract(new JAXRSContract())
                 .target(TestEchoService.class, endpointUri);
     }


### PR DESCRIPTION
ext.feign-okhttp3 is a copy of feign.okhttp.OkHttpClient in the feign.okhttp3 package.
This constructions allows clients compiled against Feign <= 8.16 (with OkHttp2) to be used
alongside clients compiled against Feign 8.17 (with OkHttp3).

This should be considered a temporary work-around and be removed as soon as Feign
sorts out their back-compat story.
