### PR TITLE
Upgrade to Brave 3.11.0

### DIFF
--- a/dropwizard-servers/src/main/java/com/palantir/remoting1/servers/DropwizardTracingFilters.java
+++ b/dropwizard-servers/src/main/java/com/palantir/remoting1/servers/DropwizardTracingFilters.java
@@ -16,6 +16,7 @@
 
 package com.palantir.remoting1.servers;
 
+import com.github.kristofa.brave.AnnotationSubmitter;
 import com.github.kristofa.brave.Sampler;
 import com.github.kristofa.brave.ServerRequestInterceptor;
 import com.github.kristofa.brave.ServerResponseInterceptor;
@@ -39,6 +40,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.EnumSet;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import javax.servlet.DispatcherType;
 
 /** Static utilities for registering Brave/Zipkin filters with Dropwizard applications. */
@@ -74,6 +76,12 @@ final class DropwizardTracingFilters {
                 .randomGenerator(new Random())
                 .state(new ThreadLocalServerClientAndLocalSpanState(ip, port, name))
                 .spanCollector(new SlfLoggingSpanCollector("tracing.server." + name))
+                .clock(new AnnotationSubmitter.Clock() {
+                    @Override
+                    public long currentTimeMicroseconds() {
+                        return TimeUnit.MICROSECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+                    }
+                })
                 .build();
     }
 

--- a/dropwizard-servers/src/test/java/com/palantir/remoting1/servers/DropwizardTracingFiltersTest.java
+++ b/dropwizard-servers/src/test/java/com/palantir/remoting1/servers/DropwizardTracingFiltersTest.java
@@ -98,8 +98,9 @@ public final class DropwizardTracingFiltersTest {
 
         ArgumentCaptor<ILoggingEvent> requestEvent = ArgumentCaptor.forClass(ILoggingEvent.class);
         verify(braveMockAppender).doAppend(requestEvent.capture());
-        assertThat(requestEvent.getValue().getFormattedMessage(),
-                containsString("\"serviceName\":\"testtracername\",\"ipv4\":\"0.0.0.0\",\"port\":61827}"));
+        String actualLogMessage = requestEvent.getValue().getFormattedMessage();
+        assertThat(actualLogMessage, containsString("\"serviceName\":\"testtracername\""));
+        assertThat(actualLogMessage, containsString("\"port\":61827"));
         Mockito.verifyNoMoreInteractions(braveMockAppender);
     }
 

