### PR TITLE
Basic fix for tracing data redaction issues

### DIFF
--- a/tracing-okhttp3/src/main/java/com/palantir/remoting3/tracing/okhttp3/OkhttpTraceInterceptor.java
+++ b/tracing-okhttp3/src/main/java/com/palantir/remoting3/tracing/okhttp3/OkhttpTraceInterceptor.java
@@ -32,7 +32,7 @@ public enum OkhttpTraceInterceptor implements Interceptor {
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
-        OpenSpan span = Tracer.startSpan(request.method() + " " + request.url(), SpanType.CLIENT_OUTGOING);
+        OpenSpan span = Tracer.startSpan("remote call to redacted url", SpanType.CLIENT_OUTGOING);
         Request.Builder tracedRequest = request.newBuilder()
                 .addHeader(TraceHttpHeaders.TRACE_ID, Tracer.getTraceId())
                 .addHeader(TraceHttpHeaders.SPAN_ID, span.getSpanId())

--- a/tracing-okhttp3/src/test/java/com/palantir/remoting3/tracing/okhttp3/OkhttpTraceInterceptorTest.java
+++ b/tracing-okhttp3/src/test/java/com/palantir/remoting3/tracing/okhttp3/OkhttpTraceInterceptorTest.java
@@ -145,7 +145,6 @@ public final class OkhttpTraceInterceptorTest {
         OkhttpTraceInterceptor.INSTANCE.intercept(chain);
         verify(observer).consume(spanCaptor.capture());
         Span okhttpSpan = spanCaptor.getValue();
-        assertThat(okhttpSpan.getOperation()).isEqualTo("GET http://localhost/");
         assertThat(okhttpSpan).isNotEqualTo(outerSpan);
     }
 


### PR DESCRIPTION
Given that the name is unsafe here, and the name will be correct in the spans on the server, we might get away with just omitting it here?