### PR TITLE
Bans NaN, Infinity, +Infinity for double type serde

### DIFF
--- a/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/ObjectMappers.java
+++ b/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/ObjectMappers.java
@@ -95,7 +95,7 @@ public final class ObjectMappers {
     /**
      * Configures provided ObjectMapper with default modules and settings.
      * <p>
-     * Modules: Guava, JDK7, JDK8, Afterburner, JavaTime
+     * Modules: Guava, JDK7, JDK8, Afterburner, JavaTime, and StrictDouble.
      * <p>
      * Settings:
      * <ul>
@@ -103,6 +103,7 @@ public final class ObjectMappers {
      *   <li>Dates remain in received timezone.
      *   <li>Exceptions will not be wrapped with Jackson exceptions.
      *   <li>Deserializing a null for a primitive field will throw an exception.
+     *   <li>Serialize/Deserializing a double with "NaN" or "Infinity" or "-Infinity" will throw an exception.
      * </ul>
      */
     public static ObjectMapper withDefaultModules(ObjectMapper mapper) {

--- a/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/ObjectMappers.java
+++ b/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/ObjectMappers.java
@@ -112,6 +112,7 @@ public final class ObjectMappers {
                 .registerModule(new Jdk8Module().configureAbsentsAsNulls(true))
                 .registerModule(new AfterburnerModule())
                 .registerModule(new JavaTimeModule())
+                .registerModule(new StrictDoubleModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                 .disable(DeserializationFeature.WRAP_EXCEPTIONS)

--- a/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
+++ b/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
@@ -44,9 +44,9 @@ import java.lang.reflect.Type;
  */
 public class StrictDoubleModule extends SimpleModule {
 
-   public StrictDoubleModule() {
+    public StrictDoubleModule() {
         super(StrictDoubleModule.class.getCanonicalName());
-        
+
         addDeserializer(Double.class, new StrictDoubleDeserializer(Double.class, null));
         addDeserializer(double.class, new StrictDoubleDeserializer(double.class, 0.d));
         addSerializer(Double.class, new StrictDoubleSerializer(Double.class));

--- a/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
+++ b/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
@@ -1,0 +1,106 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.ext.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.NumberDeserializers;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+/**
+ * Used to enforce strict double values by banning "NaN", "+Infinity", and "-Infinity" for both serialization
+ * and deserialization.
+ */
+class StrictDoubleModule extends SimpleModule {
+
+    public StrictDoubleModule() {
+        super(StrictDoubleModule.class.getCanonicalName());
+        addDeserializer(Double.class, new StrictDoubleDeserializer(Double.class, null));
+        addDeserializer(double.class, new StrictDoubleDeserializer(double.class, 0.d));
+        addSerializer(Double.class, new StrictDoubleSerializer(Double.class));
+        addSerializer(double.class, new StrictDoubleSerializer(double.class));
+    }
+
+    static class StrictDoubleDeserializer extends NumberDeserializers.DoubleDeserializer {
+
+        StrictDoubleDeserializer(Class<Double> cls, Double nvl) {
+            super(cls, nvl);
+        }
+
+        @Override
+        public Double deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            Double doubleValue = super.deserialize(p, ctxt);
+            if (Double.isInfinite(doubleValue.doubleValue()) || Double.isNaN(doubleValue.doubleValue())) {
+                throw new JsonParseException(p,
+                        "NaN or Infinity is not allowed and only concrete double value is allowed.");
+            }
+            return doubleValue;
+        }
+
+        @Override
+        public Double deserializeWithType(JsonParser p, DeserializationContext ctxt,
+                TypeDeserializer typeDeserializer) throws IOException {
+            return deserialize(p, ctxt);
+        }
+    }
+
+
+    static class StrictDoubleSerializer extends StdScalarSerializer<Double> {
+        protected StrictDoubleSerializer(Class<Double> t) {
+            super(t);
+        }
+
+        @Override
+        public JsonNode getSchema(SerializerProvider provider, Type typeHint) {
+            return createSchemaNode("number", true);
+        }
+
+        @Override
+        public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint)
+                throws JsonMappingException {
+            visitFloatFormat(visitor, typeHint, JsonParser.NumberType.DOUBLE);
+        }
+
+        @Override
+        public void serialize(Double value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            if (Double.isInfinite(value.doubleValue()) || Double.isNaN(value.doubleValue())) {
+                throw new JsonGenerationException(
+                        "NaN or Infinity is not allowed and only concrete double value is allowed.", gen);
+            }
+            gen.writeNumber(value.doubleValue());
+        }
+
+        @Override
+        public void serializeWithType(Double value, JsonGenerator gen, SerializerProvider provider,
+                TypeSerializer typeSer) throws IOException {
+            serialize(value, gen, provider);
+        }
+    }
+}

--- a/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
+++ b/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
@@ -71,7 +71,6 @@ class StrictDoubleModule extends SimpleModule {
         }
     }
 
-
     static class StrictDoubleSerializer extends StdScalarSerializer<Double> {
         protected StrictDoubleSerializer(Class<Double> t) {
             super(t);

--- a/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
+++ b/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
@@ -42,9 +42,9 @@ import java.lang.reflect.Type;
  *
  * @see <a href="https://github.com/FasterXML/jackson-databind/issues/911">https://github.com/FasterXML/jackson-databind/issues/911</a> for more details.
  */
-public class StrictDoubleModule extends SimpleModule {
+final class StrictDoubleModule extends SimpleModule {
 
-    public StrictDoubleModule() {
+    StrictDoubleModule() {
         super(StrictDoubleModule.class.getCanonicalName());
 
         addDeserializer(Double.class, new StrictDoubleDeserializer(Double.class, null));
@@ -53,7 +53,7 @@ public class StrictDoubleModule extends SimpleModule {
         addSerializer(double.class, new StrictDoubleSerializer(double.class));
     }
 
-    static class StrictDoubleDeserializer extends NumberDeserializers.DoubleDeserializer {
+    static final class StrictDoubleDeserializer extends NumberDeserializers.DoubleDeserializer {
 
         StrictDoubleDeserializer(Class<Double> cls, Double nvl) {
             super(cls, nvl);
@@ -76,7 +76,11 @@ public class StrictDoubleModule extends SimpleModule {
         }
     }
 
-    static class StrictDoubleSerializer extends StdScalarSerializer<Double> {
+    /**
+     * Based on {@link com.fasterxml.jackson.databind.ser.std.NumberSerializers.DoubleSerializer}
+     * and {@link com.fasterxml.jackson.databind.ser.std.NumberSerializers.Base}.
+     */
+    static final class StrictDoubleSerializer extends StdScalarSerializer<Double> {
         protected StrictDoubleSerializer(Class<Double> clazz) {
             super(clazz);
         }

--- a/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
+++ b/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
@@ -64,7 +64,7 @@ public class StrictDoubleModule extends SimpleModule {
             Double doubleValue = super.deserialize(parser, ctxt);
             if (Double.isInfinite(doubleValue.doubleValue()) || Double.isNaN(doubleValue.doubleValue())) {
                 throw new JsonParseException(parser,
-                        "NaN or Infinity is not allowed and only concrete double value is allowed.");
+                        "NaN or Infinity is not allowed and only concrete double values are allowed.");
             }
             return doubleValue;
         }
@@ -96,7 +96,7 @@ public class StrictDoubleModule extends SimpleModule {
         public void serialize(Double value, JsonGenerator gen, SerializerProvider provider) throws IOException {
             if (Double.isInfinite(value.doubleValue()) || Double.isNaN(value.doubleValue())) {
                 throw new JsonGenerationException(
-                        "NaN or Infinity is not allowed and only concrete double value is allowed.", gen);
+                        "NaN or Infinity is not allowed and only concrete double values are allowed.", gen);
             }
             gen.writeNumber(value.doubleValue());
         }

--- a/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
+++ b/extras/jackson-support/src/main/java/com/palantir/remoting3/ext/jackson/StrictDoubleModule.java
@@ -37,11 +37,16 @@ import java.lang.reflect.Type;
 /**
  * Used to enforce strict double values by banning "NaN", "+Infinity", and "-Infinity" for both serialization
  * and deserialization.
+ * <p>
+ * Jackson does not support serialization/deserialization of strict numbers as of 2.9.6.
+ *
+ * @see <a href="https://github.com/FasterXML/jackson-databind/issues/911">https://github.com/FasterXML/jackson-databind/issues/911</a> for more details.
  */
-class StrictDoubleModule extends SimpleModule {
+public class StrictDoubleModule extends SimpleModule {
 
-    public StrictDoubleModule() {
+   public StrictDoubleModule() {
         super(StrictDoubleModule.class.getCanonicalName());
+        
         addDeserializer(Double.class, new StrictDoubleDeserializer(Double.class, null));
         addDeserializer(double.class, new StrictDoubleDeserializer(double.class, 0.d));
         addSerializer(Double.class, new StrictDoubleSerializer(Double.class));
@@ -55,25 +60,25 @@ class StrictDoubleModule extends SimpleModule {
         }
 
         @Override
-        public Double deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-            Double doubleValue = super.deserialize(p, ctxt);
+        public Double deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException {
+            Double doubleValue = super.deserialize(parser, ctxt);
             if (Double.isInfinite(doubleValue.doubleValue()) || Double.isNaN(doubleValue.doubleValue())) {
-                throw new JsonParseException(p,
+                throw new JsonParseException(parser,
                         "NaN or Infinity is not allowed and only concrete double value is allowed.");
             }
             return doubleValue;
         }
 
         @Override
-        public Double deserializeWithType(JsonParser p, DeserializationContext ctxt,
+        public Double deserializeWithType(JsonParser parser, DeserializationContext ctxt,
                 TypeDeserializer typeDeserializer) throws IOException {
-            return deserialize(p, ctxt);
+            return deserialize(parser, ctxt);
         }
     }
 
     static class StrictDoubleSerializer extends StdScalarSerializer<Double> {
-        protected StrictDoubleSerializer(Class<Double> t) {
-            super(t);
+        protected StrictDoubleSerializer(Class<Double> clazz) {
+            super(clazz);
         }
 
         @Override

--- a/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
+++ b/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
@@ -17,7 +17,10 @@
 package com.palantir.remoting3.ext.jackson;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
@@ -71,6 +74,52 @@ public final class ObjectMappersTest {
     }
 
     @Test
+    public void serializingDoubleWithoutConcreteValueThrowsException() {
+        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.valueOf("NaN")))
+                .isInstanceOf(JsonGenerationException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.valueOf("Infinity")))
+                .isInstanceOf(JsonGenerationException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.valueOf("-Infinity")))
+                .isInstanceOf(JsonGenerationException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+
+        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.NaN))
+                .isInstanceOf(JsonGenerationException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.POSITIVE_INFINITY))
+                .isInstanceOf(JsonGenerationException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.NEGATIVE_INFINITY))
+                .isInstanceOf(JsonGenerationException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+    }
+
+    @Test
+    public void deserializingToDoubleWithoutConcreteValueThrowsException() {
+        assertThatThrownBy(() -> MAPPER.readValue("\"NaN\"", Double.class))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+        assertThatThrownBy(() -> MAPPER.readValue("\"+Infinity\"", Double.class))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+        assertThatThrownBy(() -> MAPPER.readValue("\"-Infinity\"", Double.class))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+
+        assertThatThrownBy(() -> MAPPER.readValue("\"NaN\"", double.class))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+        assertThatThrownBy(() -> MAPPER.readValue("\"+Infinity\"", double.class))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+        assertThatThrownBy(() -> MAPPER.readValue("\"-Infinity\"", double.class))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+    }
+
+    @Test
     public void testMappersReturnNewInstance() {
         assertThat(ObjectMappers.newClientObjectMapper()).isNotSameAs(ObjectMappers.newClientObjectMapper());
     }
@@ -101,4 +150,5 @@ public final class ObjectMappersTest {
     private static <T> T serDe(Object object, Class<T> clazz) throws IOException {
         return MAPPER.readValue(ser(object), clazz);
     }
+
 }

--- a/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
+++ b/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
@@ -74,49 +74,31 @@ public final class ObjectMappersTest {
     }
 
     @Test
-    public void serializingDoubleWithoutConcreteValueThrowsException() {
-        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.valueOf("NaN")))
-                .isInstanceOf(JsonGenerationException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
-        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.valueOf("Infinity")))
-                .isInstanceOf(JsonGenerationException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
-        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.valueOf("-Infinity")))
-                .isInstanceOf(JsonGenerationException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+    public void serializeUsingStrictDoubleModule() throws JsonProcessingException {
+        testSerStrictDoubleWithoutConcreteValueThrowsException(Double.valueOf("NaN"));
+        testSerStrictDoubleWithoutConcreteValueThrowsException(Double.valueOf("Infinity"));
+        testSerStrictDoubleWithoutConcreteValueThrowsException(Double.valueOf("-Infinity"));
 
-        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.NaN))
-                .isInstanceOf(JsonGenerationException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
-        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.POSITIVE_INFINITY))
-                .isInstanceOf(JsonGenerationException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
-        assertThatThrownBy(() -> MAPPER.writeValueAsString(Double.NEGATIVE_INFINITY))
-                .isInstanceOf(JsonGenerationException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+        testSerStrictDoubleWithoutConcreteValueThrowsException(Double.NaN);
+        testSerStrictDoubleWithoutConcreteValueThrowsException(Double.POSITIVE_INFINITY);
+        testSerStrictDoubleWithoutConcreteValueThrowsException(Double.NEGATIVE_INFINITY);
+
+        assertThat(MAPPER.writeValueAsString(Double.valueOf("10.0"))).isEqualTo("10.0");
+        assertThat(MAPPER.writeValueAsString(10.0)).isEqualTo("10.0");
     }
 
     @Test
-    public void deserializingToDoubleWithoutConcreteValueThrowsException() {
-        assertThatThrownBy(() -> MAPPER.readValue("\"NaN\"", Double.class))
-                .isInstanceOf(JsonParseException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
-        assertThatThrownBy(() -> MAPPER.readValue("\"+Infinity\"", Double.class))
-                .isInstanceOf(JsonParseException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
-        assertThatThrownBy(() -> MAPPER.readValue("\"-Infinity\"", Double.class))
-                .isInstanceOf(JsonParseException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+    public void deserilizeUsingStrictDoubleModule() throws IOException {
+        testDeStrictDoubleWithoutConcreteValueThrowsException("\"NaN\"", Double.class);
+        testDeStrictDoubleWithoutConcreteValueThrowsException("\"+Infinity\"", Double.class);
+        testDeStrictDoubleWithoutConcreteValueThrowsException("\"-Infinity\"", Double.class);
 
-        assertThatThrownBy(() -> MAPPER.readValue("\"NaN\"", double.class))
-                .isInstanceOf(JsonParseException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
-        assertThatThrownBy(() -> MAPPER.readValue("\"+Infinity\"", double.class))
-                .isInstanceOf(JsonParseException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
-        assertThatThrownBy(() -> MAPPER.readValue("\"-Infinity\"", double.class))
-                .isInstanceOf(JsonParseException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+        testDeStrictDoubleWithoutConcreteValueThrowsException("\"NaN\"", double.class);
+        testDeStrictDoubleWithoutConcreteValueThrowsException("\"+Infinity\"", double.class);
+        testDeStrictDoubleWithoutConcreteValueThrowsException("\"-Infinity\"", double.class);
+
+        assertThat(MAPPER.readValue("10.0", Double.class)).isEqualTo(Double.valueOf(10.0d));
+        assertThat(MAPPER.readValue("10.0", double.class)).isEqualTo(Double.valueOf(10.0d));
     }
 
     @Test
@@ -143,6 +125,19 @@ public final class ObjectMappersTest {
         assertThat(serDe(localDate, LocalDate.class)).isEqualTo(localDate);
     }
 
+    private static void testSerStrictDoubleWithoutConcreteValueThrowsException(Object object) {
+        assertThatThrownBy(() -> MAPPER.writeValueAsString(object))
+                .isInstanceOf(JsonGenerationException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+
+    }
+
+    private static<T> void testDeStrictDoubleWithoutConcreteValueThrowsException(String object, Class<T> clazz) {
+        assertThatThrownBy(() -> MAPPER.readValue(object, clazz))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+    }
+
     private static String ser(Object object) throws IOException {
         return MAPPER.writeValueAsString(object);
     }
@@ -150,5 +145,4 @@ public final class ObjectMappersTest {
     private static <T> T serDe(Object object, Class<T> clazz) throws IOException {
         return MAPPER.readValue(ser(object), clazz);
     }
-
 }

--- a/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
+++ b/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
@@ -132,7 +132,7 @@ public final class ObjectMappersTest {
 
     }
 
-    private static<T> void testDeStrictDoubleWithoutConcreteValueThrowsException(String object, Class<T> clazz) {
+    private static <T> void testDeStrictDoubleWithoutConcreteValueThrowsException(String object, Class<T> clazz) {
         assertThatThrownBy(() -> MAPPER.readValue(object, clazz))
                 .isInstanceOf(JsonParseException.class)
                 .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");

--- a/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
+++ b/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
@@ -85,6 +85,8 @@ public final class ObjectMappersTest {
 
         assertThat(MAPPER.writeValueAsString(Double.valueOf("10.0"))).isEqualTo("10.0");
         assertThat(MAPPER.writeValueAsString(10.0)).isEqualTo("10.0");
+        assertThat(MAPPER.writeValueAsString(+0.0d)).isEqualTo("0.0");
+        assertThat(MAPPER.writeValueAsString(-0.0d)).isEqualTo("-0.0");
     }
 
     @Test
@@ -97,8 +99,13 @@ public final class ObjectMappersTest {
         testDeStrictDoubleWithoutConcreteValueThrowsException("\"+Infinity\"", double.class);
         testDeStrictDoubleWithoutConcreteValueThrowsException("\"-Infinity\"", double.class);
 
-        assertThat(MAPPER.readValue("10.0", Double.class)).isEqualTo(Double.valueOf(10.0d));
-        assertThat(MAPPER.readValue("10.0", double.class)).isEqualTo(Double.valueOf(10.0d));
+        assertThat(MAPPER.readValue("10.0", Double.class)).isEqualTo(10.0d);
+        assertThat(MAPPER.readValue("10.0", double.class)).isEqualTo(10.0d);
+
+        assertThat(MAPPER.readValue("0.0", Double.class)).isEqualTo(0.0d);
+        assertThat(MAPPER.readValue("-0.0", Double.class)).isEqualTo(-0.0d);
+        assertThat(MAPPER.readValue("0.0", double.class)).isEqualTo(0.0d);
+        assertThat(MAPPER.readValue("-0.0", double.class)).isEqualTo(-0.0d);
     }
 
     @Test

--- a/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
+++ b/extras/jackson-support/src/test/java/com/palantir/remoting3/ext/jackson/ObjectMappersTest.java
@@ -128,14 +128,14 @@ public final class ObjectMappersTest {
     private static void testSerStrictDoubleWithoutConcreteValueThrowsException(Object object) {
         assertThatThrownBy(() -> MAPPER.writeValueAsString(object))
                 .isInstanceOf(JsonGenerationException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double values are allowed.");
 
     }
 
     private static <T> void testDeStrictDoubleWithoutConcreteValueThrowsException(String object, Class<T> clazz) {
         assertThatThrownBy(() -> MAPPER.readValue(object, clazz))
                 .isInstanceOf(JsonParseException.class)
-                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double value is allowed.");
+                .hasMessageContaining("NaN or Infinity is not allowed and only concrete double values are allowed.");
     }
 
     private static String ser(Object object) throws IOException {


### PR DESCRIPTION
## Before this PR
remoting objectmapper allows `NaN` and `Infinity` as values for double type during serde.

## After this PR
`NaN` and `Infinity` are now banned and object  mapper will throw an exception when serialzing/deserialing doubles that have those values. This is to be compliant with the [conjure spec(to be updated)](https://github.com/palantir/conjure/blob/develop/docs/specification.md)
