### PR TITLE
fix race in UrlSelector resulting in bad failover behaviour under any concurrent load

### DIFF
--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientFailoverTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientFailoverTest.java
@@ -64,19 +64,19 @@ public final class JaxRsClientFailoverTest extends TestBase {
     }
 
     @Test
-    public void testConnectionError_performsFailover_testHarder() throws Exception {
-        ExecutorService executorService = Executors.newFixedThreadPool(10);
+    public void testConnectionError_performsFailover_concurrentRequests() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
 
         server1.shutdown();
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 10; i++) {
             server2.enqueue(new MockResponse().setBody("\"foo\""));
         }
 
-        List<Future<String>> things = Lists.newArrayListWithCapacity(100);
-        for (int i = 0; i < 100; i++) {
+        List<Future<String>> things = Lists.newArrayListWithCapacity(10);
+        for (int i = 0; i < 10; i++) {
             things.add(executorService.submit(() -> proxy.string()));
         }
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 10; i++) {
             assertThat(things.get(i).get(), is("foo"));
         }
     }

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelectorImpl.java
@@ -98,8 +98,9 @@ final class UrlSelectorImpl implements UrlSelector {
 
     @Override
     public Optional<HttpUrl> redirectToNext(HttpUrl current) {
+        Optional<Integer> currentIndex = indexFor(current);
         int index = currentUrl.updateAndGet(
-                (currentUrlIndex) -> (indexFor(current).orElse(currentUrlIndex) + 1) % baseUrls.size());
+                (currentUrlIndex) -> (currentIndex.orElse(currentUrlIndex) + 1) % baseUrls.size());
         return redirectTo(current, baseUrls.get(index));
     }
 

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelectorImpl.java
@@ -99,7 +99,13 @@ final class UrlSelectorImpl implements UrlSelector {
     @Override
     public Optional<HttpUrl> redirectToNext(HttpUrl current) {
         int index = currentUrl.updateAndGet(operand -> (operand + 1) % baseUrls.size());
-        return redirectTo(current, baseUrls.get(index));
+        Optional<HttpUrl> newUrl = redirectTo(current, baseUrls.get(index));
+
+        if (newUrl.map(url -> url.equals(current)).orElse(false) && baseUrls.size() > 1) {
+            return redirectToNext(current);
+        } else {
+            return newUrl;
+        }
     }
 
     @Override

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelectorImpl.java
@@ -97,11 +97,14 @@ final class UrlSelectorImpl implements UrlSelector {
     }
 
     @Override
-    public Optional<HttpUrl> redirectToNext(HttpUrl current) {
-        Optional<Integer> currentIndex = indexFor(current);
+    public Optional<HttpUrl> redirectToNext(HttpUrl existingUrl) {
+        // if possible, determine the index of the passed in url (so we can be sure to return a url which is different)
+        Optional<Integer> existingUrlIndex = indexFor(existingUrl);
+
+        // ...otherwise we fall back to the stateful current url index
         int index = currentUrl.updateAndGet(
-                (currentUrlIndex) -> (currentIndex.orElse(currentUrlIndex) + 1) % baseUrls.size());
-        return redirectTo(current, baseUrls.get(index));
+                (currentUrlIndex) -> (existingUrlIndex.orElse(currentUrlIndex) + 1) % baseUrls.size());
+        return redirectTo(existingUrl, baseUrls.get(index));
     }
 
     @Override

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelectorImpl.java
@@ -98,14 +98,9 @@ final class UrlSelectorImpl implements UrlSelector {
 
     @Override
     public Optional<HttpUrl> redirectToNext(HttpUrl current) {
-        int index = currentUrl.updateAndGet(operand -> (operand + 1) % baseUrls.size());
-        Optional<HttpUrl> newUrl = redirectTo(current, baseUrls.get(index));
-
-        if (newUrl.map(url -> url.equals(current)).orElse(false) && baseUrls.size() > 1) {
-            return redirectToNext(current);
-        } else {
-            return newUrl;
-        }
+        int index = currentUrl.updateAndGet(
+                (currentUrlIndex) -> (indexFor(current).orElse(currentUrlIndex) + 1) % baseUrls.size());
+        return redirectTo(current, baseUrls.get(index));
     }
 
     @Override

--- a/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/UrlSelectorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/UrlSelectorTest.java
@@ -142,6 +142,29 @@ public final class UrlSelectorTest extends TestBase {
     }
 
     @Test
+    public void testRedirectToNext_isAFunctionOfArgument_updatesCurrent() {
+        UrlSelectorImpl selector = UrlSelectorImpl.create(list("http://foo/a", "http://bar/a"), false);
+
+        HttpUrl baseIsFoo = HttpUrl.parse("http://foo/a/b/path");
+        HttpUrl baseIsBar = HttpUrl.parse("http://bar/a/b/path");
+        HttpUrl baseIsBaz = HttpUrl.parse("http://baz/a/b/path");
+
+        // calling twice with the same argument gives the same result, i.e. move forward by one
+        assertThat(selector.redirectToNext(baseIsFoo)).contains(HttpUrl.parse("http://bar/a/b/path"));
+        assertThat(selector.redirectToNext(baseIsFoo)).contains(HttpUrl.parse("http://bar/a/b/path"));
+        // ...and bar is now the current
+        assertThat(selector.redirectToCurrent(baseIsBaz)).contains(HttpUrl.parse("http://bar/a/b/path"));
+
+        // bar goes back to foo
+        assertThat(selector.redirectToNext(baseIsBar)).contains(HttpUrl.parse("http://foo/a/b/path"));
+        assertThat(selector.redirectToCurrent(baseIsBaz)).contains(HttpUrl.parse("http://foo/a/b/path"));
+
+        // baz goes to the next after the current
+        // current is foo, so we expect bar
+        assertThat(selector.redirectToNext(baseIsBaz)).contains(HttpUrl.parse("http://bar/a/b/path"));
+    }
+
+    @Test
     public void testWorksWithWebSockets() throws Exception {
         Request wsRequest = new Request.Builder()
                 .url("wss://foo/a")


### PR DESCRIPTION
concurrent requests on the same client results in 'failover' to the same url you just failed on

the `UrlSelector` seems to be shared client-wide, so if you have multiple requests hitting a host which is down and a fairly small number of urls total, you end up with `urls.redirectToNext(request().url());` in `RemotingOkHttpCall:148` giving you the same url you just failed on, at which point you naturally fail again, then having exhausted all retries - give up!