### PR TITLE
Don't install Http2Agent by default

### DIFF
--- a/jaxrs-clients/build.gradle
+++ b/jaxrs-clients/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     compile project(":extras:refresh-utils")
     compile project(":error-handling")
     compile project(":tracing-okhttp3")
-    compile project(":http2-agent")
     compile project(":http-clients-api")
     compile project(":service-config")
 
@@ -32,7 +31,6 @@ dependencies {
     shadow project(":extras:jackson-support")
     shadow project(":extras:refresh-utils")
     shadow project(":http-clients-api")
-    shadow project(":http2-agent")
     shadow project(":tracing")
     shadow project(":tracing-okhttp3")
     shadow project(':error-handling')
@@ -61,7 +59,6 @@ shadowJar {
         exclude(project(':extras:jackson-support'))
         exclude(project(':extras:refresh-utils'))
         exclude(project(':http-clients-api'))
-        exclude(project(':http2-agent'))
         exclude(project(':service-config'))
         exclude(project(':ssl-config'))
         exclude(project(':tracing'))

--- a/jaxrs-clients/src/main/java/com/palantir/remoting2/jaxrs/FeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting2/jaxrs/FeignJaxRsClientBuilder.java
@@ -27,7 +27,6 @@ import com.palantir.remoting2.config.service.BasicCredentials;
 import com.palantir.remoting2.config.service.ProxyConfiguration;
 import com.palantir.remoting2.config.ssl.TrustContext;
 import com.palantir.remoting2.ext.jackson.ObjectMappers;
-import com.palantir.remoting2.http2.Http2Agent;
 import com.palantir.remoting2.jaxrs.feignimpl.FailoverFeignTarget;
 import com.palantir.remoting2.jaxrs.feignimpl.FeignSerializableErrorErrorDecoder;
 import com.palantir.remoting2.jaxrs.feignimpl.GuavaOptionalAwareContract;

--- a/jaxrs-clients/src/main/java/com/palantir/remoting2/jaxrs/FeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting2/jaxrs/FeignJaxRsClientBuilder.java
@@ -61,10 +61,6 @@ import okhttp3.TlsVersion;
 
 public final class FeignJaxRsClientBuilder extends ClientBuilder {
 
-    static {
-        Http2Agent.install();
-    }
-
     private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newClientObjectMapper();
 
     private final ClientConfig config;

--- a/jaxrs-clients/versions.lock
+++ b/jaxrs-clients/versions.lock
@@ -1,11 +1,5 @@
 {
     "compileClasspath": {
-        "com.ea.agentloader:ea-agent-loader": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.palantir.remoting2:http2-agent"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -121,9 +115,6 @@
         "com.palantir.remoting2:http-clients-api": {
             "project": true
         },
-        "com.palantir.remoting2:http2-agent": {
-            "project": true
-        },
         "com.palantir.remoting2:jackson-support": {
             "project": true,
             "transitive": [
@@ -184,12 +175,6 @@
             "locked": "1.0",
             "transitive": [
                 "com.netflix.feign:feign-core"
-            ]
-        },
-        "org.mortbay.jetty.alpn:jetty-alpn-agent": {
-            "locked": "2.0.6",
-            "transitive": [
-                "com.palantir.remoting2:http2-agent"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -203,12 +188,6 @@
         }
     },
     "runtime": {
-        "com.ea.agentloader:ea-agent-loader": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.palantir.remoting2:http2-agent"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -324,9 +303,6 @@
         "com.palantir.remoting2:http-clients-api": {
             "project": true
         },
-        "com.palantir.remoting2:http2-agent": {
-            "project": true
-        },
         "com.palantir.remoting2:jackson-support": {
             "project": true,
             "transitive": [
@@ -387,12 +363,6 @@
             "locked": "1.0",
             "transitive": [
                 "com.netflix.feign:feign-core"
-            ]
-        },
-        "org.mortbay.jetty.alpn:jetty-alpn-agent": {
-            "locked": "2.0.6",
-            "transitive": [
-                "com.palantir.remoting2:http2-agent"
             ]
         },
         "org.slf4j:slf4j-api": {

--- a/retrofit2-clients/build.gradle
+++ b/retrofit2-clients/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     compile project(":extras:jackson-support")
     compile project(":extras:refresh-utils")
     compile project(":error-handling")
-    compile project(":http2-agent")
     compile project(":http-clients-api")
     compile project(":service-config")
     compile project(":tracing-okhttp3")

--- a/retrofit2-clients/src/main/java/com/palantir/remoting2/retrofit2/Retrofit2ClientBuilder.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting2/retrofit2/Retrofit2ClientBuilder.java
@@ -28,7 +28,6 @@ import com.palantir.remoting2.config.service.BasicCredentials;
 import com.palantir.remoting2.config.service.ProxyConfiguration;
 import com.palantir.remoting2.config.ssl.TrustContext;
 import com.palantir.remoting2.ext.jackson.ObjectMappers;
-import com.palantir.remoting2.http2.Http2Agent;
 import com.palantir.remoting2.tracing.okhttp3.OkhttpTraceInterceptor;
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/retrofit2-clients/src/main/java/com/palantir/remoting2/retrofit2/Retrofit2ClientBuilder.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting2/retrofit2/Retrofit2ClientBuilder.java
@@ -42,10 +42,6 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 
 public final class Retrofit2ClientBuilder extends ClientBuilder {
 
-    static {
-        Http2Agent.install();
-    }
-
     private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newClientObjectMapper();
 
     private final ClientConfig config;

--- a/retrofit2-clients/versions.lock
+++ b/retrofit2-clients/versions.lock
@@ -1,11 +1,5 @@
 {
     "compileClasspath": {
-        "com.ea.agentloader:ea-agent-loader": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.palantir.remoting2:http2-agent"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -100,9 +94,6 @@
         "com.palantir.remoting2:http-clients-api": {
             "project": true
         },
-        "com.palantir.remoting2:http2-agent": {
-            "project": true
-        },
         "com.palantir.remoting2:jackson-support": {
             "project": true,
             "transitive": [
@@ -166,12 +157,6 @@
             "locked": "2.0.1",
             "transitive": [
                 "com.palantir.remoting2:error-handling"
-            ]
-        },
-        "org.mortbay.jetty.alpn:jetty-alpn-agent": {
-            "locked": "2.0.6",
-            "transitive": [
-                "com.palantir.remoting2:http2-agent"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -184,12 +169,6 @@
         }
     },
     "runtime": {
-        "com.ea.agentloader:ea-agent-loader": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.palantir.remoting2:http2-agent"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -284,9 +263,6 @@
         "com.palantir.remoting2:http-clients-api": {
             "project": true
         },
-        "com.palantir.remoting2:http2-agent": {
-            "project": true
-        },
         "com.palantir.remoting2:jackson-support": {
             "project": true,
             "transitive": [
@@ -350,12 +326,6 @@
             "locked": "2.0.1",
             "transitive": [
                 "com.palantir.remoting2:error-handling"
-            ]
-        },
-        "org.mortbay.jetty.alpn:jetty-alpn-agent": {
-            "locked": "2.0.6",
-            "transitive": [
-                "com.palantir.remoting2:http2-agent"
             ]
         },
         "org.slf4j:slf4j-api": {


### PR DESCRIPTION
- By the time the ClientBuilder is referenced, it is often too late for
  the agent to be able to replace the core SSL classes.
- If it is too late, a cryptic java.lang.NoSuchFieldError: EXT_ALPN is
  thrown
- The framework using remoting should be responsible for installing the
  Http2Agent (for example witchcraft or spark-module-lib), as to ensure
  that it is done early enough.

Discussed offline with @markelliot

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/388)
<!-- Reviewable:end -->
