### PR TITLE
fixed number of retries

### DIFF
--- a/http-clients/src/main/java/com/palantir/remoting3/clients/ClientConfigurations.java
+++ b/http-clients/src/main/java/com/palantir/remoting3/clients/ClientConfigurations.java
@@ -44,6 +44,7 @@ public final class ClientConfigurations {
     private static final Duration DEFAULT_FAILED_URL_COOLDOWN = Duration.ZERO;
     private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = false;
     private static final NodeSelectionStrategy DEFAULT_NODE_SELECTION_STRATEGY = NodeSelectionStrategy.PIN_UNTIL_ERROR;
+    private static final int DEFAULT_MAX_NUM_RETRIES = 3;
 
     private ClientConfigurations() {}
 
@@ -63,7 +64,7 @@ public final class ClientConfigurations {
                 .proxy(config.proxy().map(ClientConfigurations::createProxySelector).orElse(ProxySelector.getDefault()))
                 .proxyCredentials(config.proxy().flatMap(ProxyConfiguration::credentials))
                 .meshProxy(meshProxy(config.proxy()))
-                .maxNumRetries(config.maxNumRetries().orElse(config.uris().size()))
+                .maxNumRetries(config.maxNumRetries().orElse(DEFAULT_MAX_NUM_RETRIES))
                 .nodeSelectionStrategy(DEFAULT_NODE_SELECTION_STRATEGY)
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .backoffSlotSize(config.backoffSlotSize().orElse(DEFAULT_BACKOFF_SLOT_SIZE))


### PR DESCRIPTION
Client should retry a fixed, configurable, number of times rather than the number of nodes discovered.
This prevents poor behavior in both the single and the large N cases.