### PR TITLE
[blocked on upstream] when converting optional-valued query parameters, convert to null if not present

### DIFF
--- a/retrofit2-clients/src/test/java/com/palantir/remoting2/retrofit2/OptionalObjectToStringConverterFactoryTest.java
+++ b/retrofit2-clients/src/test/java/com/palantir/remoting2/retrofit2/OptionalObjectToStringConverterFactoryTest.java
@@ -81,29 +81,29 @@ public final class OptionalObjectToStringConverterFactoryTest {
     @Test
     public void testUnwrapsJava8Optional() throws Exception {
         assertThat(guavaConverter.convert(guavaOptional("foo"))).isEqualTo("foo");
-        assertThat(guavaConverter.convert(guavaOptional(null))).isEqualTo("");
+        assertThat(guavaConverter.convert(guavaOptional(null))).isEqualTo(null);
         assertThat(java8Converter.convert(java8Optional("foo"))).isEqualTo("foo");
-        assertThat(java8Converter.convert(java8Optional(null))).isEqualTo("");
+        assertThat(java8Converter.convert(java8Optional(null))).isEqualTo(null);
     }
 
     @Test
     public void testUnwrapsJava8OptionalInt() throws Exception {
         assertThat(Java8OptionalIntStringConverter.INSTANCE.convert(OptionalInt.of(12345))).isEqualTo("12345");
-        assertThat(Java8OptionalIntStringConverter.INSTANCE.convert(OptionalInt.empty())).isEqualTo("");
+        assertThat(Java8OptionalIntStringConverter.INSTANCE.convert(OptionalInt.empty())).isEqualTo(null);
     }
 
     @Test
     public void testUnwrapsJava8OptionalDouble() throws Exception {
         assertThat(Java8OptionalDoubleStringConverter.INSTANCE.convert(
                 OptionalDouble.of(12345.678))).isEqualTo("12345.678");
-        assertThat(Java8OptionalDoubleStringConverter.INSTANCE.convert(OptionalDouble.empty())).isEqualTo("");
+        assertThat(Java8OptionalDoubleStringConverter.INSTANCE.convert(OptionalDouble.empty())).isEqualTo(null);
     }
 
     @Test
     public void testUnwrapsJava8OptionalLong() throws Exception {
         assertThat(Java8OptionalLongStringConverter.INSTANCE.convert(
                 OptionalLong.of(1234567890123L))).isEqualTo("1234567890123");
-        assertThat(Java8OptionalLongStringConverter.INSTANCE.convert(OptionalLong.empty())).isEqualTo("");
+        assertThat(Java8OptionalLongStringConverter.INSTANCE.convert(OptionalLong.empty())).isEqualTo(null);
     }
 
     @Test

--- a/retrofit2-clients/src/test/java/com/palantir/remoting2/retrofit2/Retrofit2ClientApiTest.java
+++ b/retrofit2-clients/src/test/java/com/palantir/remoting2/retrofit2/Retrofit2ClientApiTest.java
@@ -59,7 +59,7 @@ public final class Retrofit2ClientApiTest {
         assertThat(service.getGuavaOptionalString(guavaOptional("p"), guavaEmptyOptional()).execute().body())
             .isEqualTo(guavaOptional("pong"));
         assertThat(server.takeRequest().getPath())
-            .isEqualTo("/getGuavaOptionalString/p/?queryString=q");
+            .isEqualTo("/getGuavaOptionalString/p/");
     }
 
     @Test

--- a/retrofit2-clients/src/test/java/com/palantir/remoting2/retrofit2/Retrofit2ClientApiTest.java
+++ b/retrofit2-clients/src/test/java/com/palantir/remoting2/retrofit2/Retrofit2ClientApiTest.java
@@ -54,6 +54,12 @@ public final class Retrofit2ClientApiTest {
         assertThat(service.getJava8OptionalString(java8Optional("p"), java8Optional("q")).execute().body())
                 .isEqualTo(java8Optional("pong"));
         assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalString/p/?queryString=q");
+
+        server.enqueue(new MockResponse().setBody("\"pong\""));
+        assertThat(service.getGuavaOptionalString(guavaOptional("p"), guavaEmptyOptional()).execute().body())
+            .isEqualTo(guavaOptional("pong"));
+        assertThat(server.takeRequest().getPath())
+            .isEqualTo("/getGuavaOptionalString/p/?queryString=q");
     }
 
     @Test
@@ -72,6 +78,10 @@ public final class Retrofit2ClientApiTest {
 
     private static <T> com.google.common.base.Optional<T> guavaOptional(T value) {
         return com.google.common.base.Optional.of(value);
+    }
+
+    private static <T> com.google.common.base.Optional<T> guavaEmptyOptional() {
+        return com.google.common.base.Optional.absent();
     }
 
     private static <T> java.util.Optional<T> java8Optional(T value) {


### PR DESCRIPTION
fixes #384

this is blocked on retrofit upstream https://github.com/square/retrofit/pull/2243

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/396)
<!-- Reviewable:end -->
