### PR TITLE
Re-apply "Enable wrapping a ScheduledExecutorService with a new trace"

### DIFF
--- a/tracing/src/main/java/com/palantir/remoting3/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/remoting3/tracing/Tracers.java
@@ -77,7 +77,9 @@ public final class Tracers {
 
     /**
      * Wraps the provided scheduled executor service to make submitted tasks traceable, see {@link
-     * #wrap(ScheduledExecutorService)}.
+     * #wrap(ScheduledExecutorService)}. This method should not be used to wrap a ScheduledExecutorService that has
+     * already been {@link #wrapWithNewTrace(ScheduledExecutorService) wrapped with new trace}. If this is done, a new
+     * trace will be generated for each execution, effectively bypassing the intent of this method.
      */
     public static ScheduledExecutorService wrap(ScheduledExecutorService executorService) {
         return new WrappingScheduledExecutorService(executorService) {
@@ -99,6 +101,22 @@ public final class Tracers {
     /** Like {@link #wrap(Callable)}, but for Runnables. */
     public static Runnable wrap(Runnable delegate) {
         return new TracingAwareRunnable(delegate);
+    }
+
+    /**
+     * Wraps the provided scheduled executor service to make submitted tasks traceable with a fresh {@link Trace trace}
+     * for each execution, see {@link #wrapWithNewTrace(ScheduledExecutorService)}. This method should not be used to
+     * wrap a ScheduledExecutorService that has already been {@link #wrap(ScheduledExecutorService) wrapped}. If this is
+     * done, a new trace will be generated for each execution, effectively bypassing the intent of the previous
+     * wrapping.
+     */
+    public static ScheduledExecutorService wrapWithNewTrace(ScheduledExecutorService executorService) {
+        return new WrappingScheduledExecutorService(executorService) {
+            @Override
+            protected <T> Callable<T> wrapTask(Callable<T> callable) {
+                return wrapWithNewTrace(callable);
+            }
+        };
     }
 
     /**

--- a/tracing/src/test/java/com/palantir/remoting3/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/remoting3/tracing/TracersTest.java
@@ -21,7 +21,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.Lists;
 import com.palantir.remoting.api.tracing.OpenSpan;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -73,6 +75,32 @@ public final class TracersTest {
         Tracer.startSpan("baz");
         wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
         wrappedService.schedule(traceExpectingRunnable(), 0, TimeUnit.SECONDS).get();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+    }
+
+    @Test
+    public void testScheduledExecutorServiceWrapsCallablesWithNewTraces() throws Exception {
+        ScheduledExecutorService wrappedService =
+                Tracers.wrapWithNewTrace(Executors.newSingleThreadScheduledExecutor());
+
+        Callable<Void> callable = newTraceExpectingCallable();
+        Runnable runnable = newTraceExpectingRunnable();
+
+        // Empty trace
+        wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
+
+        wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
+
+        // Non-empty trace
+        Tracer.startSpan("foo");
+        Tracer.startSpan("bar");
+        Tracer.startSpan("baz");
+        wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
         Tracer.completeSpan();
         Tracer.completeSpan();
         Tracer.completeSpan();
@@ -223,6 +251,39 @@ public final class TracersTest {
         assertThat(Tracers.longToPaddedHex(42)).isEqualTo("000000000000002a");
         assertThat(Tracers.longToPaddedHex(-42)).isEqualTo("ffffffffffffffd6");
         assertThat(Tracers.longToPaddedHex(123456789L)).isEqualTo("00000000075bcd15");
+    }
+
+    private static Callable<Void> newTraceExpectingCallable() {
+        final Set<String> seenTraceIds = new HashSet<>();
+        seenTraceIds.add(Tracer.getTraceId());
+
+        return new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                String newTraceId = Tracer.getTraceId();
+
+                assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(newTraceId);
+                assertThat(seenTraceIds).doesNotContain(newTraceId);
+                seenTraceIds.add(newTraceId);
+                return null;
+            }
+        };
+    }
+
+    private static Runnable newTraceExpectingRunnable() {
+        final Set<String> seenTraceIds = new HashSet<>();
+        seenTraceIds.add(Tracer.getTraceId());
+
+        return new Runnable() {
+            @Override
+            public void run() {
+                String newTraceId = Tracer.getTraceId();
+
+                assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(newTraceId);
+                assertThat(seenTraceIds).doesNotContain(newTraceId);
+                seenTraceIds.add(newTraceId);
+            }
+        };
     }
 
     private static Callable<Void> traceExpectingCallable() {


### PR DESCRIPTION
Unintentionally reverted https://github.com/palantir/http-remoting/pull/632 as part of the "make develop releasable" effort (https://github.com/palantir/http-remoting/issues/646) and moved to the `release/okhttp-refactor` branch, when it's not actually relevant to the okhttp changes.  Putting this back on develop.



@j-baker 