### PR TITLE
Add UserAgents#canDetectUserAgent

### DIFF
--- a/http-clients-api/src/main/java/com/palantir/remoting2/clients/UserAgents.java
+++ b/http-clients-api/src/main/java/com/palantir/remoting2/clients/UserAgents.java
@@ -34,9 +34,24 @@ public final class UserAgents {
      * package containing the given class. The default value for both properties is {@code DEFAULT_VALUE}.
      */
     public static String fromClass(Class<?> clazz) {
-        Package classPackage = clazz.getPackage();
-        String userAgent = Optional.ofNullable(classPackage.getImplementationTitle()).orElse(DEFAULT_VALUE);
-        String version = Optional.ofNullable(classPackage.getImplementationVersion()).orElse(DEFAULT_VALUE);
+        String userAgent = implementationTitle(clazz).orElse(DEFAULT_VALUE);
+        String version = implementationVersion(clazz).orElse(DEFAULT_VALUE);
         return getUserAgent(userAgent, version);
+    }
+
+    /**
+     * Returns true if a User-Agent can be determined using the method in {@link UserAgents#fromClass(Class)}
+     * without resorting to defaults.
+     */
+    public static boolean canDetectUserAgent(Class<?> clazz) {
+        return implementationTitle(clazz).isPresent() && implementationVersion(clazz).isPresent();
+    }
+
+    private static Optional<String> implementationTitle(Class<?> clazz) {
+        return Optional.ofNullable(clazz.getPackage().getImplementationTitle());
+    }
+
+    private static Optional<String> implementationVersion(Class<?> clazz) {
+        return Optional.ofNullable(clazz.getPackage().getImplementationVersion());
     }
 }

--- a/http-clients-api/src/test/java/com/palantir/remoting2/clients/UserAgentsTest.java
+++ b/http-clients-api/src/test/java/com/palantir/remoting2/clients/UserAgentsTest.java
@@ -34,4 +34,14 @@ public final class UserAgentsTest {
     public void testGetUserAgent_fromExternalVersionTestJar() throws IOException {
         assertThat(UserAgents.fromClass(VersionTest.class), is("test-name (test-version)"));
     }
+
+    @Test
+    public void testCanDetectUserAgent_fromExternalVersionTestJar() {
+        assertThat(UserAgents.canDetectUserAgent(VersionTest.class), is(true));
+    }
+
+    @Test
+    public void testCanDetectUserAgent_thisClass() {
+        assertThat(UserAgents.canDetectUserAgent(this.getClass()), is(false));
+    }
 }


### PR DESCRIPTION
I intend to use this to log a warning for services which don't have the
manifest entries to generate a user agent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/380)
<!-- Reviewable:end -->
