### PR TITLE
Feign coerces null / absent response to empty collection

### DIFF
--- a/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -30,6 +30,7 @@ import com.palantir.remoting3.okhttp.HostMetricsRegistry;
 import com.palantir.remoting3.okhttp.OkHttpClients;
 import feign.CborDelegateDecoder;
 import feign.CborDelegateEncoder;
+import feign.CoerceNullCollectionsDecoder;
 import feign.Contract;
 import feign.Feign;
 import feign.GuavaOptionalAwareDecoder;
@@ -131,12 +132,13 @@ abstract class AbstractFeignJaxRsClientBuilder {
 
     private static Decoder createDecoder(ObjectMapper objectMapper, ObjectMapper cborObjectMapper) {
         return new RejectNullDecoder(
-                new Java8OptionalAwareDecoder(
-                    new GuavaOptionalAwareDecoder(
-                            new InputStreamDelegateDecoder(
-                                    new TextDelegateDecoder(
-                                            new CborDelegateDecoder(
-                                                    cborObjectMapper,
-                                                        new JacksonDecoder(objectMapper)))))));
-    }
+                new CoerceNullCollectionsDecoder(
+                    new Java8OptionalAwareDecoder(
+                        new GuavaOptionalAwareDecoder(
+                                new InputStreamDelegateDecoder(
+                                        new TextDelegateDecoder(
+                                                new CborDelegateDecoder(
+                                                        cborObjectMapper,
+                                                            new JacksonDecoder(objectMapper))))))));
+        }
 }

--- a/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -140,5 +140,5 @@ abstract class AbstractFeignJaxRsClientBuilder {
                                                 new CborDelegateDecoder(
                                                         cborObjectMapper,
                                                             new JacksonDecoder(objectMapper))))))));
-        }
+    }
 }

--- a/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -38,7 +38,7 @@ import feign.InputStreamDelegateDecoder;
 import feign.InputStreamDelegateEncoder;
 import feign.Java8OptionalAwareDecoder;
 import feign.Logger;
-import feign.RejectNullDecoder;
+import feign.NeverReturnNullDecoder;
 import feign.Request;
 import feign.Retryer;
 import feign.TextDelegateDecoder;
