### PR TITLE
Fix regression where OkHttpClients do not randomize target URLs

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelectorImpl.java
@@ -36,6 +36,8 @@ final class UrlSelectorImpl implements UrlSelector {
     private UrlSelectorImpl(ImmutableList<HttpUrl> baseUrls) {
         this.baseUrls = baseUrls;
         this.currentUrl = new AtomicInteger(0);
+
+        Preconditions.checkArgument(!baseUrls.isEmpty(), "Must specify at least one URL");
     }
 
     static UrlSelectorImpl create(Collection<String> baseUrls, boolean randomizeOrder) {
@@ -44,7 +46,7 @@ final class UrlSelectorImpl implements UrlSelector {
             Collections.shuffle(orderedUrls);
         }
 
-        ImmutableSet.Builder<HttpUrl> canonicalUrls = ImmutableSet.builder();
+        ImmutableSet.Builder<HttpUrl> canonicalUrls = ImmutableSet.builder();  // ImmutableSet maintains insert order
         orderedUrls.forEach(url -> {
             HttpUrl httpUrl = HttpUrl.parse(switchWsToHttp(url));
             Preconditions.checkArgument(httpUrl != null, "Not a valid URL: %s", url);

--- a/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/UrlSelectorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/UrlSelectorTest.java
@@ -32,6 +32,13 @@ import org.mockito.runners.MockitoJUnitRunner;
 public final class UrlSelectorTest extends TestBase {
 
     @Test
+    public void mustSpecifyAtLeastOneUrl() throws Exception {
+        assertThatThrownBy(() -> UrlSelectorImpl.create(set(), false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Must specify at least one URL");
+    }
+
+    @Test
     public void baseUrlsMustBeCanonical() throws Exception {
         for (String url : new String[] {
                 "user:pass@foo.com/path",


### PR DESCRIPTION
This broke in 3.13.0, https://github.com/palantir/http-remoting/pull/656/files#diff-6f96ec3f89ee93b2cecdf4dd49d4f564L130

Fixes #684