### PR TITLE
Serialize dates with zone IDs

### DIFF
--- a/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/ObjectMappers.java
+++ b/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/ObjectMappers.java
@@ -116,6 +116,7 @@ public final class ObjectMappers {
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                 .disable(DeserializationFeature.WRAP_EXCEPTIONS)
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-                .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+                .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+                .enable(SerializationFeature.WRITE_DATES_WITH_ZONE_ID);
     }
 }

--- a/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
+++ b/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
@@ -17,6 +17,7 @@
 package com.palantir.remoting3.ext.jackson;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -85,9 +86,15 @@ public final class ObjectMappersTest {
         assertThat(ser(offsetDateTime)).isEqualTo("\"2001-02-03T04:05:06.000000007-05:00\"");
         assertThat(serDe(offsetDateTime, OffsetDateTime.class)).isEqualTo(offsetDateTime);
 
-        ZonedDateTime zoneDateTime = ZonedDateTime.of(2001, 2, 3, 4, 5, 6, 7, ZoneId.of(ZoneId.SHORT_IDS.get("EST")));
-        assertThat(ser(zoneDateTime)).isEqualTo("\"2001-02-03T04:05:06.000000007-05:00\"");
+        ZonedDateTime zoneDateTime = ZonedDateTime.of(2001, 2, 3, 4, 5, 6, 7, ZoneId.of(ZoneId.SHORT_IDS.get("CST")));
+        assertThat(ser(zoneDateTime)).isEqualTo("\"2001-02-03T04:05:06.000000007-06:00[America/Chicago]\"");
         assertThat(serDe(zoneDateTime, ZonedDateTime.class)).isEqualTo(zoneDateTime);
+        /* Explicitly use assertTrue since .isEqualTo() for ZonedDateTime returns true if the two instances refer to the
+         * same point on the number line expressed differently. Since we're testing serde here, we need to be more
+         * restrictive and only accept the deserialized version if it expresses the same point on the number line in the
+         * same way as the original object (and .equals() reflects this).
+          */
+        assertTrue(zoneDateTime.equals(serDe(zoneDateTime, ZonedDateTime.class)));
 
         LocalDate localDate = LocalDate.of(2001, 2, 3);
         assertThat(ser(localDate)).isEqualTo("\"2001-02-03\"");


### PR DESCRIPTION
Currently, the default mapper serializes `ZonedDateTime`s with an offset only. `ZonedDateTime`, however, contains timezone information, and offsets and timezones are different things. Thus, it's necessary to include timezone information in the serialized version of `ZonedDateTime`s in order to accurately encode all the information that's necessary to correctly reconstruct an equivalent object.

The test case was using a timezone that is defined as an offset by `java.time` (EST: https://github.com/frohoff/jdk8u-jdk/blob/master/src/share/classes/java/time/ZoneId.java#L187), so the test conveniently succeeded. However, as we all know, due to the travesty that is daylight savings time/summer time/etc., some timezones resolve to different offsets depending on the time of year, so an offset is not sufficient - the timezone is necessary, too. So, I switched the test case to use `America/Chicago` instead, since that is a timezone that resolves to different offsets at different times of the year. It would fail when using the default mapper, but when using a mapper that writes zone IDs, it succeeds.

(Relevant: https://www.youtube.com/watch?v=-5wpm-gesOY)

@uschi2000 