### PR TITLE
Handle interrupts preserve exception API

### DIFF
--- a/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -82,7 +82,8 @@ abstract class AbstractFeignJaxRsClientBuilder {
                                                 new JacksonEncoder(objectMapper)))))
                 .decoder(createDecoder(objectMapper, cborObjectMapper))
                 .requestInterceptor(PathTemplateHeaderRewriter.INSTANCE)
-                .client(new OkHttpClient(OkHttpClients.create(config, userAgent, serviceClass)))
+                .client(new RemoteIoExceptionClient(
+                        new OkHttpClient(OkHttpClients.create(config, userAgent, serviceClass))))
                 .options(createRequestOptions())
                 .logLevel(Logger.Level.NONE)  // we use OkHttp interceptors for logging. (note that NONE is the default)
                 .retryer(new Retryer.Default(0, 0, 1))  // use OkHttp retry mechanism only

--- a/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/RemoteIoExceptionClient.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/RemoteIoExceptionClient.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.jaxrs;
+
+import com.palantir.remoting3.okhttp.RemoteIoException;
+import feign.Client;
+import feign.Request;
+import feign.Response;
+import java.io.IOException;
+
+/**
+ * This client's sole purpose is to turn our special {@link RemoteIoException} into a RuntimeException.
+ * <p>
+ * It is necessary because okhttp only propagates IOExceptions nicely through all its async futures {@see
+ * okhttp3.RealCall}, but unfortunately feign turns IOExceptions into ugly FeignExceptions in its {@link
+ * feign.SynchronousMethodHandler}.
+ */
+public final class RemoteIoExceptionClient implements Client {
+    private final Client delegate;
+
+    public RemoteIoExceptionClient(Client delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Response execute(Request request, Request.Options options) throws IOException {
+        try {
+            return delegate.execute(request, options);
+        } catch (RemoteIoException e) {
+            throw e.getRuntimeExceptionCause();
+        }
+    }
+}

--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/feignimpl/GuavaOptionalAwareDecoderTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/feignimpl/GuavaOptionalAwareDecoderTest.java
@@ -34,6 +34,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
 
 public final class GuavaOptionalAwareDecoderTest extends TestBase {
 
@@ -43,6 +44,9 @@ public final class GuavaOptionalAwareDecoderTest extends TestBase {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    @Rule
+    public Timeout timeout = Timeout.millis(2000);
 
     private GuavaTestServer.TestService service;
 

--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/feignimpl/Java8OptionalAwareDecoderTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/feignimpl/Java8OptionalAwareDecoderTest.java
@@ -34,6 +34,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
 
 public final class Java8OptionalAwareDecoderTest extends TestBase {
 
@@ -43,6 +44,9 @@ public final class Java8OptionalAwareDecoderTest extends TestBase {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    @Rule
+    public Timeout timeout = Timeout.millis(2000);
 
     private Java8TestServer.TestService service;
 

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemoteIoException.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemoteIoException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.okhttp;
+
+import java.io.IOException;
+
+/**
+ * We want RuntimeExceptions eventually, but we have to wrap them up in an IOException to convince the {@link
+ * okhttp3.RealCall} method to propagate them nicely.
+ * <p>
+ * They're unwrapped right at the top of the stack by our RemoteIOExceptionClient.
+ */
+public final class RemoteIoException extends IOException {
+    public RemoteIoException(RuntimeException runtimeException) {
+        super(runtimeException);
+    }
+
+    public RuntimeException getRuntimeExceptionCause() {
+        return (RuntimeException) getCause();
+    }
+}

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/SerializableErrorInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/SerializableErrorInterceptor.java
@@ -40,7 +40,9 @@ public enum SerializableErrorInterceptor implements Interceptor {
         if (!(response.isSuccessful() || response.code() == 101)) {
             Collection<String> contentTypes = response.headers("Content-Type");
             InputStream body = response.body().byteStream();
-            throw SerializableErrorToExceptionConverter.getException(contentTypes, response.code(), body);
+            RuntimeException runtimeException = SerializableErrorToExceptionConverter.getException(
+                    contentTypes, response.code(), body);
+            throw new RemoteIoException(runtimeException);
         }
 
         return response;


### PR DESCRIPTION
This is just one possible approach to allow @CRogers's "Cancel requests when thread is interrupted" PR (#587) to maintain http-remoting's current API.