### PR TITLE
Increase visibility of some tracing classes to public

### DIFF
--- a/tracing/src/main/java/com/palantir/remoting2/tracing/AsyncSpanObserver.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/AsyncSpanObserver.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A {@link SpanObserver} whose observations are executed on a supplied {@link ExecutorService}.
  */
-abstract class AsyncSpanObserver implements SpanObserver {
+public abstract class AsyncSpanObserver implements SpanObserver {
 
     private static final Logger log = LoggerFactory.getLogger(AsyncSpanObserver.class);
     private static final int DEFAULT_MAX_INFLIGHTS = 10_000;

--- a/tracing/src/main/java/com/palantir/remoting2/tracing/AsyncSpanObserver.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/AsyncSpanObserver.java
@@ -52,7 +52,7 @@ public abstract class AsyncSpanObserver implements SpanObserver {
     public abstract void doConsume(Span span);
 
     @Override
-    public void consume(final Span span) {
+    public final void consume(final Span span) {
         if (numInflights.incrementAndGet() <= maxInflights) {
             ListenableFuture<Span> future = executorService.submit(() -> {
                 doConsume(span);

--- a/tracing/src/main/java/com/palantir/remoting2/tracing/InetAddressSupplier.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/InetAddressSupplier.java
@@ -24,7 +24,7 @@ import java.net.UnknownHostException;
 import java.util.Enumeration;
 
 // Taken from http://stackoverflow.com/questions/9481865/getting-the-ip-address-of-the-current-machine-using-java
-enum InetAddressSupplier implements Supplier<InetAddress> {
+public enum InetAddressSupplier implements Supplier<InetAddress> {
     INSTANCE;
 
     @Override


### PR DESCRIPTION
this allows consumers to re-use the async logic while emitting different output than in `AsyncSlf4jSpanObserver`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/424)
<!-- Reviewable:end -->
