### PR TITLE
[do not merge] Showing that failover doesn't happen

### DIFF
--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientFailoverTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientFailoverTest.java
@@ -117,11 +117,22 @@ public final class JaxRsClientFailoverTest extends TestBase {
     }
 
     @Test
+    public void testQosError_performsRetry() throws Exception {
+        server1.enqueue(new MockResponse().setResponseCode(503));
+        server1.enqueue(new MockResponse().setBody("\"foo\""));
+        server2.enqueue(new MockResponse().setBody("\"bar\""));
+
+        assertThat(proxy.string(), is("foo"));
+    }
+
+    // Should fail
+    @Test
     public void testQosError_performsFailover() throws Exception {
         server1.enqueue(new MockResponse().setResponseCode(503));
         server1.enqueue(new MockResponse().setBody("\"foo\""));
-        server2.enqueue(new MockResponse().setBody("\"foo\""));
+        server2.enqueue(new MockResponse().setBody("\"bar\""));
 
-        assertThat(proxy.string(), is("foo"));
+        // If we wanted the behavior to be "always try another host if the first one is unavailable"
+        assertThat(proxy.string(), is("bar"));
     }
 }


### PR DESCRIPTION
"Failover" means that when there's a _fail_, something else takes _over_ (i.e., when a server claims to be unavailable, the client tries a different server). Right now we just have retry.

This test should fail on:

```
java.lang.AssertionError: 
Expected: is "bar"
     but: was "foo"
Expected :bar
Actual   :foo
 <Click to see difference>


	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at com.palantir.remoting3.jaxrs.JaxRsClientFailoverTest.testQosError_performsFailover(JaxRsClientFailoverTest.java:135)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
```