### PR TITLE
Synchronize instead of broken atomic boolean

### DIFF
--- a/http2-agent/src/main/java/com/palantir/remoting2/http2/Http2Agent.java
+++ b/http2-agent/src/main/java/com/palantir/remoting2/http2/Http2Agent.java
@@ -12,7 +12,7 @@ import org.mortbay.jetty.alpn.agent.Premain;
 public final class Http2Agent {
     private Http2Agent() {}
 
-    private static volatile boolean hasBeenInstalled = false;
+    private static boolean hasBeenInstalled = false;
 
     /**
      * Installs the jetty-alpn-agent dynamically.
@@ -20,17 +20,13 @@ public final class Http2Agent {
      * This method protects itself from multiple invocations so may be called in multiple places, but will only
      * ever invoke the installation once.
      */
-    public static void install() {
+    public static synchronized void install() {
         if (hasBeenInstalled) {
             return;
         }
 
-        synchronized (Http2Agent.class) {
-            if (!hasBeenInstalled) {
-                AgentLoader.loadAgentClass(Http2Agent.class.getName(), "");
-                hasBeenInstalled = true;
-            }
-        }
+        AgentLoader.loadAgentClass(Http2Agent.class.getName(), "");
+        hasBeenInstalled = true;
     }
 
     /** Agent entry-point. */


### PR DESCRIPTION
There's currently a race in the Http2Agent where one can call it
from multiple threads, and then one of the threads exits before
the agent is installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/379)
<!-- Reviewable:end -->
