### PR TITLE
Add asynchronous slf4j Brave SpanCollector for logging purposes

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -71,7 +71,7 @@
         </module>
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
-            <property name="excludes" value="org.junit.Assert.*,org.junit.Assume.*,org.hamcrest.Matchers.*,org.mockito.Mockito.*,org.mockito.Matchers.*,org.assertj.core.api.Assertions.*,com.google.common.base.Preconditions.*,org.apache.commons.lang3.Validate.*,com.google.common.truth.Truth.*"/>
+            <property name="excludes" value="org.junit.Assert.*,org.junit.Assume.*,org.hamcrest.Matchers.*,org.mockito.Mockito.*,org.mockito.Matchers.*,org.assertj.core.api.Assertions.*,org.assertj.core.api.Java6Assertions.*,com.google.common.base.Preconditions.*,org.apache.commons.lang3.Validate.*,com.google.common.truth.Truth.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>

--- a/dropwizard-servers/src/main/java/com/palantir/remoting1/servers/DropwizardSpanCollectorMetricsHandler.java
+++ b/dropwizard-servers/src/main/java/com/palantir/remoting1/servers/DropwizardSpanCollectorMetricsHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting1.servers;
+
+import com.codahale.metrics.Counter;
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+import com.google.common.base.Preconditions;
+
+public final class DropwizardSpanCollectorMetricsHandler implements SpanCollectorMetricsHandler {
+
+    private final Counter acceptedCounter;
+    private final Counter droppedCounter;
+
+    public DropwizardSpanCollectorMetricsHandler(Counter acceptedCounter, Counter droppedCounter) {
+        this.acceptedCounter = Preconditions.checkNotNull(acceptedCounter, "acceptedCounter");
+        this.droppedCounter = Preconditions.checkNotNull(droppedCounter, "droppedCounter");
+    }
+
+    @Override
+    public void incrementAcceptedSpans(int quantity) {
+        acceptedCounter.inc(quantity);
+    }
+
+    @Override
+    public void incrementDroppedSpans(int quantity) {
+        droppedCounter.inc(quantity);
+    }
+}

