### PR TITLE
retry if http code is 307

### DIFF
--- a/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/feignimpl/FeignSerializableErrorErrorDecoder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/feignimpl/FeignSerializableErrorErrorDecoder.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HttpHeaders;
 import com.palantir.remoting3.errors.SerializableErrorToExceptionConverter;
 import feign.Response;
+import feign.RetryableException;
 import feign.codec.ErrorDecoder;
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,6 +31,10 @@ public enum FeignSerializableErrorErrorDecoder implements ErrorDecoder {
 
     @Override
     public Exception decode(String methodKey, Response response) {
+        if (response.status() == 307) {
+            return new RetryableException("Status was 307 indicating this call can be retried", null);
+        }
+
         Collection<String> contentTypes =
                 HeaderAccessUtils.caseInsensitiveGet(response.headers(), HttpHeaders.CONTENT_TYPE);
         if (contentTypes == null) {

--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientFailoverTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientFailoverTest.java
@@ -38,6 +38,18 @@ public final class JaxRsClientFailoverTest extends TestBase {
     public final MockWebServer server2 = new MockWebServer();
 
     @Test
+    public void testFailoverOn307() throws Exception {
+        server1.enqueue(new MockResponse().setResponseCode(307));
+        server2.enqueue(new MockResponse().setBody("\"foo\""));
+
+        Service proxy = JaxRsClient.create(Service.class, "agent",
+                createTestConfig(
+                        "http://localhost:" + server1.getPort(),
+                        "http://localhost:" + server2.getPort()));
+        assertThat(proxy.get(), is("foo"));
+    }
+
+    @Test
     public void testFailover() throws Exception {
         server1.shutdown();
         server2.enqueue(new MockResponse().setBody("\"foo\""));

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/MultiServerRetryInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/MultiServerRetryInterceptor.java
@@ -80,7 +80,11 @@ public final class MultiServerRetryInterceptor implements Interceptor {
             }
             request = redirectRequest(request, url);
             try {
-                return chain.proceed(request);
+                Response response = chain.proceed(request);
+                if (response.code() != 307) {
+                    // Status code 307 indicates request can be retried
+                    return response;
+                }
             } catch (SocketTimeoutException | UnknownHostException | HttpRetryException
                     | MalformedURLException | SocketException | UnknownServiceException e) {
                 lastException = e;

--- a/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/MultiServerRetryInterceptorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/MultiServerRetryInterceptorTest.java
@@ -56,6 +56,21 @@ public final class MultiServerRetryInterceptorTest {
     }
 
     @Test
+    public void testFailoverOn307() throws Exception {
+        Request request = new Request.Builder()
+                .url(urlA.newBuilder().addPathSegment("ping").build())
+                .get()
+                .build();
+
+        serverA.enqueue(new MockResponse().setResponseCode(307));
+        serverB.enqueue(new MockResponse().setBody("pong"));
+
+        Call call = okHttpClient.newCall(request);
+
+        assertThat(call.execute().body().string()).isEqualTo("pong");
+    }
+
+    @Test
     public void testDoNotHitSecondServerWhenFirstServerIsAvailable() throws IOException, InterruptedException {
         Request request = new Request.Builder()
                 .url(urlA.newBuilder().addPathSegment("ping").build())


### PR DESCRIPTION
As part of an internal spec, http code 307 should be retried.
This PR contains the tests and a minimal implementation of this part of the spec.