### PR TITLE
Fix JaxRs RemoteException stack traces to include the call site

### DIFF
--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientStackTraceTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientStackTraceTest.java
@@ -1,0 +1,86 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.jaxrs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.palantir.remoting.api.errors.ErrorType;
+import com.palantir.remoting.api.errors.SerializableError;
+import com.palantir.remoting.api.errors.ServiceException;
+import com.palantir.remoting3.clients.ClientConfiguration;
+import com.palantir.remoting3.ext.jackson.ObjectMappers;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class JaxRsClientStackTraceTest extends TestBase {
+
+    @Rule
+    public final MockWebServer server1 = new MockWebServer();
+
+    private TestService proxy;
+
+    @Before
+    public void before() throws Exception {
+        proxy = JaxRsClient.create(TestService.class, AGENT,
+                ClientConfiguration.builder()
+                        .from(createTestConfig("http://localhost:" + server1.getPort()))
+                        .maxNumRetries(1)
+                        .build());
+    }
+
+    @Test
+    public void stack_trace_from_ioexception_should_include_call_site() throws Exception {
+        server1.shutdown();
+
+        try {
+            proxy.string();
+            failBecauseExceptionWasNotThrown(Exception.class);
+        } catch (Exception e) {
+            assertThat(e).hasStackTraceContaining("JaxRsClientStackTraceTest."
+                    + "stack_trace_from_ioexception_should_include_call_site(JaxRsClientStackTraceTest.java:");
+        }
+    }
+
+    @Ignore // failing test
+    @Test
+    public void stack_trace_from_remote_exception_should_include_call_site() throws Exception {
+        server1.enqueue(serializableError());
+
+        try {
+            proxy.string();
+            failBecauseExceptionWasNotThrown(Exception.class);
+        } catch (Exception e) {
+            assertThat(e).hasStackTraceContaining("JaxRsClientStackTraceTest."
+                    + "stack_trace_from_remote_exception_should_include_call_site(JaxRsClientStackTraceTest.java:");
+        }
+    }
+
+    private static MockResponse serializableError() throws JsonProcessingException {
+        String json = ObjectMappers.newServerObjectMapper().writeValueAsString(
+                SerializableError.forException(new ServiceException(ErrorType.INTERNAL)));
+        return new MockResponse()
+                .setResponseCode(500)
+                .setHeader("Content-Type", "application/json")
+                .setBody(json);
+    }
+}

--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientStackTraceTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientStackTraceTest.java
@@ -28,7 +28,6 @@ import com.palantir.remoting3.ext.jackson.ObjectMappers;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,7 +60,6 @@ public final class JaxRsClientStackTraceTest extends TestBase {
         }
     }
 
-    @Ignore // failing test
     @Test
     public void stack_trace_from_remote_exception_should_include_call_site() throws Exception {
         server1.enqueue(serializableError());

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpCall.java
@@ -112,7 +112,12 @@ final class RemotingOkHttpCall extends ForwardingCall {
             getDelegate().cancel();
             if (e.getCause() instanceof IoRemoteException) {
                 // TODO(rfink): Consider unwrapping the RemoteException at the Retrofit/Feign layer for symmetry, #626
-                throw ((IoRemoteException) e.getCause()).getWrappedException();
+                RemoteException wrappedException = ((IoRemoteException) e.getCause()).getWrappedException();
+                RemoteException correctStackTrace = new RemoteException(
+                        wrappedException.getError(),
+                        wrappedException.getStatus());
+                correctStackTrace.initCause(e);
+                throw correctStackTrace;
             } else if (e.getCause() instanceof IOException) {
                 throw (IOException) e.getCause();
             } else {


### PR DESCRIPTION
fixes https://github.com/palantir/http-remoting/issues/670

On the RemoteException codepath, we now never throw _any_ information away, so you get nice clear stack traces like this:

```diff
 com.palantir.remoting.api.errors.RemoteException: RemoteException: INTERNAL (Default:Internal) with instance ID 605b5f20-a83a-46c9-a207-cf60764b7975
 	at com.palantir.remoting3.okhttp.RemotingOkHttpCall.execute(RemotingOkHttpCall.java:117)
 	at feign.okhttp.OkHttpClient.execute(OkHttpClient.java:155)
 	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:97)
 	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:76)
 	at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:103)
 	at com.sun.proxy.$Proxy14.string(Unknown Source)
+	at com.palantir.remoting3.jaxrs.JaxRsClientStackTraceTest.stack_trace_from_remote_exception_should_include_call_site(JaxRsClientStackTraceTest.java:68)
 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.lang.reflect.Method.invoke(Method.java:497)
 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
 	...
 Caused by: java.util.concurrent.ExecutionException: com.palantir.remoting3.okhttp.IoRemoteException
 	at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:500)
 	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:401)
 	at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.get(AbstractFuture.java:83)
 	at com.palantir.remoting3.okhttp.RemotingOkHttpCall.execute(RemotingOkHttpCall.java:106)
 	... 39 more
 Caused by: com.palantir.remoting3.okhttp.IoRemoteException
 	at com.palantir.remoting3.okhttp.RemotingOkHttpCall$2.onResponse(RemotingOkHttpCall.java:198)
 	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:153)
 	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
 	at com.palantir.remoting3.tracing.Tracers$TracingAwareCallable$$Lambda$55/695883542.call(Unknown Source)
 	at com.palantir.remoting3.tracing.DeferredTracer.withTrace(DeferredTracer.java:43)
 	at com.palantir.remoting3.tracing.Tracers$TracingAwareCallable.call(Tracers.java:182)
 	at com.palantir.remoting3.tracing.WrappingExecutorService.lambda$wrapTask$6(WrappingExecutorService.java:70)
 	at com.palantir.remoting3.tracing.WrappingExecutorService$$Lambda$54/1276709283.run(Unknown Source)
 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
 	at java.lang.Thread.run(Thread.java:745)
```