### PR TITLE
Customizable okhttp builder

### DIFF
--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2ClientBuilder.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2ClientBuilder.java
@@ -23,6 +23,8 @@ import com.palantir.remoting3.clients.UserAgent;
 import com.palantir.remoting3.clients.UserAgents;
 import com.palantir.remoting3.ext.jackson.ObjectMappers;
 import com.palantir.remoting3.okhttp.OkHttpClients;
+import java.util.function.UnaryOperator;
+import okhttp3.OkHttpClient.Builder;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
@@ -46,7 +48,11 @@ public final class Retrofit2ClientBuilder {
     }
 
     public <T> T build(Class<T> serviceClass, UserAgent userAgent) {
-        okhttp3.OkHttpClient client = OkHttpClients.create(config, userAgent, serviceClass);
+        return build(serviceClass, userAgent, UnaryOperator.identity());
+    }
+
+    public <T> T build(Class<T> serviceClass, UserAgent userAgent, UnaryOperator<Builder> builderExtraConfiguration) {
+        okhttp3.OkHttpClient client = OkHttpClients.create(config, userAgent, serviceClass, builderExtraConfiguration);
         Retrofit retrofit = new Retrofit.Builder()
                 .client(client)
                 .baseUrl(addTrailingSlash(config.uris().get(0)))


### PR DESCRIPTION
I'd like to be able to create remoting clients where I change some details about the okhttp client, such as
* dispatcher
* connection pool
* cache

Use case is I will create a lot of clients, most of which will share the same underlying set of hosts but have different URIs.
I'd like all these clients to share the above objects.
I'd also like to configure the cache such that I can make it an on-disk cache, and it needs to be shared in order to enforce a maximum cache size across all clients.

Currently, each new okhttp client (either created directly or through the jaxrs / retrofit2 factories) creates its own new dispatcher and connection pool. This means we can't enforce global limits on the 
* total number of connections
* number of connections per host

via the dispatcher, nor can we reuse existing connections to the same hosts from a different client.
They also don't allow configuring the cache, leaving it as the default, so it's impossible to configure a bounded on-disk cache.
