### PR TITLE
support wrapping runnables (for traces)

### DIFF
--- a/tracing/src/main/java/com/palantir/remoting3/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/remoting3/tracing/Tracers.java
@@ -99,6 +99,23 @@ public final class Tracers {
         };
     }
 
+    /**
+     * Like {@link #wrapWithNewTrace(Callable)}, but for Runnables.
+     */
+    public static Runnable wrapWithNewTrace(Runnable delegate) {
+        return () -> {
+            // clear the existing trace and keep it around for restoration when we're done
+            Trace originalTrace = Tracer.getAndClearTrace();
+
+            try {
+                Tracer.initTrace(Optional.empty(), Tracers.randomId());
+                delegate.run();
+            } finally {
+                // restore the trace
+                Tracer.setTrace(originalTrace);
+            }
+        };
+    }
 
     /**
      * Wraps a given callable such that its execution operates with the {@link Trace thread-local Trace} of the thread


### PR DESCRIPTION
implement the equivalent of `wrapWithNewTrace(Callable<>)` for `Runnable`s