### PR TITLE
Log 5xx responses as WARN in client

### DIFF
--- a/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/JsonExceptionMapper.java
+++ b/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/JsonExceptionMapper.java
@@ -36,6 +36,13 @@ import org.slf4j.LoggerFactory;
 /**
  * Writes out exceptions as serialized {@link SerializableError}s with {@link MediaType#APPLICATION_JSON JSON media
  * type}.
+ *
+ * Consider this call stack, where a caller/browser calls a remote method in a server:
+ *
+ * caller/browser -> [server]
+ *
+ * When code in the server throws an {@link Exception} that reaches Jersey, this {@link ExceptionMapper} converts that
+ * exception into an HTTP {@link Response} for return to the caller/browser.
  */
 abstract class JsonExceptionMapper<T extends Exception> implements ExceptionMapper<T> {
 

--- a/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
+++ b/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
@@ -48,7 +48,7 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
                     SafeArg.of("errorId", errorId),
                     exception);
         } else {
-            log.info("Received response status code {} from server handling request. errorId: {}",
+            log.warn("Received response status code {} from server handling request. errorId: {}",
                     SafeArg.of("statusCode", status.getStatusCode()),
                     SafeArg.of("errorId", errorId),
                     exception);

--- a/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
+++ b/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.remoting2.errors.RemoteException;
 import com.palantir.remoting2.errors.SerializableError;
-import java.util.UUID;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;

--- a/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
+++ b/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
@@ -54,6 +54,7 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
     public Response toResponse(RemoteException exception) {
         Status status = Status.fromStatusCode(exception.getStatus());
 
+        // TODO(rfink): Propagate errorId across service boundaries?
         // log at WARN instead of ERROR because although this indicates an issue in a remote server, it is not
         log.warn("Forwarding response and status code {} from remote server back to caller",
                 SafeArg.of("statusCode", status.getStatusCode()),

--- a/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
+++ b/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/RemoteExceptionMapper.java
@@ -53,14 +53,11 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
 
     @Override
     public Response toResponse(RemoteException exception) {
-        String errorId = UUID.randomUUID().toString();
-
         Status status = Status.fromStatusCode(exception.getStatus());
 
         // log at WARN instead of ERROR because although this indicates an issue in a remote server, it is not
-        log.warn("Forwarding response and status code {} from remote server back to caller. errorId: {}",
+        log.warn("Forwarding response and status code {} from remote server back to caller",
                 SafeArg.of("statusCode", status.getStatusCode()),
-                SafeArg.of("errorId", errorId),
                 exception);
 
         SerializableError error = exception.getRemoteException();
@@ -70,8 +67,7 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
             String json = JsonExceptionMapper.MAPPER.writeValueAsString(error);
             builder.entity(json);
         } catch (RuntimeException | JsonProcessingException e) {
-            log.warn("Unable to translate exception to json for request. errorId: {}",
-                    SafeArg.of("errorId", errorId), e);
+            log.warn("Unable to translate exception to json for request", e);
             // simply write out the exception message
             builder = Response.status(status);
             builder.type(MediaType.TEXT_PLAIN);


### PR DESCRIPTION
In this call stack:

> client -> server A -> server B

where an exception is thrown in B and propagates back from server B:

> client <- server A <- server B

We log in these ways at each point in the return across server-spanned call stack.

In server B at outgoing time (JsonExceptionMapper):
- 4xx => INFO
- 5xx => ERROR

In server A at incoming time (SerializableErrorToExceptionConverter):
- 4xx => none
- 5xx => none

In server A at outgoing (forwarding) time (RemoteExceptionMapper):
- 4xx => WARN
- 5xx => WARN

In server A we log as WARN as the exceptions signal an error in server B which impacts the availability of A.

Followup to https://github.com/palantir/http-remoting/pull/459

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/462)
<!-- Reviewable:end -->
