### PR TITLE
Test for sticky failover

### DIFF
--- a/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/OkHttpClientsTest.java
@@ -405,13 +405,16 @@ public final class OkHttpClientsTest extends TestBase {
     public void handlesQos_503FailsOverToAnotherUrl() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(503));
         server2.enqueue(new MockResponse().setBody("foo"));
+        server2.enqueue(new MockResponse().setBody("bar"));
 
         OkHttpClient client = createRetryingClient(1, url, url2);
         Call call = client.newCall(new Request.Builder().url(url).build());
         assertThat(call.execute().body().string()).isEqualTo("foo");
+        Call call2 = client.newCall(new Request.Builder().url(url).build());
+        assertThat(call2.execute().body().string()).isEqualTo("bar");
 
         assertThat(server.getRequestCount()).isEqualTo(1);
-        assertThat(server2.getRequestCount()).isEqualTo(1);
+        assertThat(server2.getRequestCount()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
cc @samrogerson 

This might sort of be taken care of already by `UrlSelectorTest`, but also feels right to have something explicit in `OkHttpClientsTest`

@uschi2000 