### PR TITLE
Don't use a sync timeout

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
@@ -203,9 +203,7 @@ public final class OkHttpClients {
                 () -> new ExponentialBackoff(config.maxNumRetries(), config.backoffSlotSize(), new Random()),
                 urlSelector,
                 schedulingExecutor,
-                executionExecutor,
-                largestOf(config.connectTimeout(), config.readTimeout(), config.writeTimeout())
-        );
+                executionExecutor);
     }
 
     /**

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
@@ -29,8 +29,6 @@ import com.palantir.remoting3.tracing.Tracers;
 import com.palantir.remoting3.tracing.okhttp3.OkhttpTraceInterceptor;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
@@ -204,20 +202,6 @@ public final class OkHttpClients {
                 urlSelector,
                 schedulingExecutor,
                 executionExecutor);
-    }
-
-    /**
-     * Treat {@link Duration#ZERO} as infinity to match okhttp3.
-     */
-    @VisibleForTesting
-    static Duration largestOf(Duration... durations) {
-        if (Arrays.stream(durations).anyMatch(Duration::isZero)) {
-            return Duration.ZERO;
-        }
-
-        return Arrays.stream(durations)
-                .max(Duration::compareTo)
-                .orElseThrow(() -> new IllegalArgumentException("largestOf must be called with at least one argument"));
     }
 
     /**

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpCall.java
@@ -101,6 +101,9 @@ final class RemotingOkHttpCall extends ForwardingCall {
         });
 
         try {
+            // We don't enforce a timeout here because it's not possible to know how long this operation might take.
+            // First, it might get queued indefinitely in the Dispatcher, and then it might get retried a (potentially)
+            // unknown amount of times by the BackoffStrategy.
             return future.get();
         } catch (InterruptedException e) {
             getDelegate().cancel();

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpCall.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -62,8 +61,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
     private final ScheduledExecutorService schedulingExecutor;
     private final ExecutorService executionExecutor;
 
-    private final Duration syncCallTimeout;
-
     private final int maxNumRelocations;
 
     RemotingOkHttpCall(
@@ -73,7 +70,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
             RemotingOkHttpClient client,
             ScheduledExecutorService schedulingExecutor,
             ExecutorService executionExecutor,
-            Duration syncCallTimeout,
             int maxNumRelocations) {
         super(delegate);
         this.backoffStrategy = backoffStrategy;
@@ -81,7 +77,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
         this.client = client;
         this.schedulingExecutor = schedulingExecutor;
         this.executionExecutor = executionExecutor;
-        this.syncCallTimeout = syncCallTimeout;
         this.maxNumRelocations = maxNumRelocations;
     }
 
@@ -106,10 +101,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
         });
 
         try {
-            // zero is treated as an infinite timeout
-            return syncCallTimeout.isZero()
-                    ? future.get()
-                    : future.get(syncCallTimeout.toMillis(), TimeUnit.MILLISECONDS);
+            return future.get();
         } catch (InterruptedException e) {
             getDelegate().cancel();
             Thread.currentThread().interrupt();
@@ -129,9 +121,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
             } else {
                 throw new IOException("Failed to execute call", e);
             }
-        } catch (TimeoutException e) {
-            getDelegate().cancel();
-            throw new IOException("Call timed out after: " + syncCallTimeout.toString(), e);
         }
     }
 
@@ -303,6 +292,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
     @Override
     public RemotingOkHttpCall doClone() {
         return new RemotingOkHttpCall(getDelegate().clone(), backoffStrategy, urls, client, schedulingExecutor,
-                executionExecutor, syncCallTimeout, maxNumRelocations);
+                executionExecutor, maxNumRelocations);
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpCall.java
@@ -103,7 +103,8 @@ final class RemotingOkHttpCall extends ForwardingCall {
         try {
             // We don't enforce a timeout here because it's not possible to know how long this operation might take.
             // First, it might get queued indefinitely in the Dispatcher, and then it might get retried a (potentially)
-            // unknown amount of times by the BackoffStrategy.
+            // unknown amount of times by the BackoffStrategy. The {@code get} call times out when the underlying 
+            // OkHttp call times out (, possibly after a number of retries).
             return future.get();
         } catch (InterruptedException e) {
             getDelegate().cancel();

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpClient.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/RemotingOkHttpClient.java
@@ -16,7 +16,6 @@
 
 package com.palantir.remoting3.okhttp;
 
-import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
@@ -35,24 +34,18 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
     private final UrlSelector urls;
     private final ScheduledExecutorService schedulingExecutor;
     private final ExecutorService executionExecutor;
-    /**
-     * The timeout for synchronous {@link okhttp3.Call#execute call execution}. Typically, this should be larger than
-     * the maximum of the OkHttp connect/read/write timeout.
-     */
-    private final Duration syncCallTimeout;
 
     RemotingOkHttpClient(
             OkHttpClient delegate,
             Supplier<BackoffStrategy> backoffStrategy,
             UrlSelector urls,
             ScheduledExecutorService schedulingExecutor,
-            ExecutorService executionExecutor, Duration syncCallTimeout) {
+            ExecutorService executionExecutor) {
         super(delegate);
         this.backoffStrategyFactory = backoffStrategy;
         this.urls = urls;
         this.schedulingExecutor = schedulingExecutor;
         this.executionExecutor = executionExecutor;
-        this.syncCallTimeout = syncCallTimeout;
     }
 
     @Override
@@ -69,7 +62,6 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
                 this,
                 schedulingExecutor,
                 executionExecutor,
-                syncCallTimeout,
                 maxNumRelocations);
     }
 }

--- a/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/OkHttpClientsTest.java
@@ -527,18 +527,6 @@ public final class OkHttpClientsTest extends TestBase {
         assertThat(synchronousCall.body().string()).isEqualTo("Hello, world!");
     }
 
-    @Test
-    public void largestOf_sanity() throws Exception {
-        assertThat(OkHttpClients.largestOf(Duration.ofMinutes(1), Duration.ofSeconds(20), Duration.ofHours(7)))
-                .isEqualTo(Duration.ofHours(7));
-    }
-
-    @Test
-    public void largestOf_treats_zero_as_infinity() throws Exception {
-        assertThat(OkHttpClients.largestOf(Duration.ZERO, Duration.ofSeconds(20), Duration.ofHours(7)))
-                .isEqualTo(Duration.ZERO);
-    }
-
     @Test(timeout = 10_000)
     public void randomizesUrls() throws IOException {
         boolean server2WasHit = false;


### PR DESCRIPTION
In light of using a backoff strategy, and the fact that requests can be queued in the okhttp dispatcher, it doesn't make sense to enforce a sync timeout of `max(read,write,connect timeouts)` on the future we wait on in `RemotingOkHttpCall.execute()`.
Attempts to make this timeout duration large enough to accommodate for the backoff strategy would not be completely correct either because we'd have to account for queueing too.
Therefore, it's better just to drop this blanket timeout, and trust okhttp's timeout logic.

I'm planning to follow this up by
- [x] adding metrics on the dispatcher's `queuedCallsCount()` to give more visibility into how often requests end up getting queued #742
- [ ] (if we think it necessary based on the metrics) enforcing a limit on the queued calls

Fixes #740