### PR TITLE
Enable GCM ciphers by default

### DIFF
--- a/http-clients/src/main/java/com/palantir/remoting3/clients/ClientConfigurations.java
+++ b/http-clients/src/main/java/com/palantir/remoting3/clients/ClientConfigurations.java
@@ -42,7 +42,7 @@ public final class ClientConfigurations {
     private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMinutes(10);
     private static final Duration DEFAULT_BACKOFF_SLOT_SIZE = Duration.ofMillis(250);
     private static final Duration DEFAULT_FAILED_URL_COOLDOWN = Duration.ZERO;
-    private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = false;
+    private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = true;
     private static final NodeSelectionStrategy DEFAULT_NODE_SELECTION_STRATEGY = NodeSelectionStrategy.PIN_UNTIL_ERROR;
 
     private ClientConfigurations() {}

--- a/http-clients/src/test/java/com/palantir/remoting3/clients/ClientConfigurationsTest.java
+++ b/http-clients/src/test/java/com/palantir/remoting3/clients/ClientConfigurationsTest.java
@@ -53,7 +53,7 @@ public final class ClientConfigurationsTest {
         assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
         assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(10));
         assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(10));
-        assertThat(actual.enableGcmCipherSuites()).isFalse();
+        assertThat(actual.enableGcmCipherSuites()).isTrue();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);
     }
 
@@ -69,7 +69,7 @@ public final class ClientConfigurationsTest {
         assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
         assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(10));
         assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(10));
-        assertThat(actual.enableGcmCipherSuites()).isFalse();
+        assertThat(actual.enableGcmCipherSuites()).isTrue();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);
     }
 


### PR DESCRIPTION
They are more secure than the others aside from
CHACHA20_POLY1305, and provided by the java 8 jvm.

Allowing these ciphers by default provides betters security and
compatibility with other services. Servers may choose to prefer
other ciphers if available, and clients using native tls
implementations (e.g. Conscrypt) will perform much better
using gcm ciphers than cbc.