### PR TITLE
Improve Dropwizard Zipkin tracing

### DIFF
--- a/dropwizard-servers/src/main/java/com/palantir/remoting1/servers/DropwizardTracingFilters.java
+++ b/dropwizard-servers/src/main/java/com/palantir/remoting1/servers/DropwizardTracingFilters.java
@@ -73,7 +73,7 @@ final class DropwizardTracingFilters {
                 .traceSampler(Sampler.ALWAYS_SAMPLE)
                 .randomGenerator(new Random())
                 .state(new ThreadLocalServerClientAndLocalSpanState(ip, port, name))
-                .spanCollector(new SlfLoggingSpanCollector("ServerTracer(" + name + ")"))
+                .spanCollector(new SlfLoggingSpanCollector("tracing.server." + name))
                 .build();
     }
 

--- a/dropwizard-servers/src/test/resources/test-server.yml
+++ b/dropwizard-servers/src/test/resources/test-server.yml
@@ -6,3 +6,11 @@ server:
   adminConnectors:
     - type: http
       port: 0
+
+logging:
+  level: WARN
+  loggers:
+    io.dropwizard: INFO
+    tracing: INFO
+  appenders:
+    - type: console

--- a/dropwizard-servers/src/test/resources/test-server.yml
+++ b/dropwizard-servers/src/test/resources/test-server.yml
@@ -8,7 +8,7 @@ server:
       port: 0
 
 logging:
-  level: WARN
+  level: INFO
   loggers:
     io.dropwizard: INFO
     tracing: INFO

--- a/ext/brave-extensions/src/main/java/com/github/kristofa/brave/ext/SlfLoggingSpanCollector.java
+++ b/ext/brave-extensions/src/main/java/com/github/kristofa/brave/ext/SlfLoggingSpanCollector.java
@@ -16,7 +16,6 @@
 
 package com.github.kristofa.brave.ext;
 
-import com.github.kristofa.brave.LoggingSpanCollector;
 import com.github.kristofa.brave.SpanCollector;
 import com.github.kristofa.brave.internal.Util;
 import com.twitter.zipkin.gen.BinaryAnnotation;
@@ -35,7 +34,7 @@ public final class SlfLoggingSpanCollector implements SpanCollector {
     private final Set<BinaryAnnotation> annotations = new LinkedHashSet<>();
 
     public SlfLoggingSpanCollector() {
-        log = LoggerFactory.getLogger(LoggingSpanCollector.class.getName());
+        this(SlfLoggingSpanCollector.class.getName());
     }
 
     public SlfLoggingSpanCollector(String loggerName) {
@@ -46,11 +45,13 @@ public final class SlfLoggingSpanCollector implements SpanCollector {
     @Override
     public void collect(Span span) {
         Util.checkNotNull(span, "span must not be null");
-        for (BinaryAnnotation ba : annotations) {
-            span.addToBinary_annotations(ba);
-        }
+        if (log.isInfoEnabled()) {
+            for (BinaryAnnotation ba : annotations) {
+                span.addToBinary_annotations(ba);
+            }
 
-        log.info("{}", span);
+            log.info(span.toString());
+        }
     }
 
     @Override

--- a/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/FeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/FeignJaxRsClientBuilder.java
@@ -163,7 +163,7 @@ public final class FeignJaxRsClientBuilder extends ClientBuilder {
                 .randomGenerator(new Random())
                 .state(new ThreadLocalServerClientAndLocalSpanState(
                         getIpAddress(), 0 /** Client TCP port. */, userAgent))
-                .spanCollector(new SlfLoggingSpanCollector("ClientTracer(" + userAgent + ")"))
+                .spanCollector(new SlfLoggingSpanCollector("tracing.client." + userAgent))
                 .build();
         BraveOkHttpRequestResponseInterceptor braveInterceptor =
                 new BraveOkHttpRequestResponseInterceptor(

--- a/jaxrs-clients/src/test/java/com/palantir/remoting1/jaxrs/JaxRsClientConfigTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting1/jaxrs/JaxRsClientConfigTest.java
@@ -113,7 +113,7 @@ public final class JaxRsClientConfigTest {
 
         ArgumentCaptor<ILoggingEvent> clientTracerEvent = ArgumentCaptor.forClass(ILoggingEvent.class);
         verify(clientTracerAppender).doAppend(clientTracerEvent.capture());
-        assertThat(clientTracerEvent.getValue().getFormattedMessage(), containsString("\"serviceName\":\"client\","));
+        assertThat(clientTracerEvent.getValue().getFormattedMessage(), containsString("\"serviceName\":\"test\","));
         Mockito.verifyNoMoreInteractions(clientTracerAppender);
     }
 

--- a/jaxrs-clients/src/test/java/com/palantir/remoting1/jaxrs/JaxRsClientConfigTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting1/jaxrs/JaxRsClientConfigTest.java
@@ -73,17 +73,17 @@ public final class JaxRsClientConfigTest {
 
         when(clientTracerAppender.getName()).thenReturn("MOCK");
         ch.qos.logback.classic.Logger clientTracerLogger =
-                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("ClientTracer(client)");
+                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("tracing.client.test");
         clientTracerLogger.addAppender(clientTracerAppender);
 
         when(serverTracerAppender.getName()).thenReturn("MOCK");
         ch.qos.logback.classic.Logger serverTracerLogger =
-                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("ServerTracer(TestEchoServer)");
+                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("tracing.server.TestEchoServer");
         serverTracerLogger.addAppender(serverTracerAppender);
 
         when(proxyingServerTracerAppender.getName()).thenReturn("MOCK");
         ch.qos.logback.classic.Logger proxyingServerTracerLogger =
-                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("ServerTracer(ProxyingEchoServer)");
+                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("tracing.server.ProxyingEchoServer");
         proxyingServerTracerLogger.addAppender(proxyingServerTracerAppender);
     }
 
@@ -102,13 +102,13 @@ public final class JaxRsClientConfigTest {
 
     @Test
     public void testSslSocketFactory_canConnectWhenSocketFactoryIsSet() throws Exception {
-        TestEchoService service = createProxy(ECHO_SERVER.getLocalPort(), "client");
+        TestEchoService service = createProxy(ECHO_SERVER.getLocalPort(), "test");
         assertThat(service.echo("foo"), is("foo"));
     }
 
     @Test
     public void testBraveTracing_clientLogsTraces() throws Exception {
-        TestEchoService service = createProxy(PROXYING_ECHO_SERVER.getLocalPort(), "client");
+        TestEchoService service = createProxy(PROXYING_ECHO_SERVER.getLocalPort(), "test");
         assertThat(service.echo("foo"), is("foo"));
 
         ArgumentCaptor<ILoggingEvent> clientTracerEvent = ArgumentCaptor.forClass(ILoggingEvent.class);
@@ -122,7 +122,7 @@ public final class JaxRsClientConfigTest {
         // Simulates two-hop call chain: client --> ProxyingEchoServer --> EchoServer. Verifies that
         // trace ids logged in the three locations are identical.
 
-        TestEchoService service = createProxy(PROXYING_ECHO_SERVER.getLocalPort(), "client");
+        TestEchoService service = createProxy(PROXYING_ECHO_SERVER.getLocalPort(), "test");
         assertThat(service.echo("foo"), is("foo"));
 
 


### PR DESCRIPTION
Log to following loggers:
  `tracing.server.` + tracer name
  `tracing.client.` + tracer name

Avoid slf4j message conversion when logging spans.