@@ -131,7 +131,7 @@ abstract class AbstractFeignJaxRsClientBuilder {
     }
 
     private static Decoder createDecoder(ObjectMapper objectMapper, ObjectMapper cborObjectMapper) {
-        return new RejectNullDecoder(
+        return new NeverReturnNullDecoder(
                 new CoerceNullCollectionsDecoder(
                     new Java8OptionalAwareDecoder(
                         new GuavaOptionalAwareDecoder(

--- a/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -130,13 +130,13 @@ abstract class AbstractFeignJaxRsClientBuilder {
     }
 
     private static Decoder createDecoder(ObjectMapper objectMapper, ObjectMapper cborObjectMapper) {
-        return new Java8OptionalAwareDecoder(
-                new GuavaOptionalAwareDecoder(
-                        new InputStreamDelegateDecoder(
-                                new TextDelegateDecoder(
-                                        new CborDelegateDecoder(
-                                                cborObjectMapper,
-                                                new RejectNullDecoder(
+        return new RejectNullDecoder(
+                new Java8OptionalAwareDecoder(
+                    new GuavaOptionalAwareDecoder(
+                            new InputStreamDelegateDecoder(
+                                    new TextDelegateDecoder(
+                                            new CborDelegateDecoder(
+                                                    cborObjectMapper,
                                                         new JacksonDecoder(objectMapper)))))));
     }
 }

--- a/jaxrs-clients/src/main/java/feign/CoerceNullCollectionsDecoder.java
+++ b/jaxrs-clients/src/main/java/feign/CoerceNullCollectionsDecoder.java
@@ -24,6 +24,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * We want to be lenient and interpret "null" or empty responses (including 204) as the empty value if the expected
+ * type is a collection. Jackson can only do this for fields inside an object, but for top-level fields we have to do
+ * this manually.
+ */
+// TODO(dsanduleac): link to spec
 public final class CoerceNullCollectionsDecoder implements Decoder {
     private final Decoder delegate;
 

--- a/jaxrs-clients/src/main/java/feign/CoerceNullCollectionsDecoder.java
+++ b/jaxrs-clients/src/main/java/feign/CoerceNullCollectionsDecoder.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign;
+
+import feign.codec.Decoder;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class CoerceNullCollectionsDecoder implements Decoder {
+    private final Decoder delegate;
+
+    public CoerceNullCollectionsDecoder(Decoder delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object decode(Response response, Type type) throws FeignException, IOException {
+        Object object = delegate.decode(response, type);
+        if ((response.status() == 200 || response.status() == 204) && object == null) {
+            Class<?> rawType = Types.getRawType(type);
+            if (List.class.isAssignableFrom(rawType)) {
+                return Collections.emptyList();
+            } else if (Set.class.isAssignableFrom(rawType)) {
+                return Collections.emptySet();
+            } else if (Map.class.isAssignableFrom(rawType)) {
+                return Collections.emptyMap();
+            }
+        }
+        return object;
+    }
+}

--- a/jaxrs-clients/src/main/java/feign/NeverReturnNullDecoder.java
+++ b/jaxrs-clients/src/main/java/feign/NeverReturnNullDecoder.java
@@ -22,10 +22,10 @@ import feign.codec.Decoder;
 import java.io.IOException;
 import java.lang.reflect.Type;
 
-public final class RejectNullDecoder implements Decoder {
+public final class NeverReturnNullDecoder implements Decoder {
     private final Decoder delegate;
 
-    public RejectNullDecoder(Decoder delegate) {
+    public NeverReturnNullDecoder(Decoder delegate) {
         this.delegate = delegate;
     }
 

--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientCollectionHandlingTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientCollectionHandlingTest.java
@@ -1,0 +1,98 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.jaxrs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public final class JaxRsClientCollectionHandlingTest extends TestBase {
+
+    @Rule
+    public final MockWebServer server = new MockWebServer();
+
+    private Service proxy;
+
+    @Parameters(name = "{index}: code {0} body: \"{1}\"")
+    public static Collection<Object[]> responses() {
+        return Arrays.asList(new Object[][]{
+                { 200, "null" },
+                { 200, "" },
+                { 204, "" }
+        });
+    }
+
+    @Parameter
+    public int code;
+
+    @Parameter(1)
+    public String body;
+
+    @Before
+    public void before() {
+        proxy = JaxRsClient.create(Service.class, AGENT,
+                createTestConfig("http://localhost:" + server.getPort()));
+        MockResponse mockResponse = new MockResponse().setResponseCode(code).setBody(body);
+        server.enqueue(mockResponse);
+    }
+
+    @Path("/")
+    public interface Service {
+        @GET
+        @Path("/list")
+        List<String> getList();
+
+        @GET
+        @Path("/set")
+        Set<String> getSet();
+
+        @GET
+        @Path("/map")
+        Map<String, String> getMap();
+    }
+
+    @Test
+    public void testList() {
+        assertThat(proxy.getList()).isEmpty();
+    }
+
+    @Test
+    public void testSet() {
+        assertThat(proxy.getSet()).isEmpty();
+    }
+
+    @Test
+    public void testMap() {
+        assertThat(proxy.getMap()).isEmpty();
+    }
+}

--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/feignimpl/CollectionDefaultDecodingTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/feignimpl/CollectionDefaultDecodingTest.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.jaxrs.feignimpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.remoting3.jaxrs.JaxRsClient;
+import com.palantir.remoting3.jaxrs.TestBase;
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * Tests that nulls are correctly deserialized into empty collections.
+ */
+public final class CollectionDefaultDecodingTest extends TestBase {
+
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> APP = new DropwizardAppRule<>(Java8TestServer.class,
+            "src/test/resources/test-server.yml");
+
+    private Java8TestServer.TestService service;
+
+    @Before
+    public void before() {
+        String endpointUri = "http://localhost:" + APP.getLocalPort();
+        service = JaxRsClient.create(Java8TestServer.TestService.class, AGENT, createTestConfig(endpointUri));
+    }
+
+    @Test
+    public void testList() {
+        assertThat(service.getNullList()).isEmpty();
+    }
+
+    @Test
+    public void testSet() {
+        assertThat(service.getNullSet()).isEmpty();
+    }
+
+    @Test
+    public void testMap() {
+        assertThat(service.getNullMap()).isEmpty();
+    }
+}

--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/feignimpl/Java8TestServer.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/feignimpl/Java8TestServer.java
@@ -30,7 +30,10 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.ForbiddenException;
@@ -156,6 +159,21 @@ public class Java8TestServer extends Application<Configuration> {
         public Java8ComplexType getJava8ComplexType(Java8ComplexType value) {
             return value;
         }
+
+        @Override
+        public List<String> getNullList() {
+            return null;
+        }
+
+        @Override
+        public Set<String> getNullSet() {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getNullMap() {
+            return null;
+        }
     }
 
     @Path("/")
@@ -235,5 +253,20 @@ public class Java8TestServer extends Application<Configuration> {
         @Consumes(MediaType.APPLICATION_JSON)
         @Produces(MediaType.APPLICATION_JSON)
         Java8ComplexType getJava8ComplexType(Java8ComplexType value);
+
+        @POST
+        @Path("/list")
+        @Produces(MediaType.APPLICATION_JSON)
+        List<String> getNullList();
+
+        @POST
+        @Path("/set")
+        @Produces(MediaType.APPLICATION_JSON)
+        Set<String> getNullSet();
+
+        @POST
+        @Path("/map")
+        @Produces(MediaType.APPLICATION_JSON)
+        Map<String, String> getNullMap();
     }
 }

--- a/jaxrs-clients/src/test/java/feign/NeverReturnNullDecoderTest.java
+++ b/jaxrs-clients/src/test/java/feign/NeverReturnNullDecoderTest.java
@@ -32,10 +32,10 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
-public final class RejectNullDecoderTest extends TestBase {
+public final class NeverReturnNullDecoderTest extends TestBase {
 
     private final Map<String, Collection<String>> headers = Maps.newHashMap();
-    private final Decoder textDelegateDecoder = new RejectNullDecoder(
+    private final Decoder textDelegateDecoder = new NeverReturnNullDecoder(
             new JacksonDecoder(ObjectMappers.newClientObjectMapper()));
 
     @Test

--- a/jaxrs-clients/src/test/java/feign/TextDelegateDecoderTest.java
+++ b/jaxrs-clients/src/test/java/feign/TextDelegateDecoderTest.java
@@ -32,6 +32,7 @@ import com.google.common.net.HttpHeaders;
 import com.palantir.remoting3.jaxrs.JaxRsClient;
 import com.palantir.remoting3.jaxrs.TestBase;
 import com.palantir.remoting3.jaxrs.feignimpl.GuavaTestServer;
+import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import io.dropwizard.Configuration;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -140,6 +141,8 @@ public final class TextDelegateDecoderTest extends TestBase {
     @Test
     public void testStandardClientsUseTextDelegateEncoder() {
         assertThat(service.getString("string"), is("string"));
-        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> service.getString(null));
+        assertThatExceptionOfType(DecodeException.class)
+                .isThrownBy(() -> service.getString(null))
+                .withCauseInstanceOf(NullPointerException.class);
     }
 }

--- a/jaxrs-clients/src/test/java/feign/TextDelegateDecoderTest.java
+++ b/jaxrs-clients/src/test/java/feign/TextDelegateDecoderTest.java
@@ -16,6 +16,7 @@
 
 package feign;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -139,5 +140,6 @@ public final class TextDelegateDecoderTest extends TestBase {
     @Test
     public void testStandardClientsUseTextDelegateEncoder() {
         assertThat(service.getString("string"), is("string"));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> service.getString(null));
     }
 }


### PR DESCRIPTION
Fixes the break introduced in #766 - namely, that servers returning `null` where a collection was expected suddenly started throwing.

However, whereas before a `null` response would convert into a java null, with this change we
* still blow up on nulls if not expecting a collection
* create an empty collection otherwise

We support deserializing an empty collection out of

| Response code | Body      |
|---------------|-----------|
| 200           | \<empty\> |
| 200           | `null`    |
| 204           | \<empty\> |