### PR TITLE
Unwrap and catch ITEs

### DIFF
--- a/extras/refresh-utils/src/main/java/com/palantir/remoting2/ext/refresh/RefreshableProxyInvocationHandler.java
+++ b/extras/refresh-utils/src/main/java/com/palantir/remoting2/ext/refresh/RefreshableProxyInvocationHandler.java
@@ -19,6 +19,7 @@ package com.palantir.remoting2.ext.refresh;
 import com.google.common.base.Preconditions;
 import com.google.common.reflect.AbstractInvocationHandler;
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.function.Function;
@@ -54,7 +55,11 @@ public final class RefreshableProxyInvocationHandler<R, T> extends AbstractInvoc
     protected Object handleInvocation(@Nonnull Object proxy, @Nonnull Method method, @Nonnull Object[] args)
             throws Throwable {
         updateDelegate();
-        return method.invoke(delegate, args);
+        try {
+            return method.invoke(delegate, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
     }
 
     private void updateDelegate() {

--- a/extras/refresh-utils/src/test/java/com/palantir/remoting2/ext/refresh/RefreshableProxyInvocationHandlerTest.java
+++ b/extras/refresh-utils/src/test/java/com/palantir/remoting2/ext/refresh/RefreshableProxyInvocationHandlerTest.java
@@ -96,4 +96,25 @@ public final class RefreshableProxyInvocationHandlerTest {
         verify(delegate2, times(2)).call();
         Mockito.verifyNoMoreInteractions(delegate1, delegate2, supplier);
     }
+
+    @Test(expected = IllegalStateException.class)
+    public void testUnwrapsItes() {
+        ThrowingExceptionClass object = new ThrowingExceptionClass();
+        Refreshable<ThrowingExceptionClass> refreshable = Refreshable.of(object);
+
+
+        RefreshableProxyInvocationHandler<ThrowingExceptionClass, Callable> handler =
+                RefreshableProxyInvocationHandler.create(refreshable, (tec) -> object);
+
+        Callable proxy = Reflection.newProxy(Callable.class, handler);
+
+        proxy.call();
+    }
+
+    private static class ThrowingExceptionClass implements Callable {
+        @Override
+        public void call() {
+            throw new IllegalStateException("Whoops!");
+        }
+    }
 }


### PR DESCRIPTION
This fixes issues where you see the following stack trace:

```
com.palantir.remoting2.errors.RemoteException: HTTP 404 Not Found
        at com.palantir.remoting2.errors.SerializableErrorToExceptionConverter.getException(SerializableErrorToExceptionConverter.java:58)
        at com.palantir.remoting2.jaxrs.feignimpl.FeignSerializableErrorErrorDecoder.decode(FeignSerializableErrorErrorDecoder.java:45)
        at httpremoting.shaded.feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:134)
        at httpremoting.shaded.feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:76)
        at httpremoting.shaded.feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:103)
        at com.sun.proxy.$Proxy35.getGroupMembers(Unknown Source)
        ... 30 common frames omitted
Wrapped by: java.lang.reflect.InvocationTargetException: null
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.palantir.remoting2.ext.refresh.RefreshableProxyInvocationHandler.handleInvocation(RefreshableProxyInvocationHandler.java:57)
        at com.google.common.reflect.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:84)
        ... 24 common frames omitted
Wrapped by: java.lang.reflect.UndeclaredThrowableException: null
        at com.sun.proxy.$Proxy35.getGroupMembers(Unknown Source)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        ....
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:748)
```

Which are not super helpful since they're preventing the actual
exception from getting shown (which in this case is RemoteException).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/414)
<!-- Reviewable:end -->
