### PR TITLE
Custom GsonConverterFactory in retrofit2-clients

### DIFF
--- a/error-handling/build.gradle
+++ b/error-handling/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     testCompile libs.hamcrest
     testCompile libs.junit
 
-    processor libs.immutables
+    processor libs.immutables.value
 }

--- a/gradle/libs.gradle
+++ b/gradle/libs.gradle
@@ -18,7 +18,10 @@ project.ext.libs = [
     ],
     'guava': 'com.google.guava:guava:18.0',
     'hamcrest': 'org.hamcrest:hamcrest-all:1.3',
-    'immutables': 'org.immutables:value:2.0.21',
+    'immutables': [
+        'value': 'org.immutables:value:2.0.21',
+        'gson': 'org.immutables:gson:2.0.21'
+    ],
     'jackson': [
         'databind': 'com.fasterxml.jackson.core:jackson-databind:2.6.1',
         'guava': 'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.1',

--- a/retrofit-clients/build.gradle
+++ b/retrofit-clients/build.gradle
@@ -17,5 +17,5 @@ dependencies {
     testCompile libs.mockito
     testCompile libs.mockwebserver
 
-    processor libs.immutables
+    processor libs.immutables.value
 }

--- a/retrofit2-clients/build.gradle
+++ b/retrofit2-clients/build.gradle
@@ -11,13 +11,14 @@ dependencies {
     compile libs.retrofit2.retrofit
     compile libs.retrofit2.gson
     compile libs.slf4j
+    compile libs.immutables.gson
 
     testCompile libs.hamcrest
     testCompile libs.junit
     testCompile libs.mockito
     testCompile libs.mockwebserver
 
-    processor libs.immutables
+    processor libs.immutables.value
 }
 
 configurations.all {

--- a/retrofit2-clients/src/main/java/com/palantir/remoting/retrofit/RetrofitClientFactory.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting/retrofit/RetrofitClientFactory.java
@@ -72,11 +72,18 @@ public final class RetrofitClientFactory {
 
     public static <T> T createProxy(Optional<SSLSocketFactory> sslSocketFactoryOptional, String uri, Class<T> type,
             OkHttpClientOptions options, String userAgent) {
+        return createProxy(sslSocketFactoryOptional, uri, type, options, userAgent, GsonConverterFactory.create());
+    }
+
+    public static <T> T createProxy(Optional<SSLSocketFactory> sslSocketFactoryOptional, String uri, Class<T> type,
+                                    OkHttpClientOptions options, String userAgent,
+                                    GsonConverterFactory gsonConverterFactory) {
         okhttp3.OkHttpClient client = newHttpClient(sslSocketFactoryOptional, options, userAgent);
+
         Retrofit retrofit = new Retrofit.Builder()
                 .client(client)
                 .baseUrl(uri)
-                .addConverterFactory(GsonConverterFactory.create())
+                .addConverterFactory(gsonConverterFactory)
                 .build();
         return retrofit.create(type);
     }

--- a/service-config/build.gradle
+++ b/service-config/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     testCompile project(':ext:feign-okhttp3')
     testCompile libs.junit
 
-    processor libs.immutables
+    processor libs.immutables.value
 }

--- a/ssl-config/build.gradle
+++ b/ssl-config/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testCompile libs.hamcrest
     testCompile libs.junit
 
-    processor libs.immutables
+    processor libs.immutables.value
 }
 
 task generateCerts(type:Exec) {


### PR DESCRIPTION
Allow a custom GsonConverterFactory to be provided when constructing a retrofit2 proxy. This is useful when configuring custom type adapters
