### PR TITLE
Retry on other nodes with 503s

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/AsyncQosIoExceptionHandler.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/AsyncQosIoExceptionHandler.java
@@ -17,6 +17,7 @@
 package com.palantir.remoting3.okhttp;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -31,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
+import okhttp3.Request;
 import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,15 +49,22 @@ class AsyncQosIoExceptionHandler implements QosIoExceptionHandler {
     private final ListeningExecutorService executorService;
     private final BackoffStrategy backoffStrategy;
 
+    private final MultiServerRequestCreator requestCreator;
+    private final Call.Factory callFactory;
+
     AsyncQosIoExceptionHandler(
             ScheduledExecutorService scheduledExecutorService,
             ExecutorService executorService,
-            BackoffStrategy backoffStrategy) {
+            BackoffStrategy backoffStrategy,
+            MultiServerRequestCreator requestCreator,
+            Call.Factory callFactory) {
         Preconditions.checkArgument(scheduledExecutorService != executorService,
                 "Almost certainly you want these to be different - need fixed pool vs cached.");
         this.scheduledExecutorService = MoreExecutors.listeningDecorator(scheduledExecutorService);
         this.executorService = MoreExecutors.listeningDecorator(executorService);
         this.backoffStrategy = backoffStrategy;
+        this.requestCreator = requestCreator;
+        this.callFactory = callFactory;
     }
 
     @Override
@@ -72,7 +81,7 @@ class AsyncQosIoExceptionHandler implements QosIoExceptionHandler {
                     return Futures.immediateFailedFuture(qosIoException);
                 } else {
                     log.debug("Rescheduling call after backoff", SafeArg.of("backoffMillis", backoff.get().toMillis()));
-                    return retry(call, backoff.get());
+                    return retry(call::clone, backoff.get());
                 }
             }
 
@@ -89,19 +98,30 @@ class AsyncQosIoExceptionHandler implements QosIoExceptionHandler {
                 if (!backoff.isPresent()) {
                     log.debug("No backoff advertised, failing call");
                     return Futures.immediateFailedFuture(qosIoException);
-                } else {
-                    log.debug("Rescheduling call after backoff", SafeArg.of("backoffMillis", backoff.get().toMillis()));
-                    return retry(call, backoff.get());
                 }
+
+                Request newRequest;
+                try {
+                    newRequest = requestCreator.getNextRequest(call.request());
+                } catch (IOException e) {
+                    log.debug("Could not find a suitable subsequent server, failing call");
+                    return Futures.immediateFailedFuture(qosIoException);
+                }
+
+                log.debug("Rescheduling call on a new host, after backoff",
+                        SafeArg.of("backoffMillis", backoff.get().toMillis()),
+                        SafeArg.of("host", newRequest.url().host())); // Must be host, url itself is unsafe
+                return retry(() -> callFactory.newCall(newRequest), backoff.get());
             }
         });
     }
 
     // Have to schedule the retry on a different thread to avoid deadlocking a fixed size thread pool.
