### PR TITLE
Proper infinite timeouts

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
@@ -159,9 +159,18 @@ public final class OkHttpClients {
         );
     }
 
+    /**
+     * Treat {@link Duration#ZERO} as infinity to match okhttp3.
+     */
     @VisibleForTesting
     static Duration largestOf(Duration... durations) {
-        return Arrays.stream(durations).max(Duration::compareTo).orElse(Duration.ZERO);
+        if (Arrays.stream(durations).anyMatch(Duration::isZero)) {
+            return Duration.ZERO;
+        }
+
+        return Arrays.stream(durations)
+                .max(Duration::compareTo)
+                .orElseThrow(() -> new IllegalArgumentException("largestOf must be called with at least one argument"));
     }
 
     /**

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpCall.java
@@ -100,7 +100,10 @@ final class RemotingOkHttpCall extends ForwardingCall {
         });
 
         try {
-            return future.get(syncCallTimeout.toMillis(), TimeUnit.MILLISECONDS);
+            // zero is treated as an infinite timeout
+            return syncCallTimeout.isZero()
+                    ? future.get()
+                    : future.get(syncCallTimeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             getDelegate().cancel();
             Thread.currentThread().interrupt();

--- a/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/OkHttpClientsTest.java
@@ -500,9 +500,14 @@ public final class OkHttpClientsTest extends TestBase {
 
     @Test
     public void largestOf_sanity() throws Exception {
-        assertThat(OkHttpClients.largestOf()).isEqualTo(Duration.ZERO);
         assertThat(OkHttpClients.largestOf(Duration.ofMinutes(1), Duration.ofSeconds(20), Duration.ofHours(7)))
                 .isEqualTo(Duration.ofHours(7));
+    }
+
+    @Test
+    public void largestOf_treats_zero_as_infinity() throws Exception {
+        assertThat(OkHttpClients.largestOf(Duration.ZERO, Duration.ofSeconds(20), Duration.ofHours(7)))
+                .isEqualTo(Duration.ZERO);
     }
 
     private OkHttpClient createRetryingClient(int maxNumRetries) {

--- a/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/OkHttpClientsTest.java
@@ -23,10 +23,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterables;
 import com.google.common.net.HttpHeaders;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.remoting.api.config.service.ServiceConfiguration;
+import com.palantir.remoting.api.config.ssl.SslConfiguration;
 import com.palantir.remoting.api.errors.RemoteException;
 import com.palantir.remoting.api.errors.SerializableError;
 import com.palantir.remoting3.clients.ClientConfiguration;
+import com.palantir.remoting3.clients.ClientConfigurations;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -440,6 +444,58 @@ public final class OkHttpClientsTest extends TestBase {
         Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
         thread.interrupt();
         thread.join();
+    }
+
+    @Test
+    public void timeouts_set_to_all_zero_should_be_treated_as_infinity() throws Exception {
+        server.enqueue(new MockResponse()
+                .setBodyDelay(Duration.ofSeconds(11).toMillis(), TimeUnit.MILLISECONDS)
+                .setBody("Hello, world!"));
+
+        OkHttpClient client = OkHttpClients.withStableUris(
+                ClientConfiguration.builder()
+                        .from(createTestConfig(url))
+                        .connectTimeout(Duration.ZERO)
+                        .readTimeout(Duration.ZERO)
+                        .writeTimeout(Duration.ZERO) // want to allow unlimited time for uploads
+                        .maxNumRetries(0)
+                        .backoffSlotSize(Duration.ofMillis(10))
+                        .build(),
+                AGENT,
+                OkHttpClientsTest.class);
+
+        Request request = new Request.Builder()
+                .url(url)
+                .build();
+
+        Response synchronousCall = client.newCall(request).execute();
+        assertThat(synchronousCall.body().string()).isEqualTo("Hello, world!");
+    }
+
+    @Test
+    public void sync_call_to_a_slow_endpoint_should_not_time_out_if_read_timeout_is_zero() throws Exception {
+        server.enqueue(new MockResponse()
+                .setBodyDelay(Duration.ofSeconds(11).toMillis(), TimeUnit.MILLISECONDS)
+                .setBody("Hello, world!"));
+
+        OkHttpClient client = OkHttpClients.withStableUris(
+                ClientConfigurations.of(
+                        ServiceConfiguration.builder()
+                                // ClientConfigurations has a connectTimeout default of 10 seconds
+                                .readTimeout(Duration.ZERO) // unlimited pls
+                                .writeTimeout(Duration.ZERO) // unlimited pls
+                                .security(SslConfiguration.of(Paths.get("src", "test", "resources", "trustStore.jks")))
+                                .build()
+                ),
+                AGENT,
+                OkHttpClientsTest.class);
+
+        Request request = new Request.Builder()
+                .url(url)
+                .build();
+
+        Response synchronousCall = client.newCall(request).execute();
+        assertThat(synchronousCall.body().string()).isEqualTo("Hello, world!");
     }
 
     @Test


### PR DESCRIPTION
After upgrading to http-remoting 3.13.0 our data upload product has been throwing timeout exceptions when an upload takes longer than 10 seconds.

This failure was introduced because okhttp treats zero as infinity but our new `largestOf` method treats zero as zero.  In addition, we had a `future.get(timeoutMillis)` call which also did not treat zero as infinity.
