### PR TITLE
Allow direct proxy configuration

### DIFF
--- a/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
@@ -35,6 +35,10 @@ import org.immutables.value.Value.Style;
 @JsonSerialize(as = ImmutableProxyConfiguration.class)
 @Style(visibility = Style.ImplementationVisibility.PACKAGE, builder = "new")
 public abstract class ProxyConfiguration {
+    enum Type {
+        direct, http;
+    }
+
     /**
      * The hostname and port of the HTTP/HTTPS Proxy. Recognized formats include those recognized by {@link
      * com.google.common.net.HostAndPort}, for instance {@code foo.com:80}, {@code 192.168.3.100:8080}, etc.
@@ -46,16 +50,23 @@ public abstract class ProxyConfiguration {
      */
     public abstract Optional<BasicCredentials> credentials();
 
-    public abstract Optional<Boolean> direct();
+    @Value.Default
+    @SuppressWarnings("checkstyle:designforextension")
+    public Type type() {
+        return Type.http;
+    }
 
     @Value.Check
     protected final void check() {
-        Preconditions.checkArgument(direct().isPresent() || hostAndPort().isPresent(), "proxy configuration must either be direct or configured with host-and-port");
-
         if (hostAndPort().isPresent()) {
+            Preconditions.checkArgument(type() == Type.http, "host-and-port only valid for http proxies");
             HostAndPort host = HostAndPort.fromString(hostAndPort().get());
             Preconditions.checkArgument(host.hasPort(),
                     "Given hostname does not contain a port number: " + host);
+        }
+
+        if (credentials().isPresent()) {
+            Preconditions.checkArgument(type() == Type.http, "credentials only valid for http proxies");
         }
     }
 
@@ -63,11 +74,15 @@ public abstract class ProxyConfiguration {
     @SuppressWarnings("checkstyle:designforextension")
     @JsonIgnore
     public Proxy toProxy() {
-        if (hostAndPort().isPresent()) {
-            HostAndPort hostAndPort = HostAndPort.fromString(hostAndPort().get());
-            return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(hostAndPort.getHostText(), hostAndPort.getPort()));
-        } else {
-            return Proxy.NO_PROXY;
+        switch (type()) {
+            case http:
+                HostAndPort hostAndPort = HostAndPort.fromString(hostAndPort().get());
+                InetSocketAddress addr = new InetSocketAddress(hostAndPort.getHostText(), hostAndPort.getPort());
+                return new Proxy(Proxy.Type.HTTP, addr);
+            case direct:
+                return Proxy.NO_PROXY;
+            default:
+                throw new IllegalStateException("unrecognized proxy type; this is a library error");
         }
     }
 

--- a/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
@@ -94,6 +94,10 @@ public abstract class ProxyConfiguration {
         return new ProxyConfiguration.Builder().hostAndPort(hostAndPort).credentials(credentials).build();
     }
 
+    public static ProxyConfiguration direct() {
+        return new ProxyConfiguration.Builder().type(Type.direct).build();
+    }
+
     // TODO(jnewman): #317 - remove kebab-case methods when Jackson 2.7 is picked up
     static final class Builder extends ImmutableProxyConfiguration.Builder {
 

--- a/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
@@ -74,6 +74,9 @@ public abstract class ProxyConfiguration {
      */
     public abstract Optional<BasicCredentials> credentials();
 
+    /**
+     * The type of Proxy.  Defaults to {@link Type#http}.
+     */
     @Value.Default
     @SuppressWarnings("checkstyle:designforextension")
     public Type type() {
@@ -84,6 +87,8 @@ public abstract class ProxyConfiguration {
     protected final void check() {
         switch (type()) {
             case http:
+                Preconditions.checkArgument(maybeHostAndPort().isPresent(), "host-and-port must be "
+                        + "configured for an http proxy");
                 HostAndPort host = HostAndPort.fromString(maybeHostAndPort().get());
                 Preconditions.checkArgument(host.hasPort(),
                         "Given hostname does not contain a port number: " + host);

--- a/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
@@ -61,9 +61,9 @@ public abstract class ProxyConfiguration {
      * @deprecated Use maybeHostAndPort().
      */
     @Deprecated
-    @Value.Derived
     @SuppressWarnings("checkstyle:designforextension")
     @JsonIgnore
+    @Lazy
     public String hostAndPort() {
         Preconditions.checkState(maybeHostAndPort().isPresent(), "hostAndPort was not configured");
         return maybeHostAndPort().get();

--- a/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
@@ -54,7 +54,8 @@ public abstract class ProxyConfiguration {
 
         if (hostAndPort().isPresent()) {
             HostAndPort host = HostAndPort.fromString(hostAndPort().get());
-            Preconditions.checkArgument(host.hasPort(), "Given hostname does not contain a port number: " + host);
+            Preconditions.checkArgument(host.hasPort(),
+                    "Given hostname does not contain a port number: " + host);
         }
     }
 

--- a/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
@@ -88,7 +88,7 @@ public abstract class ProxyConfiguration {
         switch (type()) {
             case HTTP:
                 Preconditions.checkArgument(maybeHostAndPort().isPresent(), "host-and-port must be "
-                        + "configured for an http proxy");
+                        + "configured for an HTTP proxy");
                 HostAndPort host = HostAndPort.fromString(maybeHostAndPort().get());
                 Preconditions.checkArgument(host.hasPort(),
                         "Given hostname does not contain a port number: " + host);

--- a/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting2/config/service/ProxyConfiguration.java
@@ -41,13 +41,13 @@ public abstract class ProxyConfiguration {
         /**
          * Use a direct connection. This option will bypass any JVM-level configured proxy settings.
          */
-        direct,
+        DIRECT,
 
         /**
          * Use an http-proxy specified by {@link ProxyConfiguration#hostAndPort()}  and (optionally)
          * {@link ProxyConfiguration#credentials()}.
          */
-        http;
+        HTTP;
     }
 
     /**
@@ -75,34 +75,34 @@ public abstract class ProxyConfiguration {
     public abstract Optional<BasicCredentials> credentials();
 
     /**
-     * The type of Proxy.  Defaults to {@link Type#http}.
+     * The type of Proxy.  Defaults to {@link Type#HTTP}.
      */
     @Value.Default
     @SuppressWarnings("checkstyle:designforextension")
     public Type type() {
-        return Type.http;
+        return Type.HTTP;
     }
 
     @Value.Check
     protected final void check() {
         switch (type()) {
-            case http:
+            case HTTP:
                 Preconditions.checkArgument(maybeHostAndPort().isPresent(), "host-and-port must be "
                         + "configured for an http proxy");
                 HostAndPort host = HostAndPort.fromString(maybeHostAndPort().get());
                 Preconditions.checkArgument(host.hasPort(),
                         "Given hostname does not contain a port number: " + host);
                 break;
-            case direct:
+            case DIRECT:
                 Preconditions.checkArgument(!maybeHostAndPort().isPresent() && !credentials().isPresent(),
-                        "Neither credential nor host-and-port may be configured for direct proxies");
+                        "Neither credential nor host-and-port may be configured for DIRECT proxies");
                 break;
             default:
                 throw new IllegalStateException("Unrecognized case; this is a library bug");
         }
 
         if (credentials().isPresent()) {
-            Preconditions.checkArgument(type() == Type.http, "credentials only valid for http proxies");
+            Preconditions.checkArgument(type() == Type.HTTP, "credentials only valid for http proxies");
         }
     }
 
@@ -111,11 +111,11 @@ public abstract class ProxyConfiguration {
     @JsonIgnore
     public Proxy toProxy() {
         switch (type()) {
-            case http:
+            case HTTP:
                 HostAndPort hostAndPort = HostAndPort.fromString(maybeHostAndPort().get());
                 InetSocketAddress addr = new InetSocketAddress(hostAndPort.getHostText(), hostAndPort.getPort());
                 return new Proxy(Proxy.Type.HTTP, addr);
-            case direct:
+            case DIRECT:
                 return Proxy.NO_PROXY;
             default:
                 throw new IllegalStateException("unrecognized proxy type; this is a library error");
@@ -131,7 +131,7 @@ public abstract class ProxyConfiguration {
     }
 
     public static ProxyConfiguration direct() {
-        return new ProxyConfiguration.Builder().type(Type.direct).build();
+        return new ProxyConfiguration.Builder().type(Type.DIRECT).build();
     }
 
     // TODO(jnewman): #317 - remove kebab-case methods when Jackson 2.7 is picked up

--- a/service-config/src/main/java/com/palantir/remoting2/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting2/config/service/ServiceConfiguration.java
@@ -68,7 +68,7 @@ public abstract class ServiceConfiguration {
     public abstract List<String> uris();
 
     /**
-     * Proxy configuration for connecting to the service.
+     * Proxy configuration for connecting to the service. If absent, uses system proxy configuration.
      */
     public abstract Optional<ProxyConfiguration> proxyConfiguration();
 

--- a/service-config/src/test/java/com/palantir/remoting2/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/remoting2/config/service/ProxyConfigurationTests.java
@@ -63,7 +63,7 @@ public final class ProxyConfigurationTests {
     @Test(expected = IllegalArgumentException.class)
     public void testDirectProxyWithHostAndPort() {
         new ProxyConfiguration.Builder()
-                .hostAndPort("squid:3128")
+                .maybeHostAndPort("squid:3128")
                 .type(ProxyConfiguration.Type.direct)
                 .build();
     }

--- a/service-config/src/test/java/com/palantir/remoting2/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/remoting2/config/service/ProxyConfigurationTests.java
@@ -65,9 +65,9 @@ public final class ProxyConfigurationTests {
     public void serDe() throws Exception {
         ProxyConfiguration serialized = ProxyConfiguration.of("host:80", BasicCredentials.of("username", "password"));
         String deserializedCamelCase =
-                "{\"hostAndPort\":\"host:80\",\"credentials\":{\"username\":\"username\",\"password\":\"password\"}}";
+                "{\"hostAndPort\":\"host:80\",\"credentials\":{\"username\":\"username\",\"password\":\"password\"},\"direct\":null}";
         String deserializedKebabCase =
-                "{\"host-and-port\":\"host:80\",\"credentials\":{\"username\":\"username\",\"password\":\"password\"}}";
+                "{\"host-and-port\":\"host:80\",\"credentials\":{\"username\":\"username\",\"password\":\"password\"}, \"direct\": null}";
 
         assertThat(ObjectMappers.newClientObjectMapper().writeValueAsString(serialized))
                 .isEqualTo(deserializedCamelCase);

--- a/service-config/src/test/java/com/palantir/remoting2/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/remoting2/config/service/ProxyConfigurationTests.java
@@ -64,7 +64,7 @@ public final class ProxyConfigurationTests {
     public void testDirectProxyWithHostAndPort() {
         new ProxyConfiguration.Builder()
                 .maybeHostAndPort("squid:3128")
-                .type(ProxyConfiguration.Type.direct)
+                .type(ProxyConfiguration.Type.DIRECT)
                 .build();
     }
 
@@ -81,9 +81,9 @@ public final class ProxyConfigurationTests {
     public void serDe() throws Exception {
         ProxyConfiguration serialized = ProxyConfiguration.of("host:80", BasicCredentials.of("username", "password"));
         String deserializedCamelCase = "{\"hostAndPort\":\"host:80\",\"credentials\":{\"username\":\"username\","
-                + "\"password\":\"password\"},\"type\":\"http\"}";
+                + "\"password\":\"password\"},\"type\":\"HTTP\"}";
         String deserializedKebabCase = "{\"host-and-port\":\"host:80\",\"credentials\":{\"username\":\"username\","
-                + "\"password\":\"password\"},\"type\":\"http\"}";
+                + "\"password\":\"password\"},\"type\":\"HTTP\"}";
 
         assertThat(ObjectMappers.newClientObjectMapper().writeValueAsString(serialized))
                 .isEqualTo(deserializedCamelCase);

--- a/service-config/src/test/java/com/palantir/remoting2/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/remoting2/config/service/ProxyConfigurationTests.java
@@ -54,12 +54,28 @@ public final class ProxyConfigurationTests {
     }
 
     @Test
+    public void testDeserializationDirect() throws Exception {
+        URL resource = Resources.getResource("configs/proxy-config-direct.yml");
+        ProxyConfiguration config = mapper.readValue(resource, ProxyConfiguration.class);
+        assertEquals(config, ProxyConfiguration.direct());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDirectProxyWithHostAndPort() {
+        new ProxyConfiguration.Builder()
+                .hostAndPort("squid:3128")
+                .type(ProxyConfiguration.Type.direct)
+                .build();
+    }
+
+    @Test
     public void testToProxy() {
         ProxyConfiguration proxyConfiguration = ProxyConfiguration.of("squid:3128");
 
         Proxy expected = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("squid", 3128));
         assertEquals(expected, proxyConfiguration.toProxy());
     }
+
 
     @Test
     public void serDe() throws Exception {

--- a/service-config/src/test/java/com/palantir/remoting2/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/remoting2/config/service/ProxyConfigurationTests.java
@@ -64,10 +64,10 @@ public final class ProxyConfigurationTests {
     @Test
     public void serDe() throws Exception {
         ProxyConfiguration serialized = ProxyConfiguration.of("host:80", BasicCredentials.of("username", "password"));
-        String deserializedCamelCase =
-                "{\"hostAndPort\":\"host:80\",\"credentials\":{\"username\":\"username\",\"password\":\"password\"},\"direct\":null}";
-        String deserializedKebabCase =
-                "{\"host-and-port\":\"host:80\",\"credentials\":{\"username\":\"username\",\"password\":\"password\"}, \"direct\": null}";
+        String deserializedCamelCase = "{\"hostAndPort\":\"host:80\",\"credentials\":{\"username\":\"username\","
+                + "\"password\":\"password\"},\"type\":\"http\"}";
+        String deserializedKebabCase = "{\"host-and-port\":\"host:80\",\"credentials\":{\"username\":\"username\","
+                + "\"password\":\"password\"},\"type\":\"http\"}";
 
         assertThat(ObjectMappers.newClientObjectMapper().writeValueAsString(serialized))
                 .isEqualTo(deserializedCamelCase);

--- a/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceConfigurationTest.java
+++ b/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceConfigurationTest.java
@@ -42,7 +42,7 @@ public final class ServiceConfigurationTest {
                 + "\"keyStorePassword\":null,\"keyStoreType\":\"JKS\",\"keyStoreKeyAlias\":null},"
                 + "\"connectTimeout\":\"1 day\",\"readTimeout\":\"1 day\",\"writeTimeout\":\"1 day\","
                 + "\"enableGcmCipherSuites\":null,"
-                + "\"uris\":[\"uri1\"],\"proxyConfiguration\":{\"hostAndPort\":\"host:80\",\"credentials\":null}}";
+                + "\"uris\":[\"uri1\"],\"proxyConfiguration\":{\"hostAndPort\":\"host:80\",\"credentials\":null,\"direct\":null}}";
         String deserializedKebabCase = "{\"api-token\":\"bearerToken\",\"security\":"
                 + "{\"trust-store-path\":\"truststore.jks\",\"trust-store-type\":\"JKS\",\"key-store-path\":null,"
                 + "\"key-store-password\":null,\"key-store-type\":\"JKS\",\"key-store-key-alias\":null},"

--- a/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceConfigurationTest.java
+++ b/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceConfigurationTest.java
@@ -43,7 +43,7 @@ public final class ServiceConfigurationTest {
                 + "\"connectTimeout\":\"1 day\",\"readTimeout\":\"1 day\",\"writeTimeout\":\"1 day\","
                 + "\"enableGcmCipherSuites\":null,"
                 + "\"uris\":[\"uri1\"],\"proxyConfiguration\":{\"hostAndPort\":\"host:80\",\"credentials\":null,"
-                + "\"type\":\"http\"}}";
+                + "\"type\":\"HTTP\"}}";
         String deserializedKebabCase = "{\"api-token\":\"bearerToken\",\"security\":"
                 + "{\"trust-store-path\":\"truststore.jks\",\"trust-store-type\":\"JKS\",\"key-store-path\":null,"
                 + "\"key-store-password\":null,\"key-store-type\":\"JKS\",\"key-store-key-alias\":null},"

--- a/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceConfigurationTest.java
+++ b/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceConfigurationTest.java
@@ -42,7 +42,8 @@ public final class ServiceConfigurationTest {
                 + "\"keyStorePassword\":null,\"keyStoreType\":\"JKS\",\"keyStoreKeyAlias\":null},"
                 + "\"connectTimeout\":\"1 day\",\"readTimeout\":\"1 day\",\"writeTimeout\":\"1 day\","
                 + "\"enableGcmCipherSuites\":null,"
-                + "\"uris\":[\"uri1\"],\"proxyConfiguration\":{\"hostAndPort\":\"host:80\",\"credentials\":null,\"direct\":null}}";
+                + "\"uris\":[\"uri1\"],\"proxyConfiguration\":{\"hostAndPort\":\"host:80\",\"credentials\":null,"
+                + "\"type\":\"http\"}}";
         String deserializedKebabCase = "{\"api-token\":\"bearerToken\",\"security\":"
                 + "{\"trust-store-path\":\"truststore.jks\",\"trust-store-type\":\"JKS\",\"key-store-path\":null,"
                 + "\"key-store-password\":null,\"key-store-type\":\"JKS\",\"key-store-key-alias\":null},"

--- a/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceDiscoveryConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceDiscoveryConfigurationTests.java
@@ -186,7 +186,7 @@ public final class ServiceDiscoveryConfigurationTests {
                 + "{\"service\":{\"apiToken\":null,\"security\":null,\"connectTimeout\":null,\"readTimeout\":null,"
                 + "\"writeTimeout\":null,\"enableGcmCipherSuites\":null,\"uris\":[\"uri\"],"
                 + "\"proxyConfiguration\":null}},\"proxyConfiguration\":"
-                + "{\"hostAndPort\":\"host:80\",\"credentials\":null,\"direct\":null},\"connectTimeout\":\"1 day\","
+                + "{\"hostAndPort\":\"host:80\",\"credentials\":null,\"type\":\"http\"},\"connectTimeout\":\"1 day\","
                 + "\"readTimeout\":\"1 day\",\"enableGcmCipherSuites\":null}";
         String deserializedKebabCase = "{\"api-token\":\"bearerToken\",\"security\":"
                 + "{\"trust-store-path\":\"truststore.jks\",\"trust-store-type\":\"JKS\",\"key-store-path\":null,"

--- a/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceDiscoveryConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceDiscoveryConfigurationTests.java
@@ -186,7 +186,7 @@ public final class ServiceDiscoveryConfigurationTests {
                 + "{\"service\":{\"apiToken\":null,\"security\":null,\"connectTimeout\":null,\"readTimeout\":null,"
                 + "\"writeTimeout\":null,\"enableGcmCipherSuites\":null,\"uris\":[\"uri\"],"
                 + "\"proxyConfiguration\":null}},\"proxyConfiguration\":"
-                + "{\"hostAndPort\":\"host:80\",\"credentials\":null},\"connectTimeout\":\"1 day\","
+                + "{\"hostAndPort\":\"host:80\",\"credentials\":null,\"direct\":null},\"connectTimeout\":\"1 day\","
                 + "\"readTimeout\":\"1 day\",\"enableGcmCipherSuites\":null}";
         String deserializedKebabCase = "{\"api-token\":\"bearerToken\",\"security\":"
                 + "{\"trust-store-path\":\"truststore.jks\",\"trust-store-type\":\"JKS\",\"key-store-path\":null,"

--- a/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceDiscoveryConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/remoting2/config/service/ServiceDiscoveryConfigurationTests.java
@@ -186,7 +186,7 @@ public final class ServiceDiscoveryConfigurationTests {
                 + "{\"service\":{\"apiToken\":null,\"security\":null,\"connectTimeout\":null,\"readTimeout\":null,"
                 + "\"writeTimeout\":null,\"enableGcmCipherSuites\":null,\"uris\":[\"uri\"],"
                 + "\"proxyConfiguration\":null}},\"proxyConfiguration\":"
-                + "{\"hostAndPort\":\"host:80\",\"credentials\":null,\"type\":\"http\"},\"connectTimeout\":\"1 day\","
+                + "{\"hostAndPort\":\"host:80\",\"credentials\":null,\"type\":\"HTTP\"},\"connectTimeout\":\"1 day\","
                 + "\"readTimeout\":\"1 day\",\"enableGcmCipherSuites\":null}";
         String deserializedKebabCase = "{\"api-token\":\"bearerToken\",\"security\":"
                 + "{\"trust-store-path\":\"truststore.jks\",\"trust-store-type\":\"JKS\",\"key-store-path\":null,"

--- a/service-config/src/test/resources/configs/proxy-config-direct.yml
+++ b/service-config/src/test/resources/configs/proxy-config-direct.yml
@@ -1,0 +1,1 @@
+type: direct

--- a/service-config/src/test/resources/configs/proxy-config-direct.yml
+++ b/service-config/src/test/resources/configs/proxy-config-direct.yml
@@ -1,1 +1,1 @@
-type: direct
+type: DIRECT


### PR DESCRIPTION
This allows users to bypass the proxy settings set at the JVM  with `-Dhttps.proxyHost`/`-Dhttps.proxyPort`. This can be useful if you are using a third-party library which needs to make proxied http calls, but the library does not allow you to set an external proxy.

Previously okhttp would default to using a direct connection if the proxy failed, but that changed in 3.5.0 (https://github.com/square/okhttp/blob/master/CHANGELOG.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/435)
<!-- Reviewable:end -->
