### PR TITLE
A few perf improvments for Tracing

### DIFF
--- a/tracing/src/main/java/com/palantir/remoting3/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/remoting3/tracing/Tracer.java
@@ -18,8 +18,6 @@ package com.palantir.remoting3.tracing;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.palantir.remoting.api.tracing.OpenSpan;
 import com.palantir.remoting.api.tracing.Span;
 import com.palantir.remoting.api.tracing.SpanObserver;

--- a/tracing/src/main/java/com/palantir/remoting3/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/remoting3/tracing/Tracer.java
@@ -50,11 +50,12 @@ public final class Tracer {
         return trace;
     });
 
+    // Only access in a class-synchronized fashion
     private static final Map<String, SpanObserver> observers = new HashMap<>();
-    private static List<SpanObserver> observersList = ImmutableList.of();
+    private static volatile List<SpanObserver> observersList = ImmutableList.of();
 
     // Thread-safe since stateless
-    private static TraceSampler sampler = AlwaysSampler.INSTANCE;
+    private static volatile TraceSampler sampler = AlwaysSampler.INSTANCE;
 
     /**
      * Creates a new trace, but does not set it as the current trace. The new trace is {@link Trace#isObservable

--- a/tracing/src/main/java/com/palantir/remoting3/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/remoting3/tracing/Tracer.java
@@ -208,8 +208,7 @@ public final class Tracer {
      * observer if it existed, or null otherwise.
      */
     public static synchronized SpanObserver unsubscribe(String name) {
-        Map<String, SpanObserver> newObservers = new HashMap<>(observers);
-        SpanObserver removedObserver = newObservers.remove(name);
+        SpanObserver removedObserver = observers.remove(name);
         computeObserversList();
         return removedObserver;
     }

--- a/tracing/src/main/java/com/palantir/remoting3/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/remoting3/tracing/Tracers.java
@@ -16,7 +16,6 @@
 
 package com.palantir.remoting3.tracing;
 
-import com.google.common.base.Strings;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -27,6 +26,8 @@ import java.util.concurrent.ThreadLocalRandom;
 public final class Tracers {
     /** The key under which trace ids are inserted into SLF4J {@link org.slf4j.MDC MDCs}. */
     public static final String TRACE_ID_KEY = "traceId";
+    private static final char[] HEX_DIGITS =
+            {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
     private Tracers() {}
 
@@ -36,7 +37,24 @@ public final class Tracers {
     }
 
     static String longToPaddedHex(long number) {
-        return Strings.padStart(Long.toHexString(number), 16, '0');
+        char[] data = new char[16];
+        data[0] = HEX_DIGITS[(int) ((number >> 60) & 0xF)];
+        data[1] = HEX_DIGITS[(int) ((number >> 56) & 0xF)];
+        data[2] = HEX_DIGITS[(int) ((number >> 52) & 0xF)];
+        data[3] = HEX_DIGITS[(int) ((number >> 48) & 0xF)];
+        data[4] = HEX_DIGITS[(int) ((number >> 44) & 0xF)];
+        data[5] = HEX_DIGITS[(int) ((number >> 40) & 0xF)];
+        data[6] = HEX_DIGITS[(int) ((number >> 36) & 0xF)];
+        data[7] = HEX_DIGITS[(int) ((number >> 32) & 0xF)];
+        data[8] = HEX_DIGITS[(int) ((number >> 28) & 0xF)];
+        data[9] = HEX_DIGITS[(int) ((number >> 24) & 0xF)];
+        data[10] = HEX_DIGITS[(int) ((number >> 20) & 0xF)];
+        data[11] = HEX_DIGITS[(int) ((number >> 16) & 0xF)];
+        data[12] = HEX_DIGITS[(int) ((number >> 12) & 0xF)];
+        data[13] = HEX_DIGITS[(int) ((number >> 8) & 0xF)];
+        data[14] = HEX_DIGITS[(int) ((number >> 4) & 0xF)];
+        data[15] = HEX_DIGITS[(int) ((number >> 0) & 0xF)];
+        return new String(data);
     }
 
     /**

--- a/tracing/src/main/java/com/palantir/remoting3/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/remoting3/tracing/Tracers.java
@@ -36,6 +36,11 @@ public final class Tracers {
         return longToPaddedHex(ThreadLocalRandom.current().nextLong());
     }
 
+    /**
+     * Convert a long to a big-endian hex string. Hand-coded implementation is more efficient than
+     * Strings.pad(Long.toHexString) because that code has to deal with mixed length longs, and then mixed length
+     * amounts of padding - we want to minimise the overhead of tracing.
+     */
     static String longToPaddedHex(long number) {
         char[] data = new char[16];
         data[0] = HEX_DIGITS[(int) ((number >> 60) & 0xF)];

--- a/tracing/src/test/java/com/palantir/remoting3/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/remoting3/tracing/TracersTest.java
@@ -218,7 +218,6 @@ public final class TracersTest {
 
     @Test
     public void testTraceIdGeneration() throws Exception {
-        assertThat(Tracers.randomId()).hasSize(16); // fails with p=1/16 if generated string is not padded
         assertThat(Tracers.longToPaddedHex(0)).isEqualTo("0000000000000000");
         assertThat(Tracers.longToPaddedHex(42)).isEqualTo("000000000000002a");
         assertThat(Tracers.longToPaddedHex(-42)).isEqualTo("ffffffffffffffd6");

--- a/tracing/src/test/java/com/palantir/remoting3/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/remoting3/tracing/TracersTest.java
@@ -218,6 +218,7 @@ public final class TracersTest {
 
     @Test
     public void testTraceIdGeneration() throws Exception {
+        assertThat(Tracers.randomId()).hasSize(16); // fails with p=1/16 if generated string is not padded
         assertThat(Tracers.longToPaddedHex(0)).isEqualTo("0000000000000000");
         assertThat(Tracers.longToPaddedHex(42)).isEqualTo("000000000000002a");
         assertThat(Tracers.longToPaddedHex(-42)).isEqualTo("ffffffffffffffd6");


### PR DESCRIPTION
I want Tritium to trace by default, but the overhead seemed a little excessive (700ns per method invocation).

Here, we have 3 improvements:

First, don't iterate over a hashmap.

Second, handcoded 'toString' method.

Third, 'completeTraceFast' which avoids a bunch of computation if I'm
not going to use it (e.g. a System.nanoTime call which is 100 cycles
plus).

For changes (with the Tritium benchmark):

Unchanged: 711ns
With iterating over the list not the hashmap: 666ns
With the custom toHexString: 588ns

With the shortcircuit and a 1% sampling collector:

After all changes but shortcircuit: 256ns
With shortcircuit only: 220ns
After all changes: 198ns