--- a/dropwizard-servers/versions.lock
+++ b/dropwizard-servers/versions.lock
@@ -262,20 +262,20 @@
             ]
         },
         "io.zipkin.brave:brave-core": {
-            "locked": "3.9.0",
+            "locked": "3.11.0",
             "transitive": [
                 "com.palantir.remoting1:brave-extensions",
                 "io.zipkin.brave:brave-http"
             ]
         },
         "io.zipkin.brave:brave-http": {
-            "locked": "3.9.0",
+            "locked": "3.11.0",
             "transitive": [
                 "io.zipkin.brave:brave-jaxrs2"
             ]
         },
         "io.zipkin.brave:brave-jaxrs2": {
-            "locked": "3.9.0"
+            "locked": "3.11.0"
         },
         "io.zipkin.java:zipkin": {
             "locked": "1.0.0",
@@ -854,20 +854,20 @@
             ]
         },
         "io.zipkin.brave:brave-core": {
-            "locked": "3.9.0",
+            "locked": "3.11.0",
             "transitive": [
                 "com.palantir.remoting1:brave-extensions",
                 "io.zipkin.brave:brave-http"
             ]
         },
         "io.zipkin.brave:brave-http": {
-            "locked": "3.9.0",
+            "locked": "3.11.0",
             "transitive": [
                 "io.zipkin.brave:brave-jaxrs2"
             ]
         },
         "io.zipkin.brave:brave-jaxrs2": {
-            "locked": "3.9.0"
+            "locked": "3.11.0"
         },
         "io.zipkin.java:zipkin": {
             "locked": "1.0.0",

--- a/dropwizard-servers/versions.lock
+++ b/dropwizard-servers/versions.lock
@@ -278,7 +278,7 @@
             "locked": "3.11.0"
         },
         "io.zipkin.java:zipkin": {
-            "locked": "1.0.0",
+            "locked": "1.8.4",
             "transitive": [
                 "io.zipkin.brave:brave-core"
             ]
@@ -870,7 +870,7 @@
             "locked": "3.11.0"
         },
         "io.zipkin.java:zipkin": {
-            "locked": "1.0.0",
+            "locked": "1.8.4",
             "transitive": [
                 "io.zipkin.brave:brave-core"
             ]

--- a/ext/brave-extensions/versions.lock
+++ b/ext/brave-extensions/versions.lock
@@ -4,7 +4,7 @@
             "locked": "3.11.0"
         },
         "io.zipkin.java:zipkin": {
-            "locked": "1.0.0",
+            "locked": "1.8.4",
             "transitive": [
                 "io.zipkin.brave:brave-core"
             ]
@@ -18,7 +18,7 @@
             "locked": "3.11.0"
         },
         "io.zipkin.java:zipkin": {
-            "locked": "1.0.0",
+            "locked": "1.8.4",
             "transitive": [
                 "io.zipkin.brave:brave-core"
             ]

--- a/ext/brave-extensions/versions.lock
+++ b/ext/brave-extensions/versions.lock
@@ -1,7 +1,7 @@
 {
     "compileClasspath": {
         "io.zipkin.brave:brave-core": {
-            "locked": "3.9.0"
+            "locked": "3.11.0"
         },
         "io.zipkin.java:zipkin": {
             "locked": "1.0.0",
@@ -15,7 +15,7 @@
     },
     "runtime": {
         "io.zipkin.brave:brave-core": {
-            "locked": "3.9.0"
+            "locked": "3.11.0"
         },
         "io.zipkin.java:zipkin": {
             "locked": "1.0.0",

--- a/jaxrs-clients/versions.lock
+++ b/jaxrs-clients/versions.lock
@@ -111,23 +111,23 @@
             ]
         },
         "io.zipkin.brave:brave-core": {
-            "locked": "3.9.0",
+            "locked": "3.11.0",
             "transitive": [
                 "com.palantir.remoting1:brave-extensions",
                 "io.zipkin.brave:brave-http"
             ]
         },
         "io.zipkin.brave:brave-http": {
-            "locked": "3.9.0",
+            "locked": "3.11.0",
             "transitive": [
                 "io.zipkin.brave:brave-okhttp"
             ]
         },
         "io.zipkin.brave:brave-okhttp": {
-            "locked": "3.9.0"
+            "locked": "3.11.0"
         },
         "io.zipkin.java:zipkin": {
-            "locked": "1.0.0",
+            "locked": "1.8.4",
             "transitive": [
                 "io.zipkin.brave:brave-core"
             ]
@@ -273,23 +273,23 @@
             ]
         },
         "io.zipkin.brave:brave-core": {
-            "locked": "3.9.0",
+            "locked": "3.11.0",
             "transitive": [
                 "com.palantir.remoting1:brave-extensions",
                 "io.zipkin.brave:brave-http"
             ]
         },
         "io.zipkin.brave:brave-http": {
-            "locked": "3.9.0",
+            "locked": "3.11.0",
             "transitive": [
                 "io.zipkin.brave:brave-okhttp"
             ]
         },
         "io.zipkin.brave:brave-okhttp": {
-            "locked": "3.9.0"
+            "locked": "3.11.0"
         },
         "io.zipkin.java:zipkin": {
-            "locked": "1.0.0",
+            "locked": "1.8.4",
             "transitive": [
                 "io.zipkin.brave:brave-core"
             ]

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,4 @@
-io.zipkin.brave:brave-* = 3.9.0
+io.zipkin.brave:brave-* = 3.11.0
 io.dropwizard:dropwizard-* = 0.8.2
 com.netflix.feign:feign-*= 8.17.0
 com.google.guava:guava = 18.0


### PR DESCRIPTION
Bump Brave version to 3.11.0 which supports inheritable Brave tracing.

Note that we still need to make the Brave tracer accessible for application local tracing use.

See https://github.com/openzipkin/brave/issues/206 for one option of global `BraveRegistry` though we could expose through Jersey DI.
