### PR TITLE
In clients, log 4xx errors at higher level than 5xx errors

### DIFF
--- a/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
+++ b/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
@@ -16,8 +16,6 @@
 
 package com.palantir.remoting2.servers.jersey;
 
-import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.remoting2.errors.RemoteException;
@@ -44,7 +42,7 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
         Status status = Status.fromStatusCode(exception.getStatus());
 
         // here in the client, log responses that indicate client error (4xx) at higher level than server error (5xx)
-        if (CLIENT_ERROR.equals(status.getFamily())) {
+        if (Status.Family.CLIENT_ERROR.equals(status.getFamily())) {
             log.error("Received response status code {} from server handling request. errorId: {}",
                     SafeArg.of("statusCode", status.getStatusCode()),
                     SafeArg.of("errorId", errorId),

--- a/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
+++ b/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
@@ -48,7 +48,7 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
                     SafeArg.of("errorId", errorId),
                     exception);
         } else {
-            log.warn("Received response status code {} from server handling request. errorId: {}",
+            log.info("Received response status code {} from server handling request. errorId: {}",
                     SafeArg.of("statusCode", status.getStatusCode()),
                     SafeArg.of("errorId", errorId),
                     exception);


### PR DESCRIPTION
Since 4xx errors are client-side, the client should care more about the issue
than problems that are server-side (5xx).

This is the complement to https://github.com/palantir/http-remoting/pull/458 by @meditativeape which changes logging on the server to put 5xx responses at a higher level than 4xx responses.

I'm unsure if this is the correct exception mapper used in clients rather than in servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/459)
<!-- Reviewable:end -->
