### PR TITLE
IOException not IllegalStateException

### DIFF
--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/MultiServerRetryInterceptor.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/MultiServerRetryInterceptor.java
@@ -88,7 +88,7 @@ public final class MultiServerRetryInterceptor implements Interceptor {
                 logger.warn("Failed to send request to {}", request.url(), e);
             }
         }
-        throw new IllegalStateException("Could not connect to any of the following servers: " + urls + ". "
+        throw new IOException("Could not connect to any of the following servers: " + urls + ". "
                 + "Please check that the URIs are correct and servers are accessible.", lastException);
     }
 

--- a/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/MultiServerRetryInterceptorTest.java
+++ b/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/MultiServerRetryInterceptorTest.java
@@ -115,7 +115,7 @@ public final class MultiServerRetryInterceptorTest extends TestBase {
     }
 
     @Test
-    public void testThrowIllegalStateExceptionWhenNoServerIsAvailable() throws IOException {
+    public void testThrowIoExceptionWhenNoServerIsAvailable() throws IOException {
         serverA.shutdown();
         serverB.shutdown();
 
@@ -124,7 +124,7 @@ public final class MultiServerRetryInterceptorTest extends TestBase {
                 .get()
                 .build();
 
-        expectedException.expect(IllegalStateException.class);
+        expectedException.expect(IOException.class);
         okHttpClient.newCall(request).execute();
     }
 

--- a/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/Retrofit2ClientApiTest.java
+++ b/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/Retrofit2ClientApiTest.java
@@ -18,6 +18,7 @@ package com.palantir.remoting3.retrofit2;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -144,6 +145,14 @@ public final class Retrofit2ClientApiTest extends TestBase {
             assertThat(e.getCause()).isInstanceOf(RemoteException.class);
             assertThat(((RemoteException) e.getCause()).getError()).isEqualTo(error);
         }
+    }
+
+    @Test
+    public void connectionFailureWithCompletableFuture() {
+        service = Retrofit2Client.create(TestService.class, "agent",
+                createTestConfig("https://invalid.service.dev"));
+
+        assertThatExceptionOfType(CompletionException.class).isThrownBy(() -> service.makeFutureRequest().join());
     }
 
     private static <T> com.google.common.base.Optional<T> guavaOptional(T value) {


### PR DESCRIPTION
OkHttp interceptors are not allowed to throw IllegalStateExceptions.

The contract of an OkHttp call is...

```
   * @throws IOException if the request could not be executed due to cancellation, a connectivity
   * problem or timeout. Because networks can fail during an exchange, it is possible that the
   * remote server accepted the request before the failure.
```

which throwing an IllegalStateException in an interceptor breaks. This breaks assumptions
in OkHttp, and notably will cause callbacks to never be triggered.

I didn't notice this when I added the CompletableFuture retrofit
support (only noticed the other interceptor).

Fixes #504.