### PR TITLE
Prefer chacha ciphers when available

### DIFF
--- a/http-clients/src/main/java/com/palantir/remoting3/clients/CipherSuites.java
+++ b/http-clients/src/main/java/com/palantir/remoting3/clients/CipherSuites.java
@@ -9,6 +9,8 @@ import com.google.common.collect.ImmutableList;
 public final class CipherSuites {
 
     private static final ImmutableList<String> FAST_CIPHER_SUITES = ImmutableList.of(
+            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
             "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
             "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
             "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
@@ -21,8 +23,6 @@ public final class CipherSuites {
             "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
             "TLS_RSA_WITH_AES_256_CBC_SHA",
             "TLS_RSA_WITH_AES_128_CBC_SHA",
-            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
             "TLS_EMPTY_RENEGOTIATION_INFO_SCSV");
 
     private static final ImmutableList<String> GCM_CIPHER_SUITES = ImmutableList.of(


### PR DESCRIPTION
More secure and performant than the other ciphers listed.