### PR TITLE
Remove the client span creation

### DIFF
--- a/tracing-okhttp3/src/main/java/com/palantir/remoting3/tracing/okhttp3/OkhttpTraceInterceptor.java
+++ b/tracing-okhttp3/src/main/java/com/palantir/remoting3/tracing/okhttp3/OkhttpTraceInterceptor.java
@@ -33,12 +33,6 @@ public enum OkhttpTraceInterceptor implements Interceptor {
         Tracer.getEnrichmentHeaders().entrySet().stream().forEach(entrySet -> {
             tracedRequest.addHeader(entrySet.getKey(), entrySet.getValue());
         });
-        Response response;
-        try {
-            response = chain.proceed(tracedRequest.build());
-        } finally {
-            Tracer.completeSpan();
-        }
-        return response;
+        return chain.proceed(tracedRequest.build());
     }
 }


### PR DESCRIPTION
- Happy to close this if we want a more full-fledged solution as mentioned at the bottom of https://github.com/palantir/http-remoting/pull/575
- However curious to hear thoughts on instead of trying to determine the unsubstituted path at the interceptor layer, just no longer create a span on out going client requests
- We will still propagate the tracing headers for the current open span if it exists
- On the incoming server side, determine the unsubstituted path. I believe that currently it will still be an unsafe span name that has substituted path params
- Main thought here is that instead of creating a span for rpc requests on both the client and the incoming server, just create it at the incoming service. There is a very good change that an open span will already exist on the client service. 
- Lose some fidelity in being able to cleanly view network overhead between rpc calls and also lose originating service on rpc call if there is not a currently open span
- More than happy to close this pr if this is the wrong approach, however would still want to salvage some changes to TraceEnrichingFilter.java to close out https://github.com/palantir/http-remoting/issues/566 . Did not fix tests