### PR TITLE
Remove classifier from published jar

### DIFF
--- a/jaxrs-clients/build.gradle
+++ b/jaxrs-clients/build.gradle
@@ -55,6 +55,7 @@ shadowJar {
         exclude(dependency { it.moduleGroup.contains("javax.ws.rs") })
         exclude(dependency { it.moduleGroup.contains("com.fasterxml.jackson") })
     }
+    classifier ''
 }
 
 publishing.publications {


### PR DESCRIPTION
without this the jar gets published to `jaxrs-clients-all-1.0.0-rc4-all.jar`. the extra `-all` directly before `.jar` is incorrect
