### PR TITLE
jaxrs-clients shadowJar does not contain ssl-config or service-config classes

### DIFF
--- a/jaxrs-clients/build.gradle
+++ b/jaxrs-clients/build.gradle
@@ -17,7 +17,10 @@ dependencies {
 
 shadowJar {
     mergeServiceFiles()
-    relocate('com.fasterxml.jackson', 'httpremoting.shaded.com.fasterxml.jackson')
+    relocate('com.fasterxml.jackson', 'httpremoting.shaded.com.fasterxml.jackson') {
+        exclude 'com.fasterxml.jackson.annotation.*'
+        exclude 'com.fasterxml.jackson.databind.annotation.*'
+    }
     relocate('feign', 'httpremoting.shaded.feign')
     relocate('zipkin', 'httpremoting.shaded.zipkin')
     relocate('okhttp3', 'httpremoting.shaded.okhttp3')
@@ -26,11 +29,6 @@ shadowJar {
     relocate('org.joda.time', 'httpremoting.shaded.org.joda.time')
     relocate('okio', 'httpremoting.shaded.okio')
     relocate('com.github.kristofa.brave', 'httpremoting.shaded.com.github.kristofa.brave')
-    dependencies {
-        exclude(project(':error-handling'))
-        exclude(project(':service-config'))
-        exclude(project(':ssl-config'))
-    }
     classifier = ''
 }
 

--- a/jaxrs-clients/build.gradle
+++ b/jaxrs-clients/build.gradle
@@ -21,6 +21,7 @@ shadowJar {
     relocate('feign', 'httpremoting.shaded.feign')
     relocate('zipkin', 'httpremoting.shaded.zipkin')
     relocate('okhttp3', 'httpremoting.shaded.okhttp3')
+    relocate('io.dropwizard', 'httpremoting.shaded.io.dropwizard')
     relocate('io.zipkin.brave', 'httpremoting.shaded.io.zipkin.brave')
     relocate('org.joda.time', 'httpremoting.shaded.org.joda.time')
     relocate('okio', 'httpremoting.shaded.okio')

--- a/jaxrs-clients/build.gradle
+++ b/jaxrs-clients/build.gradle
@@ -25,6 +25,11 @@ shadowJar {
     relocate('org.joda.time', 'httpremoting.shaded.org.joda.time')
     relocate('okio', 'httpremoting.shaded.okio')
     relocate('com.github.kristofa.brave', 'httpremoting.shaded.com.github.kristofa.brave')
+    dependencies {
+        exclude(project(':error-handling'))
+        exclude(project(':service-config'))
+        exclude(project(':ssl-config'))
+    }
     classifier = ''
 }
 


### PR DESCRIPTION
This once's nasty: we cannot include those classes since their jackson annotations get relocated. Any ideas, @pnepywoda @markelliot ?
