### PR TITLE
Enabling customizable headers and re-enabling support for ciphers TLSv1.0, TLSv1.1

### DIFF
--- a/http-clients-api/src/main/java/com/palantir/remoting1/clients/ClientConfig.java
+++ b/http-clients-api/src/main/java/com/palantir/remoting1/clients/ClientConfig.java
@@ -17,11 +17,13 @@
 package com.palantir.remoting1.clients;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
 import com.palantir.remoting1.config.service.Duration;
 import com.palantir.remoting1.config.service.ProxyConfiguration;
 import com.palantir.remoting1.config.service.ServiceConfiguration;
 import com.palantir.remoting1.config.ssl.SslSocketFactories;
 import com.palantir.remoting1.config.ssl.TrustContext;
+import java.util.Map;
 import org.immutables.value.Value;
 
 /** Implementation-independent configuration options for HTTP-based dynamic proxies. */
@@ -59,6 +61,11 @@ public abstract class ClientConfig {
     @Value.Default
     public Integer maxNumRetries() {
         return MAX_NUM_RETRIES;
+    }
+
+    @Value.Default
+    public Map<String, String> headers() {
+        return Maps.newHashMap();
     }
 
     public static ClientConfig fromServiceConfig(ServiceConfiguration serviceConfig) {

--- a/http-clients-api/src/main/java/com/palantir/remoting1/clients/ClientConfig.java
+++ b/http-clients-api/src/main/java/com/palantir/remoting1/clients/ClientConfig.java
@@ -17,7 +17,6 @@
 package com.palantir.remoting1.clients;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.Maps;
 import com.palantir.remoting1.config.service.Duration;
 import com.palantir.remoting1.config.service.ProxyConfiguration;
 import com.palantir.remoting1.config.service.ServiceConfiguration;
@@ -63,10 +62,8 @@ public abstract class ClientConfig {
         return MAX_NUM_RETRIES;
     }
 
-    @Value.Default
-    public Map<String, String> headers() {
-        return Maps.newHashMap();
-    }
+    @Value.Parameter
+    public abstract Map<String, String> headers();
 
     public static ClientConfig fromServiceConfig(ServiceConfiguration serviceConfig) {
         ClientConfig.Builder clientConfig = builder();

--- a/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/FeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/FeignJaxRsClientBuilder.java
@@ -26,6 +26,7 @@ import com.palantir.remoting1.config.service.BasicCredentials;
 import com.palantir.remoting1.config.service.ProxyConfiguration;
 import com.palantir.remoting1.config.ssl.TrustContext;
 import com.palantir.remoting1.ext.jackson.ObjectMappers;
+import com.palantir.remoting1.jaxrs.feignimpl.CustomizableInterceptor;
 import com.palantir.remoting1.jaxrs.feignimpl.FailoverFeignTarget;
 import com.palantir.remoting1.jaxrs.feignimpl.FeignSerializableErrorErrorDecoder;
 import com.palantir.remoting1.jaxrs.feignimpl.GuavaOptionalAwareContract;
@@ -120,6 +121,7 @@ public final class FeignJaxRsClientBuilder extends ClientBuilder {
                 .logger(new Slf4jLogger(JaxRsClient.class))
                 .logLevel(Logger.Level.BASIC)
                 .requestInterceptor(UserAgentInterceptor.of(userAgent))
+                .requestInterceptor(CustomizableInterceptor.of(config.headers()))
                 .target(target);
     }
 

--- a/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/FeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/FeignJaxRsClientBuilder.java
@@ -26,10 +26,10 @@ import com.palantir.remoting1.config.service.BasicCredentials;
 import com.palantir.remoting1.config.service.ProxyConfiguration;
 import com.palantir.remoting1.config.ssl.TrustContext;
 import com.palantir.remoting1.ext.jackson.ObjectMappers;
-import com.palantir.remoting1.jaxrs.feignimpl.CustomizableInterceptor;
 import com.palantir.remoting1.jaxrs.feignimpl.FailoverFeignTarget;
 import com.palantir.remoting1.jaxrs.feignimpl.FeignSerializableErrorErrorDecoder;
 import com.palantir.remoting1.jaxrs.feignimpl.GuavaOptionalAwareContract;
+import com.palantir.remoting1.jaxrs.feignimpl.HeaderInterceptor;
 import com.palantir.remoting1.jaxrs.feignimpl.Jackson24Encoder;
 import com.palantir.remoting1.jaxrs.feignimpl.NeverRetryingBackoffStrategy;
 import com.palantir.remoting1.jaxrs.feignimpl.SlashEncodingContract;
@@ -119,7 +119,7 @@ public final class FeignJaxRsClientBuilder extends ClientBuilder {
                 .logger(new Slf4jLogger(JaxRsClient.class))
                 .logLevel(Logger.Level.BASIC)
                 .requestInterceptor(UserAgentInterceptor.of(userAgent))
-                .requestInterceptor(CustomizableInterceptor.of(config.headers()))
+                .requestInterceptor(HeaderInterceptor.of(config.headers()))
                 .target(target);
     }
 

--- a/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/FeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/FeignJaxRsClientBuilder.java
@@ -61,13 +61,11 @@ import okhttp3.ConnectionSpec;
 import okhttp3.Credentials;
 import okhttp3.Response;
 import okhttp3.Route;
-import okhttp3.TlsVersion;
 
 public final class FeignJaxRsClientBuilder extends ClientBuilder {
 
     private static final ImmutableList<ConnectionSpec> CONNECTION_SPEC = ImmutableList.of(
             new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                    .tlsVersions(TlsVersion.TLS_1_2)
                     .cipherSuites(
                             // In an ideal world, we'd use GCM suites, but they're an order of
                             // magnitude slower than the CBC suites, which have JVM optimizations

--- a/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/feignimpl/CustomizableInterceptor.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/feignimpl/CustomizableInterceptor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting1.jaxrs.feignimpl;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import java.util.Collections;
+import java.util.Map;
+
+public final class CustomizableInterceptor implements RequestInterceptor {
+
+    private final Map<String, String> headers;
+
+    private CustomizableInterceptor(Map<String, String> headers) {
+        this.headers = (headers != null) ? headers : Collections.<String, String>emptyMap();
+    }
+
+    public static CustomizableInterceptor of(Map<String, String> headers) {
+        return new CustomizableInterceptor(headers);
+    }
+
+    @Override
+    public void apply(RequestTemplate template) {
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            template.header(header.getKey(), header.getValue());
+        }
+    }
+}

--- a/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/feignimpl/HeaderInterceptor.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/feignimpl/HeaderInterceptor.java
@@ -16,18 +16,23 @@
 
 package com.palantir.remoting1.jaxrs.feignimpl;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
-import java.util.Collections;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class HeaderInterceptor implements RequestInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(HeaderInterceptor.class);
 
     private final Map<String, String> headers;
 
     private HeaderInterceptor(Map<String, String> headers) {
-        this.headers = (headers != null) ? ImmutableMap.copyOf(headers) : Collections.<String, String>emptyMap();
+        this.headers = Preconditions.checkNotNull(ImmutableMap.copyOf(headers),
+                "Custom request headers cannot be null");
     }
 
     public static HeaderInterceptor of(Map<String, String> headers) {
@@ -37,6 +42,10 @@ public final class HeaderInterceptor implements RequestInterceptor {
     @Override
     public void apply(RequestTemplate template) {
         for (Map.Entry<String, String> header : headers.entrySet()) {
+            if (template.headers().containsKey(header.getKey())) {
+                log.warn("Header {} with value {} is being overwritten with value {}", header.getKey(),
+                        template.headers().get(header.getKey()), header.getValue());
+            }
             template.header(header.getKey(), header.getValue());
         }
     }

--- a/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/feignimpl/HeaderInterceptor.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting1/jaxrs/feignimpl/HeaderInterceptor.java
@@ -16,21 +16,22 @@
 
 package com.palantir.remoting1.jaxrs.feignimpl;
 
+import com.google.common.collect.ImmutableMap;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import java.util.Collections;
 import java.util.Map;
 
-public final class CustomizableInterceptor implements RequestInterceptor {
+public final class HeaderInterceptor implements RequestInterceptor {
 
     private final Map<String, String> headers;
 
-    private CustomizableInterceptor(Map<String, String> headers) {
-        this.headers = (headers != null) ? headers : Collections.<String, String>emptyMap();
+    private HeaderInterceptor(Map<String, String> headers) {
+        this.headers = (headers != null) ? ImmutableMap.copyOf(headers) : Collections.<String, String>emptyMap();
     }
 
-    public static CustomizableInterceptor of(Map<String, String> headers) {
-        return new CustomizableInterceptor(headers);
+    public static HeaderInterceptor of(Map<String, String> headers) {
+        return new HeaderInterceptor(headers);
     }
 
     @Override


### PR DESCRIPTION
Products that still have clients in java 6 cannot drop TLSv1.0 yet, plus we'd like the header customization for custom authentication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/306)
<!-- Reviewable:end -->
