### PR TITLE
Allow CHACHA20_POLY1305 ciphers

### DIFF
--- a/http-clients/src/main/java/com/palantir/remoting3/clients/CipherSuites.java
+++ b/http-clients/src/main/java/com/palantir/remoting3/clients/CipherSuites.java
@@ -21,6 +21,8 @@ public final class CipherSuites {
             "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
             "TLS_RSA_WITH_AES_256_CBC_SHA",
             "TLS_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
             "TLS_EMPTY_RENEGOTIATION_INFO_SCSV");
 
     private static final ImmutableList<String> GCM_CIPHER_SUITES = ImmutableList.of(


### PR DESCRIPTION
These will only be enabled when using a different security provider such as conscrypt, but are recommended going forward