### PR TITLE
Proxy support

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -71,7 +71,7 @@
         </module>
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
-            <property name="excludes" value="org.junit.Assert.*,org.junit.Assume.*,org.hamcrest.Matchers.*,org.mockito.Mockito.*,org.mockito.Matchers.*,org.assertj.core.api.Assertions.*,com.google.common.base.Strings.*,com.google.common.base.Preconditions.*,org.apache.commons.lang3.Validate.*,com.google.common.truth.Truth.*"/>
+            <property name="excludes" value="org.junit.Assert.*,org.junit.Assume.*,org.hamcrest.Matchers.*,org.mockito.Mockito.*,org.mockito.Matchers.*,org.assertj.core.api.Assertions.*,com.google.common.base.Strings.*,com.google.common.base.Throwables.*,com.google.common.base.Preconditions.*,org.apache.commons.lang3.Validate.*,com.google.common.truth.Truth.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>

--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -71,7 +71,7 @@
         </module>
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
-            <property name="excludes" value="org.junit.Assert.*,org.junit.Assume.*,org.hamcrest.Matchers.*,org.mockito.Mockito.*,org.mockito.Matchers.*,org.assertj.core.api.Assertions.*,com.google.common.base.Preconditions.*,org.apache.commons.lang3.Validate.*,com.google.common.truth.Truth.*"/>
+            <property name="excludes" value="org.junit.Assert.*,org.junit.Assume.*,org.hamcrest.Matchers.*,org.mockito.Mockito.*,org.mockito.Matchers.*,org.assertj.core.api.Assertions.*,com.google.common.base.Strings.*,com.google.common.base.Preconditions.*,org.apache.commons.lang3.Validate.*,com.google.common.truth.Truth.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>

--- a/error-handling/build.gradle
+++ b/error-handling/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     testCompile libs.hamcrest
     testCompile libs.junit
 
-    processor libs.immutables
+    processor libs.immutables.value
 }

