### PR TITLE
Jersey maps exceptions to json using standard mechanisms

### DIFF
--- a/jersey-servers/src/main/java/com/palantir/remoting3/servers/jersey/JsonExceptionMapper.java
+++ b/jersey-servers/src/main/java/com/palantir/remoting3/servers/jersey/JsonExceptionMapper.java
@@ -16,7 +16,6 @@
 
 package com.palantir.remoting3.servers.jersey;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.palantir.logsafe.SafeArg;
@@ -76,17 +75,15 @@ abstract class JsonExceptionMapper<T extends Exception> implements ExceptionMapp
             String exceptionClass) {
         ResponseBuilder builder = Response.status(httpErrorCode);
         try {
-            SerializableError error = SerializableError.builder()
+            builder.entity(SerializableError.builder()
                     .errorCode(errorCode)
                     .errorName(errorName)
                     .errorInstanceId(errorInstanceId)
                     .exceptionClass(exceptionClass)
                     .message("Refer to the server logs with this errorInstanceId: " + errorInstanceId)
-                    .build();
-            builder.type(MediaType.APPLICATION_JSON);
-            String json = MAPPER.writeValueAsString(error);
-            builder.entity(json);
-        } catch (RuntimeException | JsonProcessingException e) {
+                    .build())
+                    .type(MediaType.APPLICATION_JSON);
+        } catch (RuntimeException e) {
             log.warn("Unable to translate exception to json",
                     SafeArg.of("errorInstanceId", errorInstanceId), e);
             builder = Response.status(httpErrorCode);

--- a/jersey-servers/src/main/java/com/palantir/remoting3/servers/jersey/RemoteExceptionMapper.java
+++ b/jersey-servers/src/main/java/com/palantir/remoting3/servers/jersey/RemoteExceptionMapper.java
@@ -16,7 +16,6 @@
 
 package com.palantir.remoting3.servers.jersey;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.remoting.api.errors.RemoteException;
 import com.palantir.remoting.api.errors.SerializableError;
@@ -62,9 +61,8 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
         ResponseBuilder builder = Response.status(status);
         try {
             builder.type(MediaType.APPLICATION_JSON);
-            String json = JsonExceptionMapper.MAPPER.writeValueAsString(error);
-            builder.entity(json);
-        } catch (RuntimeException | JsonProcessingException e) {
+            builder.entity(error);
+        } catch (RuntimeException e) {
             log.warn("Unable to translate exception to json for request", e);
             // simply write out the exception message
             builder = Response.status(status);

--- a/jersey-servers/src/main/java/com/palantir/remoting3/servers/jersey/ServiceExceptionMapper.java
+++ b/jersey-servers/src/main/java/com/palantir/remoting3/servers/jersey/ServiceExceptionMapper.java
@@ -16,13 +16,9 @@
 
 package com.palantir.remoting3.servers.jersey;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.remoting.api.errors.SerializableError;
 import com.palantir.remoting.api.errors.ServiceException;
-import com.palantir.remoting3.ext.jackson.ObjectMappers;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
@@ -38,8 +34,6 @@ import org.slf4j.LoggerFactory;
 final class ServiceExceptionMapper implements ExceptionMapper<ServiceException> {
 
     private static final Logger log = LoggerFactory.getLogger(ServiceExceptionMapper.class);
-    private static final ObjectMapper MAPPER =
-            ObjectMappers.newServerObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
     @Override
     public Response toResponse(ServiceException exception) {
@@ -60,9 +54,8 @@ final class ServiceExceptionMapper implements ExceptionMapper<ServiceException> 
                     .message("Refer to the server logs with this errorInstanceId: " + exception.getErrorInstanceId())
                     .build();
             builder.type(MediaType.APPLICATION_JSON);
-            String json = MAPPER.writeValueAsString(error);
-            builder.entity(json);
-        } catch (RuntimeException | JsonProcessingException e) {
+            builder.entity(error);
+        } catch (RuntimeException e) {
             log.warn("Unable to translate exception to json",
                     SafeArg.of("errorInstanceId", exception.getErrorInstanceId()), e);
             // simply write out the exception message

--- a/jersey-servers/src/test/java/com/palantir/remoting3/servers/jersey/JerseyExceptionMapperTest.java
+++ b/jersey-servers/src/test/java/com/palantir/remoting3/servers/jersey/JerseyExceptionMapperTest.java
@@ -1,0 +1,91 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.servers.jersey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.MetricRegistry;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.remoting.api.errors.ErrorType;
+import com.palantir.remoting.api.errors.SerializableError;
+import com.palantir.remoting.api.errors.ServiceException;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+public final class JerseyExceptionMapperTest extends JerseyTest {
+
+    @Override
+    protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+                .register(HttpRemotingJerseyFeature.INSTANCE)
+                .register(AngryResource.class);
+    }
+
+    @Test
+    public void testServiceException() {
+        Response response = target("/angry/service").request().get();
+        assertThat(response.getStatus()).isEqualTo(400);
+        SerializableError entity = response.readEntity(SerializableError.class);
+        assertThat(entity.parameters().get("message")).isEqualTo("Hello");
+    }
+
+    @Test
+    public void testWebException() {
+        Response response = target("/angry/web").request().get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.readEntity(String.class)).doesNotContain("secret");
+    }
+
+    @Test
+    public void testRuntimeException() {
+        Response response = target("/angry/runtime").request().get();
+        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.readEntity(String.class)).contains(RuntimeException.class.getName());
+    }
+
+    @Path("angry")
+    @Produces(MediaType.TEXT_PLAIN)
+    public static final class AngryResource {
+        @GET
+        @Path("service")
+        public void serviceException() {
+            throw new ServiceException(ErrorType.INVALID_ARGUMENT, SafeArg.of("message", "Hello"));
+        }
+
+        @GET
+        @Path("web")
+        public void webApplicationException() {
+            throw new ForbiddenException("secret");
+        }
+
+        @GET
+        @Path("runtime")
+        public void runtimeException() {
+            throw new RuntimeException("Run Forrest, run!");
+        }
+    }
+}

--- a/jersey-servers/src/test/java/com/palantir/remoting3/servers/jersey/WebApplicationExceptionMapperTest.java
+++ b/jersey-servers/src/test/java/com/palantir/remoting3/servers/jersey/WebApplicationExceptionMapperTest.java
@@ -18,6 +18,9 @@ package com.palantir.remoting3.servers.jersey;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.palantir.remoting3.ext.jackson.ObjectMappers;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotFoundException;
@@ -30,73 +33,81 @@ import org.junit.Test;
 public final class WebApplicationExceptionMapperTest {
 
     private final WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper();
+    private final ObjectMapper objectMapper = ObjectMappers.newServerObjectMapper()
+            .enable(SerializationFeature.INDENT_OUTPUT);
 
     @Test
-    public void testExplicitlyHandledExceptions() {
+    public void testExplicitlyHandledExceptions() throws Exception {
         Response response;
 
         response = mapper.toResponse(new ForbiddenException("secret"));
-        assertThat(response.getEntity().toString()).contains("\"errorCode\" : \"PERMISSION_DENIED\"");
-        assertThat(response.getEntity().toString()).contains("\"errorName\" : \"Default:PermissionDenied\"");
-        assertThat(response.getEntity().toString()).contains("\"exceptionClass\" : \"javax.ws.rs.ForbiddenException\"");
-        assertThat(response.getEntity().toString())
+        String entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity).contains("\"errorCode\" : \"PERMISSION_DENIED\"");
+        assertThat(entity).contains("\"errorName\" : \"Default:PermissionDenied\"");
+        assertThat(entity).contains("\"exceptionClass\" : \"javax.ws.rs.ForbiddenException\"");
+        assertThat(entity)
                 .contains("\"message\" : \"Refer to the server logs with this errorInstanceId:");
         assertThat(response.getStatus()).isEqualTo(403);
-        assertThat(response.getEntity().toString()).doesNotContain("secret");
+        assertThat(entity).doesNotContain("secret");
 
         response = mapper.toResponse(new NotFoundException());
-        assertThat(response.getEntity().toString()).contains("\"errorCode\" : \"NOT_FOUND\"");
-        assertThat(response.getEntity().toString()).contains("\"errorName\" : \"Default:NotFound\"");
-        assertThat(response.getEntity().toString()).contains("\"exceptionClass\" : \"javax.ws.rs.NotFoundException\"");
-        assertThat(response.getEntity().toString())
+        entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity).contains("\"errorCode\" : \"NOT_FOUND\"");
+        assertThat(entity).contains("\"errorName\" : \"Default:NotFound\"");
+        assertThat(entity).contains("\"exceptionClass\" : \"javax.ws.rs.NotFoundException\"");
+        assertThat(entity)
                 .contains("\"message\" : \"Refer to the server logs with this errorInstanceId:");
         assertThat(response.getStatus()).isEqualTo(404);
-        assertThat(response.getEntity().toString()).doesNotContain("secret");
+        assertThat(entity).doesNotContain("secret");
 
         response = mapper.toResponse(new BadRequestException());
-        assertThat(response.getEntity().toString()).contains("\"errorCode\" : \"INVALID_ARGUMENT\"");
-        assertThat(response.getEntity().toString()).contains("\"errorName\" : \"Default:InvalidArgument\"");
-        assertThat(response.getEntity().toString())
+        entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity).contains("\"errorCode\" : \"INVALID_ARGUMENT\"");
+        assertThat(entity).contains("\"errorName\" : \"Default:InvalidArgument\"");
+        assertThat(entity)
                 .contains("\"exceptionClass\" : \"javax.ws.rs.BadRequestException\"");
-        assertThat(response.getEntity().toString())
+        assertThat(entity)
                 .contains("\"message\" : \"Refer to the server logs with this errorInstanceId:");
         assertThat(response.getStatus()).isEqualTo(400);
-        assertThat(response.getEntity().toString()).doesNotContain("secret");
+        assertThat(entity).doesNotContain("secret");
 
         response = mapper.toResponse(new ParamException.CookieParamException(null, null, null));
-        assertThat(response.getEntity().toString()).contains("\"errorCode\" : \"INVALID_ARGUMENT\"");
-        assertThat(response.getEntity().toString()).contains("\"errorName\" : \"Default:InvalidArgument\"");
-        assertThat(response.getEntity().toString())
+        entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity).contains("\"errorCode\" : \"INVALID_ARGUMENT\"");
+        assertThat(entity).contains("\"errorName\" : \"Default:InvalidArgument\"");
+        assertThat(entity)
                 .contains("\"exceptionClass\" : \"org.glassfish.jersey.server.ParamException$CookieParamException\"");
-        assertThat(response.getEntity().toString())
+        assertThat(entity)
                 .contains("\"message\" : \"Refer to the server logs with this errorInstanceId:");
         assertThat(response.getStatus()).isEqualTo(400);
-        assertThat(response.getEntity().toString()).doesNotContain("secret");
+        assertThat(entity).doesNotContain("secret");
     }
 
     @Test
