### PR TITLE
Updated CipherSuites.FAST_CIPHER_SUITES

### DIFF
--- a/http-clients/src/main/java/com/palantir/remoting3/clients/CipherSuites.java
+++ b/http-clients/src/main/java/com/palantir/remoting3/clients/CipherSuites.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 public final class CipherSuites {
 
     private static final ImmutableList<String> FAST_CIPHER_SUITES = ImmutableList.of(
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
             "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
             "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
             "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",


### PR DESCRIPTION
Now FAST_CIPHER_SUITES includes
TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 which is not provided
by default by current versions of the JVM, however can be taken
advantage of by using a native JSSE implementation.