--- a/dropwizard-servers/src/test/java/com/palantir/remoting1/servers/DropwizardTracingFiltersTest.java
+++ b/dropwizard-servers/src/test/java/com/palantir/remoting1/servers/DropwizardTracingFiltersTest.java
@@ -96,6 +96,8 @@ public final class DropwizardTracingFiltersTest {
 
         target.path("echo").request().header(BraveHttpHeaders.TraceId.getName(), "myTraceId").get();
 
+        Thread.sleep(1500L); // allow flush
+
         ArgumentCaptor<ILoggingEvent> requestEvent = ArgumentCaptor.forClass(ILoggingEvent.class);
         verify(braveMockAppender).doAppend(requestEvent.capture());
         assertThat(requestEvent.getValue().getFormattedMessage(),

--- a/ext/brave-extensions/build.gradle
+++ b/ext/brave-extensions/build.gradle
@@ -3,4 +3,9 @@ apply from: "${rootDir}/gradle/publish.gradle"
 dependencies {
     compile "io.zipkin.brave:brave-core"
     compile "org.slf4j:slf4j-api"
+
+    testCompile "junit:junit"
+    testCompile "org.assertj:assertj-core"
+    testCompile "org.hamcrest:hamcrest-all"
+    testCompile "org.mockito:mockito-core"
 }

--- a/ext/brave-extensions/src/main/java/com/github/kristofa/brave/ext/AsyncSlf4jLoggingSpanCollector.java
+++ b/ext/brave-extensions/src/main/java/com/github/kristofa/brave/ext/AsyncSlf4jLoggingSpanCollector.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.kristofa.brave.ext;
+
+import com.github.kristofa.brave.FlushingSpanCollector;
+import com.github.kristofa.brave.SpanCollector;
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+import com.github.kristofa.brave.internal.Util;
+import com.twitter.zipkin.gen.BinaryAnnotation;
+import com.twitter.zipkin.gen.Span;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+
+/**
+ * {@link SpanCollector} implementation that logs through SLF4J at INFO level.
+ */
+public final class AsyncSlf4jLoggingSpanCollector extends FlushingSpanCollector {
+
+    private final Logger logger;
+    private final Set<BinaryAnnotation> annotations = Collections.synchronizedSet(
+            new LinkedHashSet<BinaryAnnotation>());
+
+    public AsyncSlf4jLoggingSpanCollector(Logger logger, SpanCollectorMetricsHandler metrics, int flushInterval) {
+        super(metrics, flushInterval);
+        this.logger = Util.checkNotNull(logger, "logger must not be null");
+    }
+
+    private void logSpan(Span span) {
+        Util.checkNotNull(span, "span must not be null");
+        if (getLogger().isInfoEnabled()) {
+            for (BinaryAnnotation ba : getAnnotations()) {
+                span.addToBinary_annotations(ba);
+            }
+
+            getLogger().info(span.toString());
+        }
+    }
+
+    @Override
+    protected void reportSpans(List<Span> drained) throws IOException {
+        for (Span span : drained) {
+            logSpan(span);
+        }
+    }
+
+    @Override
+    public void addDefaultAnnotation(String key, String value) {
+        getAnnotations().add(BinaryAnnotation.create(key, value, null));
+    }
+
+    private Logger getLogger() {
+        return logger;
+    }
+
+    private Set<BinaryAnnotation> getAnnotations() {
+        return annotations;
+    }
+}
+

--- a/ext/brave-extensions/src/test/java/com/github/kristofa/brave/ext/AsyncSlf4jLoggingSpanCollectorTest.java
+++ b/ext/brave-extensions/src/test/java/com/github/kristofa/brave/ext/AsyncSlf4jLoggingSpanCollectorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.kristofa.brave.ext;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+import com.twitter.zipkin.gen.BinaryAnnotation;
+import com.twitter.zipkin.gen.Span;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+public final class AsyncSlf4jLoggingSpanCollectorTest {
+
+    private static final String KEY1 = "key1";
+    private static final String VALUE1 = "value1";
+    private static final String KEY2 = "key1";
+    private static final String VALUE2 = "value1";
+
+    // current FlushingSpanCollector hardcoded default
+    // see https://github.com/openzipkin/brave/pull/226/files
+    private static final int QUEUE_CAPACITY = 1000;
+
+    private Logger mockLogger;
+    private AsyncSlf4jLoggingSpanCollector spanCollector;
+    private TestMetricsHander metrics;
+
+    @Before
+    public void setup() {
+        mockLogger = mock(Logger.class);
+        when(mockLogger.isInfoEnabled()).thenReturn(true);
+
+        metrics = new TestMetricsHander();
+        spanCollector = new AsyncSlf4jLoggingSpanCollector(
+                mockLogger, metrics, 0 /* explicitly control flush */);
+    }
+
+    @Test
+    public void testCollect() {
+        final Span mockSpan = mock(Span.class);
+        spanCollector.collect(mockSpan);
+
+        verifyZeroInteractions(mockLogger);
+        spanCollector.flush(); // manually flush the spans
+
+        verify(mockLogger).isInfoEnabled();
+        verify(mockLogger).info(mockSpan.toString());
+        verifyNoMoreInteractions(mockLogger, mockSpan);
+    }
+
+    @Test
+    public void testCollectMany() {
+        List<Span> mockSpans = new ArrayList<>(QUEUE_CAPACITY);
+        for (int i = 0; i < QUEUE_CAPACITY + 1; i++) {
+            Span mockSpan = span(i, "test");
+            spanCollector.collect(mockSpan);
+            mockSpans.add(mockSpan);
+        }
+
+        verifyZeroInteractions(mockLogger);
+        spanCollector.flush(); // manually flush the spans
+
+        verify(mockLogger, times(QUEUE_CAPACITY)).isInfoEnabled();
+        verify(mockLogger, times(QUEUE_CAPACITY)).info(anyString());
+
+        assertThat(metrics.getAcceptedSpans()).isEqualTo(QUEUE_CAPACITY + 1);
+        assertThat(metrics.getDroppedSpans()).isEqualTo(1);
+
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockSpans.toArray());
+    }
+
+    @Test
+    public void testCollectAfterAddingTwoDefaultAnnotations() {
+
+        spanCollector.addDefaultAnnotation(KEY1, VALUE1);
+        spanCollector.addDefaultAnnotation(KEY2, VALUE2);
+
+        final Span mockSpan = span(1L, "test");
+        spanCollector.collect(mockSpan);
+
+        verifyZeroInteractions(mockLogger);
+        spanCollector.flush(); // manually flush the spans
+
+        // Create expected annotations.
+        final BinaryAnnotation expectedBinaryAnnotation = BinaryAnnotation.create(KEY1, VALUE1, null);
+        final BinaryAnnotation expectedBinaryAnnotation2 = BinaryAnnotation.create(KEY2, VALUE2, null);
+
+        verify(mockSpan).addToBinary_annotations(expectedBinaryAnnotation);
+        verify(mockSpan).addToBinary_annotations(expectedBinaryAnnotation2);
+        verify(mockLogger).isInfoEnabled();
+        verify(mockLogger).info(anyString());
+
+        verifyNoMoreInteractions(mockLogger, mockSpan);
+    }
+
+    private Span span(long id, String name) {
+        final Span mockSpan = mock(Span.class);
+        when(mockSpan.getId()).thenReturn(id);
+        when(mockSpan.getName()).thenReturn(name);
+        return mockSpan;
+    }
+
+    private static class TestMetricsHander implements SpanCollectorMetricsHandler {
+
+        private final AtomicInteger acceptedSpans = new AtomicInteger();
+        private final AtomicInteger droppedSpans = new AtomicInteger();
+
+        @Override
+        public void incrementAcceptedSpans(int quantity) {
+            acceptedSpans.addAndGet(quantity);
+        }
+
+        @Override
+        public void incrementDroppedSpans(int quantity) {
+            droppedSpans.addAndGet(quantity);
+        }
+
+        int getAcceptedSpans() {
+            return acceptedSpans.get();
+        }
+
+        int getDroppedSpans() {
+            return droppedSpans.get();
+        }
+    }
+}

--- a/jaxrs-clients/src/test/java/com/palantir/remoting1/jaxrs/JaxRsClientConfigTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting1/jaxrs/JaxRsClientConfigTest.java
@@ -111,6 +111,8 @@ public final class JaxRsClientConfigTest {
         TestEchoService service = createProxy(PROXYING_ECHO_SERVER.getLocalPort(), "test");
         assertThat(service.echo("foo"), is("foo"));
 
+        Thread.sleep(1500L); // allow flush
+
         ArgumentCaptor<ILoggingEvent> clientTracerEvent = ArgumentCaptor.forClass(ILoggingEvent.class);
         verify(clientTracerAppender).doAppend(clientTracerEvent.capture());
         assertThat(clientTracerEvent.getValue().getFormattedMessage(), containsString("\"serviceName\":\"test\","));
@@ -125,6 +127,7 @@ public final class JaxRsClientConfigTest {
         TestEchoService service = createProxy(PROXYING_ECHO_SERVER.getLocalPort(), "test");
         assertThat(service.echo("foo"), is("foo"));
 
+        Thread.sleep(1500L); // allow flush
 
         // Extract client trace id.
         ArgumentCaptor<ILoggingEvent> clientTracerEvent = ArgumentCaptor.forClass(ILoggingEvent.class);

--- a/jaxrs-clients/src/test/java/com/palantir/remoting1/jaxrs/JaxRsClientProxyConfigTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting1/jaxrs/JaxRsClientProxyConfigTest.java
@@ -16,7 +16,7 @@
 
 package com.palantir.remoting1.jaxrs;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import com.palantir.remoting1.clients.ClientConfig;
 import com.palantir.remoting1.config.service.BasicCredentials;

--- a/versions.props
+++ b/versions.props
@@ -16,3 +16,4 @@ org.slf4j:slf4j-api = 1.7.12
 com.palantir.tokens:auth-tokens = 0.2.3
 javax.ws.rs:javax.ws.rs-api = 2.0.1
 org.bouncycastle:bcpkix-jdk15on = 1.54
+org.assertj:assertj-core = 3.5.2


### PR DESCRIPTION
AsyncSlf4jLoggingSpanCollector collects spans and asynchronously logs to an slf4j logger at INFO level.

See pending upstream PR https://github.com/openzipkin/brave/pull/226