-    public void testNotExplicitlyHandledExceptions() {
+    public void testNotExplicitlyHandledExceptions() throws Exception {
         Response response;
 
         response = mapper.toResponse(new WebApplicationException("secret", 503));
-        assertThat(response.getEntity().toString()).contains("\"errorCode\" : \"javax.ws.rs.WebApplicationException\"");
-        assertThat(response.getEntity().toString()).contains("\"errorName\" : \"WebApplicationException\"");
-        assertThat(response.getEntity().toString())
+        String entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity).contains("\"errorCode\" : \"javax.ws.rs.WebApplicationException\"");
+        assertThat(entity).contains("\"errorName\" : \"WebApplicationException\"");
+        assertThat(entity)
                 .contains("\"exceptionClass\" : \"javax.ws.rs.WebApplicationException\"");
-        assertThat(response.getEntity().toString())
+        assertThat(entity)
                 .contains("\"message\" : \"Refer to the server logs with this errorInstanceId:");
         assertThat(response.getStatus()).isEqualTo(503);
-        assertThat(response.getEntity().toString()).doesNotContain("secret");
+        assertThat(entity).doesNotContain("secret");
 
         response = mapper.toResponse(new ServiceUnavailableException("secret"));
-        assertThat(response.getEntity().toString())
+        entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity)
                 .contains("\"errorCode\" : \"javax.ws.rs.ServiceUnavailableException\"");
-        assertThat(response.getEntity().toString()).contains("\"errorName\" : \"ServiceUnavailableException\"");
-        assertThat(response.getEntity().toString())
+        assertThat(entity).contains("\"errorName\" : \"ServiceUnavailableException\"");
+        assertThat(entity)
                 .contains("\"exceptionClass\" : \"javax.ws.rs.ServiceUnavailableException\"");
-        assertThat(response.getEntity().toString())
+        assertThat(entity)
                 .contains("\"message\" : \"Refer to the server logs with this errorInstanceId:");
         assertThat(response.getStatus()).isEqualTo(503);
-        assertThat(response.getEntity().toString()).doesNotContain("secret");
+        assertThat(entity).doesNotContain("secret");
     }
 }


### PR DESCRIPTION
This allows us to write string responses as json for
compatibility with the feign client.