-    private ListenableFuture<Response> retry(QosIoExceptionAwareCall call, Duration backoff) {
+    private ListenableFuture<Response> retry(Supplier<Call> callSupplier, Duration backoff) {
         ListenableFuture<ListenableFuture<Response>> result =
                 scheduledExecutorService.schedule(
-                        () -> executorService.submit(() -> call.clone().execute()),
+                        () -> executorService.submit(
+                                () -> new QosIoExceptionAwareCall(callSupplier.get(), this).execute()),
                         backoff.toMillis(), TimeUnit.MILLISECONDS);
         return Futures.dereference(result);
     }

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/AsyncQosIoExceptionHandlerFactory.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/AsyncQosIoExceptionHandlerFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.okhttp;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.remoting3.clients.ClientConfiguration;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+import okhttp3.Call;
+
+/**
+ * Constructs instances of {@link AsyncQosIoExceptionHandler} given a {@link okhttp3.Call.Factory}, which is often
+ * provided at a substantially later time (e.g. after constructing an {@link okhttp3.OkHttpClient}) than the
+ * other parameters needed for construction.
+ */
+final class AsyncQosIoExceptionHandlerFactory implements QosIoExceptionHandlerProvider {
+    private final ScheduledExecutorService scheduledExecutorService;
+    private final ExecutorService executorService;
+    private final Supplier<BackoffStrategy> backoffStrategy;
+    private final MultiServerRequestCreator requestCreator;
+
+    @VisibleForTesting
+    AsyncQosIoExceptionHandlerFactory(
+            ScheduledExecutorService scheduledExecutorService,
+            ExecutorService executorService,
+            Supplier<BackoffStrategy> backoffStrategy,
+            MultiServerRequestCreator requestCreator) {
+        this.scheduledExecutorService = scheduledExecutorService;
+        this.executorService = executorService;
+        this.backoffStrategy = backoffStrategy;
+        this.requestCreator = requestCreator;
+    }
+
+    AsyncQosIoExceptionHandlerFactory(
+            ScheduledExecutorService scheduledExecutorService,
+            ExecutorService executorService,
+            ClientConfiguration config) {
+        this(scheduledExecutorService,
+                executorService,
+                () -> new ExponentialBackoff(config.maxNumRetries(), config.backoffSlotSize(), new Random()),
+                new MultiServerRequestCreator(UrlSelectorImpl.create(config.uris(), true)));
+    }
+
+    @Override
+    public QosIoExceptionHandler createHandler(Call.Factory callFactory) {
+        return new AsyncQosIoExceptionHandler(
+                scheduledExecutorService, executorService, backoffStrategy.get(), requestCreator, callFactory);
+    }
+}

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/MultiServerRequestCreator.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/MultiServerRequestCreator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.okhttp;
+
+import java.io.IOException;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class MultiServerRequestCreator {
+    private static final Logger logger = LoggerFactory.getLogger(MultiServerRequestCreator.class);
+
+    private final UrlSelector urls;
+
+    public MultiServerRequestCreator(UrlSelector urls) {
+        this.urls = urls;
+    }
+
+    public Request getNextRequest(Request originalRequest) throws IOException {
+        HttpUrl originalUrl = originalRequest.url();
+        HttpUrl nextUrl = urls.redirectToNext(originalUrl).orElseThrow(() -> new IOException(
+                "Failed to determine suitable target URL for request URL " + originalUrl
+                        + " amongst known base URLs: " + urls.getBaseUrls()));
+        logger.debug("Creating a new request that redirects from {} to {}", originalUrl, nextUrl);
+        return originalRequest.newBuilder()
+                .url(nextUrl)
+                // Request.this.tag field by default points to request itself if it was not set in RequestBuilder.
+                // We don't want to reference old request in new one - that is why we need to reset tag to null.
+                .tag(originalRequest.tag().equals(originalRequest) ? null : originalRequest.tag())
+                .build();
+    }
+}

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/MultiServerRequestCreator.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/MultiServerRequestCreator.java
@@ -27,11 +27,11 @@ class MultiServerRequestCreator {
 
     private final UrlSelector urls;
 
-    public MultiServerRequestCreator(UrlSelector urls) {
+    MultiServerRequestCreator(UrlSelector urls) {
         this.urls = urls;
     }
 
-    public Request getNextRequest(Request originalRequest) throws IOException {
+    Request getNextRequest(Request originalRequest) throws IOException {
         HttpUrl originalUrl = originalRequest.url();
         HttpUrl nextUrl = urls.redirectToNext(originalUrl).orElseThrow(() -> new IOException(
                 "Failed to determine suitable target URL for request URL " + originalUrl

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
@@ -140,7 +140,8 @@ public final class OkHttpClients {
         client.dispatcher(createDispatcher());
 
         OkHttpClient okHttpClient = client.build();
-        return new QosIoExceptionAwareOkHttpClient(okHttpClient, () -> handlerProvider.createHandler(okHttpClient));
+        return new QosIoExceptionAwareOkHttpClient(okHttpClient, () -> handlerProvider.createHandler(
+                urls, okHttpClient));
     }
 
     private static ImmutableList<ConnectionSpec> createConnectionSpecs(boolean enableGcmCipherSuites) {

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/QosIoExceptionHandler.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/QosIoExceptionHandler.java
@@ -38,8 +38,8 @@ interface QosIoExceptionHandler {
      *          OkHttp {@link Interceptor}s could wait-and-retry upon observing 429 or 503, but this would happen on the
      *          same thread. Since all http-remoting clients (in a JVM) share the same OkHttp thread pool, only a few
      *          backed up requests would have the potential to stall all outgoing RPC. The {@link QosIoExceptionHandler}
-     *          approach taken here circumnavigates this pitful by re-scheduling call re-execution instead of performing
-     *          thread-blocking sleep.
+     *          approach taken here circumnavigates this pitfall by re-scheduling call re-execution instead of
+     *          performing thread-blocking sleep.
      *      </li>
      * </ul>
      * <p>

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/QosIoExceptionHandlerProvider.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/QosIoExceptionHandlerProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.okhttp;
+
+import okhttp3.Call;
+
+interface QosIoExceptionHandlerProvider {
+    QosIoExceptionHandler createHandler(Call.Factory factory);
+}

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/QosIoExceptionHandlerProvider.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/QosIoExceptionHandlerProvider.java
@@ -19,5 +19,5 @@ package com.palantir.remoting3.okhttp;
 import okhttp3.Call;
 
 interface QosIoExceptionHandlerProvider {
-    QosIoExceptionHandler createHandler(Call.Factory factory);
+    QosIoExceptionHandler createHandler(UrlSelector urlSelector, Call.Factory factory);
 }

--- a/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/OkHttpClientsTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.net.HttpHeaders;
 import com.google.common.util.concurrent.Futures;
 import com.palantir.remoting.api.errors.QosException;
@@ -36,9 +37,11 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
@@ -70,15 +73,18 @@ public final class OkHttpClientsTest extends TestBase {
     private String url2;
     private OkHttpClient mockHandlerClient;
 
+    private MultiServerRequestCreator requestCreator;
+
     @Before
     public void before() {
         url = "http://localhost:" + server.getPort();
         url2 = "http://localhost:" + server2.getPort();
-        mockHandlerClient = OkHttpClients.withCustomQosHandler(
+        mockHandlerClient = OkHttpClients.withCustomQosHandlerProvider(
                 createTestConfig(url),
                 "test",
                 OkHttpClientsTest.class,
-                () -> handler);
+                unused -> handler);
+        requestCreator = new MultiServerRequestCreator(UrlSelectorImpl.create(ImmutableList.of(url), false));
     }
 
     @Test
@@ -119,25 +125,21 @@ public final class OkHttpClientsTest extends TestBase {
         int threadPoolSize = 5;
 
         AtomicLong counter = new AtomicLong(maxRetries);
-        QosIoExceptionHandler retryingHandler = new AsyncQosIoExceptionHandler(
-                Executors.newScheduledThreadPool(threadPoolSize),
-                Executors.newCachedThreadPool(),
-                () -> {
-                    if (counter.decrementAndGet() <= 0) {
-                        return Optional.empty();
-                    }
-                    return Optional.of(Duration.ofMillis(1));
-                });
+        Supplier<BackoffStrategy> countingBackoffStrategy = () -> () -> {
+            if (counter.decrementAndGet() <= 0) {
+                return Optional.empty();
+            }
+            return Optional.of(Duration.ofMillis(1));
+        };
 
         for (int i = 0; i <= maxRetries; i++) {
             server.enqueue(new MockResponse().setResponseCode(503));
         }
 
-        OkHttpClient client = OkHttpClients.withCustomQosHandler(
-                createTestConfig(url),
-                "test",
-                OkHttpClientsTest.class,
-                () -> retryingHandler);
+        OkHttpClient client = createClientWithRetryingQosHandler(
+                threadPoolSize,
+                Executors.newCachedThreadPool(),
+                countingBackoffStrategy);
 
         Call call = client.newCall(new Request.Builder().url(url).build());
         assertThatThrownBy(call::execute).isInstanceOf(QosIoException.class);
@@ -145,13 +147,6 @@ public final class OkHttpClientsTest extends TestBase {
 
     @Test
     public void throwsProperRemoteExceptionAfterRetry() throws Exception {
-        QosIoExceptionHandler retryingHandler = new AsyncQosIoExceptionHandler(
-                Executors.newScheduledThreadPool(5),
-                Executors.newSingleThreadExecutor(),
-                () -> {
-                    return Optional.of(Duration.ofMillis(1));
-                });
-
         // first we get a 503
         server.enqueue(new MockResponse().setResponseCode(503));
 
@@ -163,11 +158,10 @@ public final class OkHttpClientsTest extends TestBase {
                 .setResponseCode(400);
         server.enqueue(mockResponse);
 
-        OkHttpClient client = OkHttpClients.withCustomQosHandler(
-                createTestConfig(url),
-                "test",
-                OkHttpClientsTest.class,
-                () -> retryingHandler);
+        OkHttpClient client = createClientWithRetryingQosHandler(
+                5,
+                Executors.newSingleThreadExecutor(),
+                () -> () -> Optional.of(Duration.ofMillis(1)));
 
         Call call = client.newCall(new Request.Builder().url(url).build());
         assertThatThrownBy(call::execute).isInstanceOf(RemoteException.class);
@@ -321,5 +315,21 @@ public final class OkHttpClientsTest extends TestBase {
                 ClientConfiguration.builder().from(createTestConfig(url)).maxNumRetries(maxNumRetries).build(),
                 "test",
                 OkHttpClientsTest.class);
+    }
+
+    private OkHttpClient createClientWithRetryingQosHandler(
+            int threadPoolSize,
+            ExecutorService dispatcherExecutorService,
+            Supplier<BackoffStrategy> backoffStrategy) {
+        AsyncQosIoExceptionHandlerFactory retryingHandlerFactory = new AsyncQosIoExceptionHandlerFactory(
+                Executors.newScheduledThreadPool(threadPoolSize),
+                dispatcherExecutorService,
+                backoffStrategy,
+                requestCreator);
+        return OkHttpClients.withCustomQosHandlerProvider(
+                createTestConfig(url),
+                "test",
+                OkHttpClientsTest.class,
+                retryingHandlerFactory);
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -368,7 +368,7 @@ http-remoting clients (both Retrofit2 and JaxRs) handle the above error codes an
 * `throttle`: reschedule the request with a delay: either the indicated `Retry-After` period, or a configured
   exponential backoff
 * `retryOther`: retry the request against the indicated service node; all request parameters and headers are maintained
-* `unavailable`: retry the same host after a configurable exponential delay
+* `unavailable`: retry against a different node after a configurable exponential delay, as described below.
 
 Additionally, connection errors (e.g., `connection refused` or DNS errors) yield a retry against a different node of the
 service. Retries pick a target host by cycling through the list of URLs configured for a Service (see


### PR DESCRIPTION
This PR addresses #585 by retrying on other nodes when receiving a 503.

Main concerns:
* I equated "random node" in the discussion on 585 with `UrlSelector.redirectToNext()` which is in an undefined order according to the interface (though it's not in the readme nor in practice). Is this sufficient?
* There were some machinations involved in ensuring that the `UrlSelector` used by the handler and the other filters used by a given okhttp client were the same. Was this actually necessary?
* I don't really like the circular-ish dependency this creates between the `QosIo...Client` and the handler (which needs to know about the Client so it can create different `Call`s), but didn't see a much better way here.
* There isn't quite an analogue to AtlasDB's "fast failover" yet, where we speed through all nodes - we still follow the backoff strategy. Given that AtlasDB TimeLock often is run in 3 or 5 node setups, I think this is fine for now, but if work on GraphLock or other scalability work goes ahead we might need to think of a different solution. I'm separately tracking https://github.com/palantir/atlasdb/issues/2591 for that, though.
* I ran `./gradlew check`, is there something else I should do to verify things work?