### PR TITLE
refactor tracing so that it's straightforward to run a callable with some specified trace

### DIFF
--- a/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/TraceEnrichingFilter.java
+++ b/jersey-servers/src/main/java/com/palantir/remoting2/servers/jersey/TraceEnrichingFilter.java
@@ -30,7 +30,6 @@ import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
-import org.slf4j.MDC;
 
 @Provider
 public final class TraceEnrichingFilter implements ContainerRequestFilter, ContainerResponseFilter {
@@ -58,10 +57,6 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
                 Tracer.startSpan(operation, spanId, SpanType.SERVER_INCOMING);
             }
         }
-
-        // Give SLF4J appenders access to the trace id
-        // TODO(rfink) We should use putCloseable; when and how can we remove it though? There is no filter chain.
-        MDC.put(Tracers.TRACE_ID_KEY, Tracer.getTraceId());
 
         // Give asynchronous downstream handlers access to the trace id
         requestContext.setProperty("com.palantir.remoting2.traceId", Tracer.getTraceId());

--- a/tracing/src/main/java/com/palantir/remoting2/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/Trace.java
@@ -33,7 +33,7 @@ final class Trace {
     private final String traceId;
 
     private Trace(ArrayDeque<OpenSpan> stack, boolean isObservable, String traceId) {
-        checkArgument(traceId.isEmpty(), "traceId must be non-empty");
+        checkArgument(!traceId.isEmpty(), "traceId must be non-empty");
 
         this.stack = stack;
         this.isObservable = isObservable;

--- a/tracing/src/main/java/com/palantir/remoting2/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/Trace.java
@@ -16,6 +16,8 @@
 
 package com.palantir.remoting2.tracing;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
@@ -31,6 +33,8 @@ final class Trace {
     private final String traceId;
 
     private Trace(ArrayDeque<OpenSpan> stack, boolean isObservable, String traceId) {
+        checkArgument(traceId.isEmpty(), "traceId must be non-empty");
+
         this.stack = stack;
         this.isObservable = isObservable;
         this.traceId = traceId;
@@ -65,7 +69,7 @@ final class Trace {
     }
 
     /**
-     * The globally unique identifier for this call trace.
+     * The globally unique non-empty identifier for this call trace.
      */
     String getTraceId() {
         return traceId;

--- a/tracing/src/main/java/com/palantir/remoting2/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/Tracer.java
@@ -41,7 +41,9 @@ public final class Tracer {
     private static final ThreadLocal<Trace> currentTrace = new ThreadLocal<Trace>() {
         @Override
         protected Trace initialValue() {
-            return createTrace(Optional.empty(), Tracers.randomId());
+            Trace trace = createTrace(Optional.empty(), Tracers.randomId());
+            MDC.put(Tracers.TRACE_ID_KEY, trace.getTraceId());
+            return trace;
         }
     };
 
@@ -68,7 +70,7 @@ public final class Tracer {
      * #setSampler configured sampler} returns true.
      */
     public static void initTrace(Optional<Boolean> isObservable, String traceId) {
-        currentTrace.set(createTrace(isObservable, traceId));
+        setTrace(createTrace(isObservable, traceId));
     }
 
     /**
@@ -200,6 +202,7 @@ public final class Tracer {
     public static Trace getAndClearTrace() {
         Trace trace = currentTrace.get();
         currentTrace.remove();
+        MDC.remove(Tracers.TRACE_ID_KEY);
         return trace;
     }
 

--- a/tracing/src/main/java/com/palantir/remoting2/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/Tracer.java
@@ -198,7 +198,7 @@ public final class Tracer {
         return currentTrace.get().getTraceId();
     }
 
-    /** Clears the current trace id and (a copy of) it. */
+    /** Clears the current trace id and returns (a copy of) it. */
     public static Trace getAndClearTrace() {
         Trace trace = currentTrace.get();
         currentTrace.remove();

--- a/tracing/src/main/java/com/palantir/remoting2/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/Tracer.java
@@ -55,7 +55,7 @@ public final class Tracer {
      * Trace#isObservable observable} iff the given flag is true, or, iff {@code isObservable} is absent,
      * if the {@link #setSampler configured sampler} returns true.
      */
-    public static Trace createTrace(Optional<Boolean> isObservable, String traceId) {
+    /*package*/ static Trace createTrace(Optional<Boolean> isObservable, String traceId) {
         validateId(traceId, "traceId must be non-empty: %s");
         boolean observable = isObservable.orElse(sampler.sample());
         return new Trace(observable, traceId);

--- a/tracing/src/main/java/com/palantir/remoting2/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/Tracers.java
@@ -79,6 +79,11 @@ public final class Tracers {
         return new TracingAwareRunnable(delegate);
     }
 
+    /**
+     * Wraps the given {@link Callable} such that it creates a fresh {@link Trace tracing state} for its execution.
+     * That is, the trace during its {@link Callable#call() execution} is entirely separate from the trace at
+     * construction or any trace already set on the thread used to execute the callable.
+     */
     public static <V> Callable<V> wrapWithoutTrace(Callable<V> delegate) {
         Trace trace = Tracer.createTrace(Optional.empty(), Tracers.randomId());
         return () -> withTrace(trace, delegate);

--- a/tracing/src/main/java/com/palantir/remoting2/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/Tracers.java
@@ -82,11 +82,14 @@ public final class Tracers {
     /**
      * Wraps the given {@link Callable} such that it creates a fresh {@link Trace tracing state} for its execution.
      * That is, the trace during its {@link Callable#call() execution} is entirely separate from the trace at
-     * construction or any trace already set on the thread used to execute the callable.
+     * construction or any trace already set on the thread used to execute the callable. Each execution of the callable
+     * will have a fresh trace.
      */
     public static <V> Callable<V> wrapWithoutTrace(Callable<V> delegate) {
-        Trace trace = Tracer.createTrace(Optional.empty(), Tracers.randomId());
-        return () -> withTrace(trace, delegate);
+        return () -> {
+            Trace trace = Tracer.createTrace(Optional.empty(), Tracers.randomId());
+            return withTrace(trace, delegate);
+        };
     }
 
     private static <T> T withTrace(Trace trace, Callable<T> callable) throws Exception {

--- a/tracing/src/main/java/com/palantir/remoting2/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/remoting2/tracing/Tracers.java
@@ -17,6 +17,7 @@
 package com.palantir.remoting2.tracing;
 
 import com.google.common.base.Strings;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -78,7 +79,12 @@ public final class Tracers {
         return new TracingAwareRunnable(delegate);
     }
 
-    public static <T> T withTrace(Trace trace, Callable<T> callable) throws Exception {
+    public static <V> Callable<V> wrapWithoutTrace(Callable<V> delegate) {
+        Trace trace = Tracer.createTrace(Optional.empty(), Tracers.randomId());
+        return () -> withTrace(trace, delegate);
+    }
+
+    private static <T> T withTrace(Trace trace, Callable<T> callable) throws Exception {
         Trace originalTrace = Tracer.copyTrace();
         String originalMdcTraceIdValue = MDC.get(TRACE_ID_KEY);
 

--- a/tracing/src/test/java/com/palantir/remoting2/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/remoting2/tracing/TraceTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
-public class TraceTest {
+public final class TraceTest {
 
     @Test
     public void constructTrace_emptyTraceId() {

--- a/tracing/src/test/java/com/palantir/remoting2/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/remoting2/tracing/TraceTest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.remoting2.tracing;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class TraceTest {
+
+    @Test
+    public void constructTrace_emptyTraceId() {
+        assertThatThrownBy(() -> new Trace(false, ""))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+}

--- a/tracing/src/test/java/com/palantir/remoting2/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/remoting2/tracing/TracersTest.java
@@ -17,6 +17,7 @@
 package com.palantir.remoting2.tracing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.Lists;
 import java.util.List;
@@ -154,6 +155,19 @@ public final class TracersTest {
 
         assertThat(traceIdBeforeConstruction)
             .isEqualTo(traceIdAfterCalls);
+    }
+
+    @Test
+    public void testWrapCallableWithNewTrace_traceStateRestoredWhenThrows() throws Exception {
+        String traceIdBeforeConstruction = Tracer.getTraceId();
+
+        Callable<String> wrappedCallable = Tracers.wrapWithNewTrace(() -> {
+            throw new IllegalStateException();
+        });
+
+        assertThatThrownBy(() -> wrappedCallable.call()).isInstanceOf(IllegalStateException.class);
+
+        assertThat(Tracer.getTraceId()).isEqualTo(traceIdBeforeConstruction);
     }
 
     @Test

--- a/tracing/src/test/java/com/palantir/remoting2/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/remoting2/tracing/TracersTest.java
@@ -131,6 +131,32 @@ public final class TracersTest {
     }
 
     @Test
+    public void testWrapCallableWithNewTrace_traceStateInsideCallableIsIsolated() throws Exception {
+        String traceIdBeforeConstruction = Tracer.getTraceId();
+
+        Callable<String> wrappedCallable = Tracers.wrapWithNewTrace(() -> {
+            return Tracer.getTraceId();
+        });
+
+        String traceIdFirstCall = wrappedCallable.call();
+        String traceIdSecondCall = wrappedCallable.call();
+
+        String traceIdAfterCalls = Tracer.getTraceId();
+
+        assertThat(traceIdFirstCall)
+            .isNotEqualTo(traceIdBeforeConstruction)
+            .isNotEqualTo(traceIdAfterCalls)
+            .isNotEqualTo(traceIdSecondCall);
+
+        assertThat(traceIdSecondCall)
+            .isNotEqualTo(traceIdBeforeConstruction)
+            .isNotEqualTo(traceIdAfterCalls);
+
+        assertThat(traceIdBeforeConstruction)
+            .isEqualTo(traceIdAfterCalls);
+    }
+
+    @Test
     public void testTraceIdGeneration() throws Exception {
         assertThat(Tracers.randomId()).hasSize(16); // fails with p=1/16 if generated string is not padded
         assertThat(Tracers.longToPaddedHex(0)).isEqualTo("0000000000000000");


### PR DESCRIPTION
Usecase (there may be an existing way to do this)

I have a scheduled background task which makes requests to other services.

I want each run of this background task to run with a new trace id
- all calls to remote services as part of this single run have this new trace id in common
- all log statements made as part of this single run have the this new trace id in common

currently I do this via the somewhat janky

```java
void run() {
    String traceId = Tracers.randomId();
    Tracer.initTrace(Optional.empty(), traceId);
    MDC.put("traceId", traceId);
    // work of the scheduled task goes here
}
```

I should also probably remove the MDC when done (i.e. set it back to what it was before) and restore the traceid too, given potentially other scheduled tasks could in theory share this same scheduled executor service.

whereas with this PR I can do, I think
```java
void run() {
    Tracer.withTrace(Tracers.createTrace(Optional.empty(), () -> {
        //work of the scheduled task goes here
    });
}
```

Happy to consider other approaches - perhaps there exists something - or maybe this looks like a wrapper around a scheduled executor service, so that each scheduled call is automatically wrapped in a new trace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/http-remoting/472)
<!-- Reviewable:end -->
