### PR TITLE
AsyncSpanObserver constructors are accessible by subclasses

### DIFF
--- a/tracing/src/main/java/com/palantir/remoting2/tracing/AsyncSpanObserver.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/AsyncSpanObserver.java
@@ -39,11 +39,11 @@ public abstract class AsyncSpanObserver implements SpanObserver {
     private final AtomicInteger numInflights = new AtomicInteger(0); // number of non-completed observations
     private final int maxInflights;
 
-    AsyncSpanObserver(ExecutorService executorService) {
+    protected AsyncSpanObserver(ExecutorService executorService) {
         this(executorService, DEFAULT_MAX_INFLIGHTS);
     }
 
-    AsyncSpanObserver(ExecutorService executorService, int maxInflights) {
+    protected AsyncSpanObserver(ExecutorService executorService, int maxInflights) {
         this.executorService = MoreExecutors.listeningDecorator(executorService);
         this.maxInflights = maxInflights;
     }


### PR DESCRIPTION
missed this in #424 =/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/425)
<!-- Reviewable:end -->
