### PR TITLE
Allow charset for text/plain Content-Type

### DIFF
--- a/jaxrs-clients/src/main/java/feign/TextDelegateDecoder.java
+++ b/jaxrs-clients/src/main/java/feign/TextDelegateDecoder.java
@@ -48,7 +48,7 @@ public final class TextDelegateDecoder implements Decoder {
             contentTypes = ImmutableSet.of();
         }
         // In the case of multiple content types, or an unknown content type, we'll use the delegate instead.
-        if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").equals(MediaType.TEXT_PLAIN)) {
+        if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").contains(MediaType.TEXT_PLAIN)) {
             return stringDecoder.decode(response, type);
         }
 

--- a/jaxrs-clients/src/main/java/feign/TextDelegateDecoder.java
+++ b/jaxrs-clients/src/main/java/feign/TextDelegateDecoder.java
@@ -48,7 +48,7 @@ public final class TextDelegateDecoder implements Decoder {
             contentTypes = ImmutableSet.of();
         }
         // In the case of multiple content types, or an unknown content type, we'll use the delegate instead.
-        if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").contains(MediaType.TEXT_PLAIN)) {
+        if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").startsWith(MediaType.TEXT_PLAIN)) {
             return stringDecoder.decode(response, type);
         }
 

--- a/jaxrs-clients/src/test/java/feign/TextDelegateDecoderTest.java
+++ b/jaxrs-clients/src/test/java/feign/TextDelegateDecoderTest.java
@@ -84,6 +84,17 @@ public final class TextDelegateDecoderTest {
     }
 
     @Test
+    public void testUsesStringDecoderWithTextPlainAndCharset() throws Exception {
+        headers.put(HttpHeaders.CONTENT_TYPE, ImmutableSet.of(MediaType.TEXT_PLAIN + "; charset=utf-8"));
+        Response response = Response.create(200, "OK", headers, "text response", StandardCharsets.UTF_8);
+
+        Object decodedObject = textDelegateDecoder.decode(response, String.class);
+
+        assertEquals(decodedObject, "text response");
+        verifyZeroInteractions(delegate);
+    }
+
+    @Test
     public void testUsesStringDecoderWithTextPlainWithWeirdHeaderCapitalization() throws Exception {
         headers.put("content-TYPE", ImmutableSet.of(MediaType.TEXT_PLAIN));
         Response response = Response.create(200, "OK", headers, "text response", StandardCharsets.UTF_8);


### PR DESCRIPTION
For many HTTP responses from various places, the Content-Type includes the charset, i.e.
`Content-Type: text/plain; charset=utf-8`. According to the
Content-Type spec, this is perfectly acceptable. The TextDelegateDecoder
was checking for exact string equality, which resulted in attempting
to use the Json delegate Decoder, as opposed to the String decoder in
this situation.

This commit:

1: Added a failing test to demonstrate the issue,
2: Fixes the failing test, but changing `.equals()` to `.startsWith()` (after subsequent conversation)
