### PR TITLE
Fix Tracers.wrap to keep MDC up to date

### DIFF
--- a/tracing/src/test/java/com/palantir/remoting2/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/remoting2/tracing/TracersTest.java
@@ -28,12 +28,14 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.MDC;
 
 public final class TracersTest {
 
     @Before
     public void before() {
         MockitoAnnotations.initMocks(this);
+        MDC.clear();
     }
 
     @Test
@@ -145,6 +147,7 @@ public final class TracersTest {
             public Void call() throws Exception {
                 assertThat(Tracer.getTraceId()).isEqualTo(expectedTraceId);
                 assertThat(getCurrentFullTrace()).isEqualTo(expectedTrace);
+                assertThat(MDC.get(Tracers.MDC_KEY)).isEqualTo(expectedTraceId);
                 return null;
             }
         };
@@ -158,6 +161,7 @@ public final class TracersTest {
             public void run() {
                 assertThat(Tracer.getTraceId()).isEqualTo(expectedTraceId);
                 assertThat(getCurrentFullTrace()).isEqualTo(expectedTrace);
+                assertThat(MDC.get(Tracers.MDC_KEY)).isEqualTo(expectedTraceId);
             }
         };
     }


### PR DESCRIPTION
Previously, even though `Tracer.getTraceId()` would get propagated correctly across threads when one used `Tracers.wrap`, the generated logs would still not have a `traceId` set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/434)
<!-- Reviewable:end -->
