### PR TITLE
Disable Feign retry logic

### DIFF
--- a/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -41,6 +41,7 @@ import feign.InputStreamDelegateEncoder;
 import feign.Java8OptionalAwareDecoder;
 import feign.Logger;
 import feign.Request;
+import feign.Retryer;
 import feign.TextDelegateDecoder;
 import feign.TextDelegateEncoder;
 import feign.codec.Decoder;
@@ -98,6 +99,7 @@ abstract class AbstractFeignJaxRsClientBuilder {
                 .client(createOkHttpClient(userAgent, config.uris()))
                 .options(createRequestOptions())
                 .logLevel(Logger.Level.NONE)  // we use OkHttp interceptors for logging. (note that NONE is the default)
+                .retryer(new Retryer.Default(0, 0, 1))  // use OkHttp retry mechanism only
                 .target(serviceClass, primaryUri);
     }
 


### PR DESCRIPTION
This is a follow-up to #510: We implement retry logic in OkHttp and disable all retrying
in Feign. In particular, without this change Feign would treat all IOExceptions thrown by OkHttp
as retryable.