--- a/gradle/libs.gradle
+++ b/gradle/libs.gradle
@@ -26,7 +26,7 @@ project.ext.libs = [
     'jsr305': 'com.google.code.findbugs:jsr305:3.0.0',
     'junit': 'junit:junit:4.12',
     'mockito': 'org.mockito:mockito-core:1.10.19',
-    'mockwebserver': 'com.squareup.okhttp3:mockwebserver:3.2.0',
+    'mockwebserver': 'com.squareup.okhttp3:mockwebserver:3.4.1',
     'okhttp2': 'com.squareup.okhttp:okhttp:2.7.5',
     'retrofit': 'com.squareup.retrofit:retrofit:1.9.0',
     'retrofit2': [

--- a/gradle/libs.gradle
+++ b/gradle/libs.gradle
@@ -17,7 +17,10 @@ project.ext.libs = [
     ],
     'guava': 'com.google.guava:guava:18.0',
     'hamcrest': 'org.hamcrest:hamcrest-all:1.3',
-    'immutables': 'org.immutables:value:2.0.21',
+    'immutables': [
+        'value': 'org.immutables:value:2.0.21',
+        'gson': 'org.immutables:gson:2.0.21'
+    ],
     'jackson': [
         'databind': 'com.fasterxml.jackson.core:jackson-databind:2.6.1',
         'guava': 'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.1',

--- a/http-clients/build.gradle
+++ b/http-clients/build.gradle
@@ -32,5 +32,5 @@ dependencies {
     testCompile libs.junit
     testCompile libs.mockwebserver
 
-    processor libs.immutables
+    processor libs.immutables.value
 }

--- a/http-clients/build.gradle
+++ b/http-clients/build.gradle
@@ -1,6 +1,8 @@
 apply from: "${rootDir}/gradle/libs.gradle"
 apply from: "${rootDir}/gradle/publish.gradle"
 
+apply plugin: 'org.inferred.processors'
+
 dependencies {
     compile project(':error-handling')
     compile project(':ext:brave-extensions')
@@ -29,4 +31,6 @@ dependencies {
     testCompile libs.hamcrest
     testCompile libs.junit
     testCompile libs.mockwebserver
+
+    processor libs.immutables
 }

--- a/http-clients/src/main/java/com/palantir/remoting/http/ClientConfiguration.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/ClientConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+package com.palantir.remoting.http;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Optional;
+import com.palantir.config.service.proxy.ProxyConfigurationProvider;
+import javax.net.ssl.SSLSocketFactory;
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Style;
+
+@Immutable
+@JsonDeserialize(as = ImmutableClientConfiguration.class)
+@Style(visibility = Style.ImplementationVisibility.PACKAGE)
+public abstract class ClientConfiguration {
+
+    /**
+     * An optional {@link javax.net.ssl.SSLSocketFactory} for the client to use
+     */
+    public abstract Optional<SSLSocketFactory> sslSocketFactory();
+
+    /**
+     * An {@link com.palantir.config.service.proxy.ProxyConfigurationProvider} providing optional configuration for a
+     * proxy
+     */
+    public abstract ProxyConfigurationProvider proxyConfigurationProvider();
+
+    /**
+     * A user agent
+     */
+    public abstract String userAgent();
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder extends ImmutableClientConfiguration.Builder {}
+}

--- a/http-clients/src/main/java/com/palantir/remoting/http/ClientConfiguration.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/ClientConfiguration.java
@@ -16,18 +16,18 @@ import org.immutables.value.Value.Style;
 public abstract class ClientConfiguration {
 
     /**
-     * An optional {@link javax.net.ssl.SSLSocketFactory} for the client to use
+     * An optional {@link javax.net.ssl.SSLSocketFactory} for the client to use.
      */
     public abstract Optional<SSLSocketFactory> sslSocketFactory();
 
     /**
      * An {@link com.palantir.config.service.proxy.ProxyConfigurationProvider} providing optional configuration for a
-     * proxy
+     * proxy.
      */
     public abstract ProxyConfigurationProvider proxyConfigurationProvider();
 
     /**
-     * A user agent
+     * A user agent.
      */
     public abstract String userAgent();
 

--- a/http-clients/src/main/java/com/palantir/remoting/http/ClientSupplier.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/ClientSupplier.java
@@ -16,17 +16,14 @@
 
 package com.palantir.remoting.http;
 
-import com.google.common.base.Optional;
-import com.palantir.config.service.ProxyConfiguration;
 import feign.Client;
-import javax.net.ssl.SSLSocketFactory;
+
 
 /**
- * Given an optional {@link javax.net.ssl.SSLSocketFactory},
- * optional {@link com.palantir.config.service.ProxyConfiguration} and a user agent, creates and returns a
- * {@link feign.Client Feign client}.
+ * Creates and returns a {@link feign.Client Feign client} using the provided
+ * {@link com.palantir.remoting.http.ClientConfiguration}.
  */
 public interface ClientSupplier {
-    Client createClient(Optional<SSLSocketFactory> sslSocketFactory, Optional<ProxyConfiguration> proxyConfiguration,
-            String userAgent);
+
+    Client createClient(ClientConfiguration clientConfiguration);
 }

--- a/http-clients/src/main/java/com/palantir/remoting/http/ClientSupplier.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/ClientSupplier.java
@@ -17,13 +17,16 @@
 package com.palantir.remoting.http;
 
 import com.google.common.base.Optional;
+import com.palantir.config.service.ProxyConfiguration;
 import feign.Client;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
- * Given an optional {@link javax.net.ssl.SSLSocketFactory} and a user agent, creates and returns a {@link feign.Client
- * Feign client}.
+ * Given an optional {@link javax.net.ssl.SSLSocketFactory},
+ * optional {@link com.palantir.config.service.ProxyConfiguration} and a user agent, creates and returns a
+ * {@link feign.Client Feign client}.
  */
 public interface ClientSupplier {
-    Client createClient(Optional<SSLSocketFactory> sslSocketFactory, String userAgent);
+    Client createClient(Optional<SSLSocketFactory> sslSocketFactory, Optional<ProxyConfiguration> proxyConfiguration,
+            String userAgent);
 }

--- a/http-clients/src/main/java/com/palantir/remoting/http/FeignClientFactory.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/FeignClientFactory.java
@@ -82,7 +82,7 @@ public final class FeignClientFactory {
     private final BackoffStrategy backoffStrategy;
     private final Request.Options options;
     private final String userAgent;
-    private final ProxyConfigurationProvider proxyConfigurationProvider;
+    private final ProxyConfigurationProvider defaultProxyConfigurationProvider;
 
     private FeignClientFactory(
             Contract contract,
@@ -102,7 +102,7 @@ public final class FeignClientFactory {
         this.backoffStrategy = backoffStrategy;
         this.options = options;
         this.userAgent = userAgent;
-        this.proxyConfigurationProvider = proxyConfigurationProvider;
+        this.defaultProxyConfigurationProvider = proxyConfigurationProvider;
     }
 
     /**
@@ -162,7 +162,7 @@ public final class FeignClientFactory {
      * okhttp3.OkHttpClient} wrapped in {@link feign.okhttp.OkHttpClient}.
      */
     public <T> T createProxy(Optional<SSLSocketFactory> sslSocketFactory, String uri, Class<T> type) {
-        return createProxy(sslSocketFactory, uri, type, proxyConfigurationProvider);
+        return createProxy(sslSocketFactory, uri, type, defaultProxyConfigurationProvider);
     }
 
     /**
@@ -171,7 +171,7 @@ public final class FeignClientFactory {
      */
     public <T> T createProxy(Optional<SSLSocketFactory> sslSocketFactory, String uri, Class<T> type,
             Request.Options requestOptions) {
-        return createProxy(sslSocketFactory, uri, type, proxyConfigurationProvider, requestOptions);
+        return createProxy(sslSocketFactory, uri, type, defaultProxyConfigurationProvider, requestOptions);
     }
 
     /**
@@ -208,7 +208,7 @@ public final class FeignClientFactory {
      */
     public <T> T createProxy(Optional<SSLSocketFactory> sslSocketFactory, Set<String> uris, Class<T> type,
             Request.Options requestOptions) {
-        return createProxy(sslSocketFactory, uris, type, proxyConfigurationProvider, requestOptions);
+        return createProxy(sslSocketFactory, uris, type, defaultProxyConfigurationProvider, requestOptions);
     }
 
     /**
@@ -229,7 +229,7 @@ public final class FeignClientFactory {
     public <T> T createProxy(Optional<SSLSocketFactory> sslSocketFactory, Set<String> uris, Class<T> type,
                              ProxyConfigurationProvider proxyConfigurationProvider, Request.Options requestOptions) {
 
-        ClientConfiguration configuration = new ImmutableClientConfiguration.Builder()
+        ClientConfiguration configuration = ImmutableClientConfiguration.builder()
                 .sslSocketFactory(sslSocketFactory)
                 .proxyConfigurationProvider(proxyConfigurationProvider)
                 .userAgent(userAgent)

--- a/http-clients/src/main/java/com/palantir/remoting/http/FeignClients.java
+++ b/http-clients/src/main/java/com/palantir/remoting/http/FeignClients.java
@@ -18,9 +18,9 @@ package com.palantir.remoting.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
-import com.palantir.remoting.http.errors.FeignSerializableErrorErrorDecoder;
 import com.palantir.config.service.proxy.DefaultProxyConfigurationProviderChain;
 import com.palantir.config.service.proxy.ProxyConfigurationProvider;
+import com.palantir.remoting.http.errors.FeignSerializableErrorErrorDecoder;
 import feign.InputStreamDelegateDecoder;
 import feign.InputStreamDelegateEncoder;
 import feign.OptionalAwareDecoder;

--- a/http-clients/src/test/java/com/palantir/remoting/http/FailoverFeignTargetTest.java
+++ b/http-clients/src/test/java/com/palantir/remoting/http/FailoverFeignTargetTest.java
@@ -107,7 +107,8 @@ public final class FailoverFeignTargetTest {
                 FeignClientFactory.okHttpClient(),
                 backoffStrategy,
                 new Request.Options(),
-                "test suite user agent")
+                "test suite user agent",
+                null)
                 .createProxy(Optional.<SSLSocketFactory>absent(),
                         ImmutableSet.of("http://localhost:" + server1.getPort(),
                                 "http://localhost:" + server2.getPort()),

--- a/http-clients/src/test/java/com/palantir/remoting/http/FailoverFeignTargetTest.java
+++ b/http-clients/src/test/java/com/palantir/remoting/http/FailoverFeignTargetTest.java
@@ -107,8 +107,7 @@ public final class FailoverFeignTargetTest {
                 FeignClientFactory.okHttpClient(),
                 backoffStrategy,
                 new Request.Options(),
-                "test suite user agent",
-                null)
+                "test suite user agent")
                 .createProxy(Optional.<SSLSocketFactory>absent(),
                         ImmutableSet.of("http://localhost:" + server1.getPort(),
                                 "http://localhost:" + server2.getPort()),

--- a/retrofit-clients/build.gradle
+++ b/retrofit-clients/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     // ssl-config is not used in this project, but we depend on it here in order to provide
     // it transitively to users of retrofit-clients as a convenience.
     compile project(':ssl-config')
+    compile project(':service-config')
     compile libs.retrofit
     compile libs.okhttp2
     compile libs.slf4j

--- a/retrofit-clients/build.gradle
+++ b/retrofit-clients/build.gradle
@@ -18,5 +18,5 @@ dependencies {
     testCompile libs.mockito
     testCompile libs.mockwebserver
 
-    processor libs.immutables
+    processor libs.immutables.value
 }

--- a/retrofit-clients/src/main/java/com/palantir/remoting/retrofit/errors/RetrofitSerializableErrorErrorHandler.java
+++ b/retrofit-clients/src/main/java/com/palantir/remoting/retrofit/errors/RetrofitSerializableErrorErrorHandler.java
@@ -17,6 +17,7 @@
 package com.palantir.remoting.retrofit.errors;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HttpHeaders;
 import com.palantir.remoting.http.errors.SerializableErrorToExceptionConverter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,7 +36,7 @@ public enum RetrofitSerializableErrorErrorHandler implements ErrorHandler {
 
         Collection<String> contentTypes = ImmutableSet.of();
         for (Header header : response.getHeaders()) {
-            if (header.getName().equals("Content-Type")) {
+            if (header.getName().equalsIgnoreCase(HttpHeaders.CONTENT_TYPE)) {
                 contentTypes = ImmutableSet.of(header.getValue());
                 break;
             }

--- a/retrofit2-clients/build.gradle
+++ b/retrofit2-clients/build.gradle
@@ -13,11 +13,12 @@ dependencies {
     compile libs.retrofit2.retrofit
     compile libs.retrofit2.gson
     compile libs.slf4j
+    compile libs.immutables.gson
 
     testCompile libs.hamcrest
     testCompile libs.junit
     testCompile libs.mockito
     testCompile libs.mockwebserver
 
-    processor libs.immutables
+    processor libs.immutables.value
 }

--- a/retrofit2-clients/build.gradle
+++ b/retrofit2-clients/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     // ssl-config is not used in this project, but we depend on it here in order to provide
     // it transitively to users of retrofit-clients as a convenience.
     runtime project(':ssl-config')
+    compile project(':service-config')
+
     compile libs.retrofit2.retrofit
     compile libs.retrofit2.gson
     compile libs.slf4j

--- a/service-config/build.gradle
+++ b/service-config/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     testCompile libs.feign.okhttp
     testCompile libs.junit
 
-    processor libs.immutables
+    processor libs.immutables.value
 }

--- a/service-config/src/main/java/com/palantir/config/service/BasicCredentials.java
+++ b/service-config/src/main/java/com/palantir/config/service/BasicCredentials.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.config.service;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Preconditions;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Style;
+
+@Immutable
+@JsonDeserialize(as = ImmutableBasicCredentials.class)
+@Style(visibility = Style.ImplementationVisibility.PACKAGE)
+public abstract class BasicCredentials {
+
+    @Value.Parameter
+    public abstract String username();
+
+    @Value.Parameter
+    public abstract String password();
+
+    @Check
+    protected final void check() {
+        Preconditions.checkArgument(!username().isEmpty(), "Username must not be empty");
+        Preconditions.checkArgument(!password().isEmpty(), "Password must not be empty");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder extends ImmutableBasicCredentials.Builder {}
+
+    public static BasicCredentials of(String username, String password) {
+        return ImmutableBasicCredentials.of(username, password);
+    }
+}

--- a/service-config/src/main/java/com/palantir/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/config/service/ProxyConfiguration.java
@@ -16,53 +16,45 @@
 
 package com.palantir.config.service;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Optional;
-import com.palantir.remoting.ssl.SslConfiguration;
-import com.palantir.tokens.auth.BearerToken;
-import io.dropwizard.util.Duration;
-import java.util.List;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Lazy;
 import org.immutables.value.Value.Style;
 
 @Immutable
-@JsonDeserialize(as = ImmutableServiceConfiguration.class)
+@JsonDeserialize(as = ImmutableProxyConfiguration.class)
 @Style(visibility = Style.ImplementationVisibility.PACKAGE)
-public abstract class ServiceConfiguration {
+public abstract class ProxyConfiguration {
 
     /**
-     * The API token to be used to interact with the service.
+     * The hostname of the HTTP/HTTPS Proxy.
      */
-    public abstract Optional<BearerToken> apiToken();
+    public abstract String host();
 
     /**
-     * The SSL configuration needed to interact with the service.
+     * Port for the proxy.
      */
-    public abstract Optional<SslConfiguration> security();
+    public abstract int port();
 
     /**
-     * Connect timeout for requests.
+     * Credentials if the proxy needs authentication.
      */
-    public abstract Optional<Duration> connectTimeout();
+    public abstract Optional<BasicCredentials> credentials();
 
-    /**
-     * Read timeout for requests.
-     */
-    public abstract Optional<Duration> readTimeout();
-
-    /**
-     * A list of service URIs.
-     */
-    public abstract List<String> uris();
-
-    /**
-     * Proxy configuration for connecting to the service.
-     */
-    public abstract Optional<ProxyConfiguration> proxyConfiguration();
+    @Lazy
+    @SuppressWarnings("checkstyle:designforextension")
+    @JsonIgnore
+    public Proxy toProxy() {
+        return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host(), port()));
+    }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    public static final class Builder extends ImmutableServiceConfiguration.Builder {}
+    public static final class Builder extends ImmutableProxyConfiguration.Builder {}
 }

--- a/service-config/src/main/java/com/palantir/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/config/service/ServiceConfiguration.java
@@ -18,6 +18,7 @@ package com.palantir.config.service;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Optional;
+import com.palantir.config.service.proxy.ProxyConfiguration;
 import com.palantir.remoting.ssl.SslConfiguration;
 import com.palantir.tokens.auth.BearerToken;
 import io.dropwizard.util.Duration;

--- a/service-config/src/main/java/com/palantir/config/service/ServiceDiscoveryConfiguration.java
+++ b/service-config/src/main/java/com/palantir/config/service/ServiceDiscoveryConfiguration.java
@@ -59,13 +59,19 @@ public abstract class ServiceDiscoveryConfiguration {
     abstract Map<String, ServiceConfiguration> originalServices();
 
     /**
-     * Default global connect timeout .
+     * Default global proxy configuration for connecting to the services.
+     */
+    @JsonProperty("proxyConfiguration")
+    public abstract Optional<ProxyConfiguration> defaultProxyConfiguration();
+
+    /**
+     * Default global connect timeout.
      */
     @JsonProperty("connectTimeout")
     public abstract Optional<Duration> defaultConnectTimeout();
 
     /**
-     * Default global read timeout .
+     * Default global read timeout.
      */
     @JsonProperty("readTimeout")
     public abstract Optional<Duration> defaultReadTimeout();
@@ -84,6 +90,7 @@ public abstract class ServiceDiscoveryConfiguration {
             ServiceConfiguration configWithDefaults = ImmutableServiceConfiguration.builder()
                     .apiToken(originalConfig.apiToken().or(defaultApiToken()))
                     .security(originalConfig.security().or(defaultSecurity()))
+                    .proxyConfiguration(originalConfig.proxyConfiguration().or(defaultProxyConfiguration()))
                     .connectTimeout(originalConfig.connectTimeout().or(defaultConnectTimeout()))
                     .readTimeout(originalConfig.readTimeout().or(defaultReadTimeout()))
                     .uris(originalConfig.uris()).build();
@@ -126,6 +133,17 @@ public abstract class ServiceDiscoveryConfiguration {
      */
     public final List<String> getUris(String serviceName) {
         return getServiceConfig(serviceName).uris();
+    }
+
+    /**
+     * Uses the provided service name as the key to retrieve the proxy configuration for the respective
+     * {@link ServiceConfiguration}.
+     *
+     * @param serviceName the name of the service
+     * @return the {@link ProxyConfiguration} for the specified service
+     */
+    public final Optional<ProxyConfiguration> getProxyConfiguration(String serviceName) {
+        return getServiceConfig(serviceName).proxyConfiguration();
     }
 
     public final Optional<Duration> getConnectTimeout(String serviceName) {

--- a/service-config/src/main/java/com/palantir/config/service/ServiceDiscoveryConfiguration.java
+++ b/service-config/src/main/java/com/palantir/config/service/ServiceDiscoveryConfiguration.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.palantir.config.service.proxy.ProxyConfiguration;
 import com.palantir.remoting.ssl.SslConfiguration;
 import com.palantir.tokens.auth.BearerToken;
 import io.dropwizard.util.Duration;

--- a/service-config/src/main/java/com/palantir/config/service/proxy/DefaultProxyConfigurationProviderChain.java
+++ b/service-config/src/main/java/com/palantir/config/service/proxy/DefaultProxyConfigurationProviderChain.java
@@ -4,7 +4,8 @@
 package com.palantir.config.service.proxy;
 
 /**
- * A {@link com.palantir.config.service.proxy.ProxyConfigurationProviderChain} consisting of:
+ * A default {@link com.palantir.config.service.proxy.ProxyConfigurationProviderChain}.
+ * This chain consists of:
  * <ol>
  *     <li>{@link com.palantir.config.service.proxy.SystemPropertiesProxyConfigurationProvider}</li>
  *     <li>{@link com.palantir.config.service.proxy.EnvironmentVariableProxyConfigurationProvider}</li>

--- a/service-config/src/main/java/com/palantir/config/service/proxy/DefaultProxyConfigurationProviderChain.java
+++ b/service-config/src/main/java/com/palantir/config/service/proxy/DefaultProxyConfigurationProviderChain.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+package com.palantir.config.service.proxy;
+
+/**
+ * A {@link com.palantir.config.service.proxy.ProxyConfigurationProviderChain} consisting of:
+ * <ol>
+ *     <li>{@link com.palantir.config.service.proxy.SystemPropertiesProxyConfigurationProvider}</li>
+ *     <li>{@link com.palantir.config.service.proxy.EnvironmentVariableProxyConfigurationProvider}</li>
+ * </ol>
+ */
+public final class DefaultProxyConfigurationProviderChain extends ProxyConfigurationProviderChain {
+
+    public DefaultProxyConfigurationProviderChain() {
+        super(
+                new SystemPropertiesProxyConfigurationProvider(),
+                new EnvironmentVariableProxyConfigurationProvider()
+        );
+    }
+}

--- a/service-config/src/main/java/com/palantir/config/service/proxy/EmptyProxyConfigurationProvider.java
+++ b/service-config/src/main/java/com/palantir/config/service/proxy/EmptyProxyConfigurationProvider.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+package com.palantir.config.service.proxy;
+
+import com.google.common.base.Optional;
+
+/**
+ * A simple {@link com.palantir.config.service.proxy.ProxyConfigurationProvider} providing an empty
+ * {@link com.palantir.config.service.proxy.ProxyConfiguration}.
+ */
+public final class EmptyProxyConfigurationProvider implements ProxyConfigurationProvider {
+
+    @Override
+    public Optional<ProxyConfiguration> getProxyConfiguration() {
+        return Optional.absent();
+    }
+}

--- a/service-config/src/main/java/com/palantir/config/service/proxy/EnvironmentVariableProxyConfigurationProvider.java
+++ b/service-config/src/main/java/com/palantir/config/service/proxy/EnvironmentVariableProxyConfigurationProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+package com.palantir.config.service.proxy;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Throwables.propagate;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Lists;
+import com.palantir.config.service.BasicCredentials;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+import javax.annotation.Nullable;
+
+/**
+ * Provides a {@link com.palantir.config.service.proxy.ProxyConfiguration} based on environment variables.
+ */
+public final class EnvironmentVariableProxyConfigurationProvider implements ProxyConfigurationProvider {
+
+    private static final List<String> VARIABLES = Lists.newArrayList("http_proxy", "https_proxy", "HTTP_PROXY",
+            "HTTPS_PROXY");
+    private static final Function<String, String> SYSTEM_ENV_FUNCTION = new Function<String, String>() {
+        @Nullable
+        @Override
+        public String apply(String input) {
+            return System.getenv(input);
+        }
+    };
+
+    @Override
+    public Optional<ProxyConfiguration> getProxyConfiguration() {
+        Set<String> proxies = FluentIterable.from(Lists.transform(VARIABLES, SYSTEM_ENV_FUNCTION))
+                .filter(Predicates.notNull())
+                .toSet();
+
+        if (proxies.isEmpty()) {
+            return Optional.absent();
+        } else if (proxies.size() > 1) {
+            throw new IllegalStateException(String.format("Ambiguous proxy settings %s", proxies));
+        }
+
+        URL httpUrl;
+        try {
+            httpUrl = new URL(proxies.iterator().next());
+        } catch (MalformedURLException e) {
+            throw propagate(e);
+        }
+        ProxyConfiguration.Builder builder = ProxyConfiguration.builder()
+                .host(httpUrl.getHost())
+                .port(httpUrl.getPort());
+
+        String userInfo = httpUrl.getUserInfo();
+        if (!isNullOrEmpty(userInfo)) {
+            StringTokenizer tokenizer = new StringTokenizer(userInfo, ":");
+            builder.credentials(BasicCredentials.of(tokenizer.nextToken(), tokenizer.nextToken()));
+        }
+        return Optional.<ProxyConfiguration>of(builder.build());
+    }
+}

--- a/service-config/src/main/java/com/palantir/config/service/proxy/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/config/service/proxy/ProxyConfiguration.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.palantir.config.service;
+package com.palantir.config.service.proxy;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Optional;
+import com.palantir.config.service.BasicCredentials;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import org.immutables.value.Value.Immutable;

--- a/service-config/src/main/java/com/palantir/config/service/proxy/ProxyConfigurationProvider.java
+++ b/service-config/src/main/java/com/palantir/config/service/proxy/ProxyConfigurationProvider.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+package com.palantir.config.service.proxy;
+
+import com.google.common.base.Optional;
+
+public interface ProxyConfigurationProvider {
+
+    Optional<ProxyConfiguration> getProxyConfiguration();
+
+}

--- a/service-config/src/main/java/com/palantir/config/service/proxy/ProxyConfigurationProviderChain.java
+++ b/service-config/src/main/java/com/palantir/config/service/proxy/ProxyConfigurationProviderChain.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+package com.palantir.config.service.proxy;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.base.Optional;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link com.palantir.config.service.proxy.ProxyConfigurationProvider} that returns the first non-empty
+ * {@link com.palantir.config.service.proxy.ProxyConfiguration} defined in the chain.
+ */
+public class ProxyConfigurationProviderChain implements ProxyConfigurationProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProxyConfigurationProviderChain.class);
+
+    private final List<ProxyConfigurationProvider> providers = new LinkedList<>();
+
+    public ProxyConfigurationProviderChain(ProxyConfigurationProvider... providers) {
+        checkState(providers != null && providers.length > 0,
+                "At least one ProxyConfigurationProvider must be provided");
+        Collections.addAll(this.providers, providers);
+    }
+
+    @Override
+    public final Optional<ProxyConfiguration> getProxyConfiguration() {
+        for (ProxyConfigurationProvider provider : providers) {
+            try {
+                Optional<ProxyConfiguration> configuration = provider.getProxyConfiguration();
+                if (configuration.isPresent()) {
+                    logger.debug("Loading configuration from {}", provider);
+                    return configuration;
+                }
+            } catch (Exception e) {
+                logger.debug("Unable to load configuration from {}", provider, e);
+            }
+        }
+        return Optional.<ProxyConfiguration>absent();
+    }
+}

--- a/service-config/src/main/java/com/palantir/config/service/proxy/SystemPropertiesProxyConfigurationProvider.java
+++ b/service-config/src/main/java/com/palantir/config/service/proxy/SystemPropertiesProxyConfigurationProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+package com.palantir.config.service.proxy;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Lists;
+import com.palantir.config.service.BasicCredentials;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Provides a {@link com.palantir.config.service.proxy.ProxyConfiguration} based on system properties.
+ */
+public final class SystemPropertiesProxyConfigurationProvider implements ProxyConfigurationProvider {
+
+    private static final List<String> HOST_PROPERTIES = Lists.newArrayList(
+            "http.proxyHost", "https.proxyHost", "socksProxyHost");
+    private static final List<String> PORT_PROPERTIES = Lists.newArrayList(
+            "http.proxyPort", "https.proxyPort", "socksProxyPort");
+    private static final List<String> USERNAME_PROPERTIES = Lists.newArrayList(
+            "http.proxyUser", "https.proxyUser", "socksProxyUser");
+    private static final List<String> PASSWORD_PROPERTIES = Lists.newArrayList(
+            "http.proxyPassword", "https.proxyPassword", "socksProxyPassword");
+    private static final Function<String, String> SYSTEM_PROPERTY_FUNCTION = new Function<String, String>() {
+        @Nullable
+        @Override
+        public String apply(String input) {
+            return System.getProperty(input);
+        }
+    };
+
+    @Override
+    public Optional<ProxyConfiguration> getProxyConfiguration() {
+        Set<String> host = getProperty(HOST_PROPERTIES);
+        Set<String> port = getProperty(PORT_PROPERTIES);
+        if (host.isEmpty() || port.isEmpty()) {
+            return Optional.absent();
+        } else if (host.size() > 1) {
+            throw new IllegalStateException(String.format("Ambiguous proxy host %s from %s", host, HOST_PROPERTIES));
+        } else if (port.size() > 1) {
+            throw new IllegalStateException(String.format("Ambiguous proxy port %s from %s", port, PORT_PROPERTIES));
+        }
+
+        ProxyConfiguration.Builder builder = ProxyConfiguration.builder()
+                .host(host.iterator().next())
+                .port(Integer.parseInt(port.iterator().next()));
+
+        Set<String> username = getProperty(USERNAME_PROPERTIES);
+        Set<String> password = getProperty(PASSWORD_PROPERTIES);
+        if (username.size() > 1) {
+            throw new IllegalStateException(String.format("Ambiguous proxy username %s from %s", username,
+                    USERNAME_PROPERTIES));
+        } else if (password.size() > 1) {
+            throw new IllegalStateException(String.format("Ambiguous proxy password from %s", PASSWORD_PROPERTIES));
+        } else if (username.size() == 1 && password.size() == 1) {
+            builder.credentials(BasicCredentials.of(username.iterator().next(), password.iterator().next()));
+        }
+
+        return Optional.<ProxyConfiguration>of(builder.build());
+    }
+
+    private static Set<String> getProperty(List<String> properties) {
+        return FluentIterable.from(Lists.transform(properties, SYSTEM_PROPERTY_FUNCTION))
+                .filter(Predicates.notNull())
+                .toSet();
+    }
+}

--- a/service-config/src/main/java/com/palantir/config/service/proxy/WrapperProxyConfigurationProvider.java
+++ b/service-config/src/main/java/com/palantir/config/service/proxy/WrapperProxyConfigurationProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+package com.palantir.config.service.proxy;
+
+import com.google.common.base.Optional;
+
+/**
+ * A simple {@link com.palantir.config.service.proxy.ProxyConfigurationProvider} wrapping a provided optional
+ * {@link com.palantir.config.service.proxy.ProxyConfiguration}.
+ */
+public final class WrapperProxyConfigurationProvider implements ProxyConfigurationProvider {
+
+    private final Optional<ProxyConfiguration> proxyConfiguration;
+
+    public WrapperProxyConfigurationProvider(Optional<ProxyConfiguration> proxyConfiguration) {
+        this.proxyConfiguration = proxyConfiguration;
+    }
+
+    @Override
+    public Optional<ProxyConfiguration> getProxyConfiguration() {
+        return proxyConfiguration;
+    }
+}

--- a/service-config/src/test/java/com/palantir/config/service/BasicCredentialsTest.java
+++ b/service-config/src/test/java/com/palantir/config/service/BasicCredentialsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.service;
+
+import org.junit.Test;
+
+public final class BasicCredentialsTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void blankUsernameNotAllowed() {
+        BasicCredentials.builder()
+                .username("")
+                .password("password")
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void blankPasswordNotAllowed() {
+        BasicCredentials.builder()
+                .username("username")
+                .password("")
+                .build();
+    }
+
+    @Test
+    public void testValid() {
+        BasicCredentials.builder()
+                .username("username")
+                .password("password")
+                .build();
+    }
+}

--- a/service-config/src/test/java/com/palantir/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/config/service/ProxyConfigurationTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.config.service;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.io.Resources;
+import io.dropwizard.jackson.Jackson;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
+import org.junit.Test;
+
+public final class ProxyConfigurationTests {
+    private final ObjectMapper mapper = Jackson.newObjectMapper(new YAMLFactory());
+
+    @Test
+    public void testDeserializationWithoutCredentials() throws IOException {
+        URL resource = Resources.getResource("configs/proxy-config-without-credentials.yml");
+        ProxyConfiguration actualProxyConfiguration = mapper.readValue(resource.openStream(), ProxyConfiguration.class);
+
+        ProxyConfiguration expectedProxyConfiguration = ProxyConfiguration.builder()
+                .host("squid")
+                .port(3128)
+                .build();
+
+        assertEquals(expectedProxyConfiguration, actualProxyConfiguration);
+    }
+
+    @Test
+    public void testDeserializationWithCredentials() throws IOException {
+        URL resource = Resources.getResource("configs/proxy-config-with-credentials.yml");
+        ProxyConfiguration actualProxyConfiguration = mapper.readValue(resource.openStream(), ProxyConfiguration.class);
+
+        ProxyConfiguration expectedProxyConfiguration = ProxyConfiguration.builder()
+                .host("squid")
+                .port(3128)
+                .credentials(BasicCredentials.of("username", "password"))
+                .build();
+
+        assertEquals(expectedProxyConfiguration, actualProxyConfiguration);
+    }
+
+    @Test
+    public void testToProxy() {
+        ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder()
+                .host("squid")
+                .port(3128)
+                .build();
+
+        Proxy expected = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("squid", 3128));
+        assertEquals(expected, proxyConfiguration.toProxy());
+    }
+}

--- a/service-config/src/test/java/com/palantir/config/service/ServiceDiscoveryConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/config/service/ServiceDiscoveryConfigurationTests.java
@@ -54,6 +54,7 @@ public final class ServiceDiscoveryConfigurationTests {
         assertFalse(discoveryConfig.defaultApiToken().isPresent());
         assertFalse(discoveryConfig.defaultConnectTimeout().isPresent());
         assertFalse(discoveryConfig.defaultReadTimeout().isPresent());
+        assertFalse(discoveryConfig.defaultProxyConfiguration().isPresent());
 
         // testing service api token property
         // 1) with token
@@ -65,6 +66,9 @@ public final class ServiceDiscoveryConfigurationTests {
         assertEquals(Duration.minutes(5), discoveryConfig.getConnectTimeout("service3").get());
         assertEquals(Duration.seconds(30), discoveryConfig.getReadTimeout("service3").get());
         assertFalse(discoveryConfig.getApiToken("service3").isPresent());
+        assertEquals(ProxyConfiguration.builder().host("squid").port(3128).build(),
+                discoveryConfig.getProxyConfiguration("service3").get());
+        assertFalse(discoveryConfig.getProxyConfiguration("service2").isPresent());
 
         // testing getter for services that don't exist
         try {
@@ -88,6 +92,8 @@ public final class ServiceDiscoveryConfigurationTests {
         assertEquals(Duration.seconds(45), discoveryConfig.defaultConnectTimeout().get());
         assertTrue(discoveryConfig.defaultConnectTimeout().isPresent());
         assertEquals(Duration.minutes(15), discoveryConfig.defaultReadTimeout().get());
+        assertEquals(ProxyConfiguration.builder().host("globalSquid").port(3128).build(),
+                discoveryConfig.defaultProxyConfiguration().get());
 
         // testing service api token property
         // 1) with token
@@ -96,6 +102,10 @@ public final class ServiceDiscoveryConfigurationTests {
         assertEquals(BearerToken.valueOf("defaultApiToken"), discoveryConfig.getApiToken("service3").get());
         assertEquals(BearerToken.valueOf("defaultApiToken"),
                 discoveryConfig.getServices().get("service3").apiToken().get());
+        assertEquals(ProxyConfiguration.builder().host("globalSquid").port(3128).build(),
+                discoveryConfig.getProxyConfiguration("service1").get());
+        assertEquals(ProxyConfiguration.builder().host("service3squid").port(3128).build(),
+                discoveryConfig.getProxyConfiguration("service3").get());
     }
 
     @Test
@@ -115,6 +125,8 @@ public final class ServiceDiscoveryConfigurationTests {
         SslConfiguration security = SslConfiguration.of(mock(Path.class));
         Duration defaultReadTimeout = Duration.seconds(30);
         Duration connectTimeout = Duration.hours(1);
+        ProxyConfiguration defaultProxyConfiguration =
+                ProxyConfiguration.builder().host("globalsquid").port(3128).build();
 
         ServiceConfiguration service = ServiceConfiguration.builder()
                 .security(security)
@@ -125,6 +137,7 @@ public final class ServiceDiscoveryConfigurationTests {
                 .defaultApiToken(defaultApiToken)
                 .originalServices(ImmutableMap.of("service1", service))
                 .defaultReadTimeout(defaultReadTimeout)
+                .defaultProxyConfiguration(defaultProxyConfiguration)
                 .build();
 
         assertEquals(defaultApiToken, services.defaultApiToken().get());
@@ -137,5 +150,7 @@ public final class ServiceDiscoveryConfigurationTests {
         assertEquals(security, services.getSecurity("service1").get());
         assertEquals(security, services.getServices().get("service1").security().get());
         assertEquals(connectTimeout, services.getServices().get("service1").connectTimeout().get());
+        assertEquals(defaultProxyConfiguration, services.defaultProxyConfiguration().get());
+        assertEquals(defaultProxyConfiguration, services.getServices().get("service1").proxyConfiguration().get());
     }
 }

--- a/service-config/src/test/java/com/palantir/config/service/ServiceDiscoveryConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/config/service/ServiceDiscoveryConfigurationTests.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
+import com.palantir.config.service.proxy.ProxyConfiguration;
 import com.palantir.remoting.ssl.SslConfiguration;
 import com.palantir.tokens.auth.BearerToken;
 import io.dropwizard.jackson.Jackson;

--- a/service-config/src/test/java/com/palantir/config/service/proxy/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/config/service/proxy/ProxyConfigurationTests.java
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package com.palantir.config.service;
+package com.palantir.config.service.proxy;
 
 import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.io.Resources;
+import com.palantir.config.service.BasicCredentials;
 import io.dropwizard.jackson.Jackson;
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/service-config/src/test/resources/configs/discovery-config-with-fallback.yml
+++ b/service-config/src/test/resources/configs/discovery-config-with-fallback.yml
@@ -8,6 +8,9 @@ security:
 
 apiToken: defaultApiToken
 
+proxyConfiguration:
+  host: globalSquid
+  port: 3128
 connectTimeout: 45 seconds
 readTimeout: 15 minutes
 
@@ -37,3 +40,6 @@ services:
       - https://some.internal.url:8443/thirdservice/api
     connectTimeout: 5 minutes
     readTimeout: 30 seconds
+    proxyConfiguration:
+      host: service3squid
+      port: 3128

--- a/service-config/src/test/resources/configs/discovery-config-without-fallback.yml
+++ b/service-config/src/test/resources/configs/discovery-config-without-fallback.yml
@@ -22,5 +22,8 @@ services:
   service3:
     uris:
       - https://some.internal.url:8443/thirdservice/api
+    proxyConfiguration:
+      host: squid
+      port: 3128
     connectTimeout: 5 minutes
     readTimeout: 30 seconds

--- a/service-config/src/test/resources/configs/proxy-config-with-credentials.yml
+++ b/service-config/src/test/resources/configs/proxy-config-with-credentials.yml
@@ -1,0 +1,5 @@
+host: squid
+port: 3128
+credentials:
+    username: username
+    password: password

--- a/service-config/src/test/resources/configs/proxy-config-without-credentials.yml
+++ b/service-config/src/test/resources/configs/proxy-config-without-credentials.yml
@@ -1,0 +1,2 @@
+host: squid
+port: 3128

--- a/ssl-config/build.gradle
+++ b/ssl-config/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testCompile libs.hamcrest
     testCompile libs.junit
 
-    processor libs.immutables
+    processor libs.immutables.value
 }
 
 task generateCerts(type:Exec) {


### PR DESCRIPTION
Not ready for merging yet but aiming to get feedback on this a solution to providing proxy support to http-remoting. The main motivation for switching ProxyConfiguration to ProxyConfigurationProvider is so that we can easily setup a provider chain. If this is used in standalone libraries it should make it to use environment variables or JVM args to configure the proxy and minimize the amount of custom code required.
