### PR TITLE
Better defaults for maxNumRetries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -377,7 +377,10 @@ a `retryOther`/308 redirect, then any subsequent calls will be made against that
 a DNS error and the retried call succeeds against the URL from the list, then subsequent calls are made aginst that URL.
 
 The number of retries for `503` and connection errors can be configured via `ClientConfiguration#maxNumRetries` or
-`ServiceConfiguration#maxNumRetries`, defaulting to the number of URIs provided in `#uris`.
+`ServiceConfiguration#maxNumRetries`. A default is set based on the number of URIs provided in `#uris`: 
+* 3 when number of URIs is less than 3
+* equal to number of URIs when number of URIs is between 3 and 10
+* 10 when number of URIs is greater than 10
 
 # License
 This repository is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
The motivation is to have more number of retries when there's just 1 uri and also limit the maximum number of retries in case there's a lot of uris.