### PR TITLE
Retrofit2 coerce null / absent response to empty collection

### DIFF
--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/CoerceNullCollectionsCallAdapterFactory.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/CoerceNullCollectionsCallAdapterFactory.java
@@ -1,0 +1,155 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ */
+
+package com.palantir.remoting3.retrofit2;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import okhttp3.Request;
+import retrofit2.Call;
+import retrofit2.CallAdapter;
+import retrofit2.Callback;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+
+/**
+ * We want to be lenient and interpret "null" or empty responses (including 204) as the empty value if the expected
+ * type is a collection. Jackson can only do this for fields inside an object, but for top-level fields we have to do
+ * this manually.
+ * <p>
+ * This class is the counterpart of {@link CoerceNullCollectionsConverterFactory} and handles coercion of 204/205
+ * responses to the default values for collections (without this, the {@link Response} body would be null,
+ * according to {@link retrofit2.OkHttpCall#parseResponse(okhttp3.Response)}).
+ */
+// TODO(dsanduleac): link to spec
+final class CoerceNullCollectionsCallAdapterFactory extends CallAdapter.Factory {
+    static final CoerceNullCollectionsCallAdapterFactory INSTANCE = new CoerceNullCollectionsCallAdapterFactory();
+
+    @Nullable
+    @Override
+    public CallAdapter<?, ?> get(
+            Type returnType, Annotation[] annotations, Retrofit retrofit) {
+        if (getRawType(returnType) != Call.class) {
+            return null;
+        }
+        Type innerType = getParameterUpperBound(0, (ParameterizedType) returnType);
+        Class rawType = getRawType(innerType);
+
+        if (List.class.isAssignableFrom(rawType)) {
+            return new DefaultingOnNullAdapter<>(returnType, Collections::emptyList);
+        } else if (Set.class.isAssignableFrom(rawType)) {
+            return new DefaultingOnNullAdapter<>(returnType, Collections::emptySet);
+        } else if (Map.class.isAssignableFrom(rawType)) {
+            return new DefaultingOnNullAdapter<>(returnType, Collections::emptyMap);
+        }
+        return null;
+    }
+
+    /**
+     * An 'operator' {@link CallAdapter} that converts {@code Call<R>} into {@code Call<R>} but upon
+     * executing/enqueing the call, it replaces the resulting {@link Response}'s deserialized body with the given
+     * default value if the body was {@code null}.
+     */
+    private static final class DefaultingOnNullAdapter<R> implements CallAdapter<R, Call<R>> {
+        private final Type responseType;
+        private final Supplier<R> defaultValue;
+
+        private DefaultingOnNullAdapter(Type responseType, Supplier<R> defaultValue) {
+            this.responseType = responseType;
+            this.defaultValue = defaultValue;
+        }
+
+        @Override
+        public Type responseType() {
+            return responseType;
+        }
+
+        @Override
+        public Call<R> adapt(Call<R> call) {
+            return new DefaultingCall<>(call, defaultValue);
+        }
+    }
+
+    /**
+     * A {@link retrofit2.Call} that returns a default if the result coming out of the delegate call
+     * (probably {@link retrofit2.OkHttpCall}) is null.
+     */
+    private static final class DefaultingCall<R> implements Call<R> {
+        private final Call<R> delegate;
+        private final Supplier<R> defaultValue;
+
+        private DefaultingCall(Call<R> delegate, Supplier<R> defaultValue) {
+            this.delegate = delegate;
+            this.defaultValue = defaultValue;
+        }
+
+        @Override
+        public Response<R> execute() throws IOException {
+            return adaptResponse(delegate.execute());
+        }
+
+        /**
+         * If the response was successful and is empty (has no body), then return the default value.
+         * Otherwise, return the response unchanged.
+         */
+        private Response<R> adaptResponse(Response<R> response) {
+            R body = response.body();
+            if (response.isSuccessful() && body == null) {
+                return Response.success(defaultValue.get(), response.raw());
+            }
+            return response;
+        }
+
+        @Override
+        public void enqueue(Callback<R> callback) {
+            delegate.enqueue(new Callback<R>() {
+                @Override
+                public void onResponse(Call<R> call, Response<R> response) {
+                    callback.onResponse(call, adaptResponse(response));
+                }
+
+                @Override
+                public void onFailure(Call<R> call, Throwable throwable) {
+                    callback.onFailure(call, throwable);
+                }
+            });
+        }
+
+        // Delegates
+
+        @Override
+        public boolean isExecuted() {
+            return delegate.isExecuted();
+        }
+
+        @Override
+        public void cancel() {
+            delegate.cancel();
+        }
+
+        @Override
+        public boolean isCanceled() {
+            return delegate.isCanceled();
+        }
+
+        @SuppressWarnings({"checkstyle:NoClone", "checkstyle:SuperClone"})
+        @Override
+        public Call<R> clone() {
+            return new DefaultingCall<>(delegate.clone(), defaultValue);
+        }
+
+        @Override
+        public Request request() {
+            return delegate.request();
+        }
+    }
+}

--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/CoerceNullCollectionsConverterFactory.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/CoerceNullCollectionsConverterFactory.java
@@ -41,7 +41,7 @@ import retrofit2.Retrofit;
  * this manually.)
  */
 // TODO(dsanduleac): link to spec
-public final class CoerceNullCollectionsConverterFactory extends Converter.Factory {
+final class CoerceNullCollectionsConverterFactory extends Converter.Factory {
     private final Converter.Factory delegate;
 
     CoerceNullCollectionsConverterFactory(Converter.Factory delegate) {

--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/CoerceNullCollectionsConverterFactory.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/CoerceNullCollectionsConverterFactory.java
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.retrofit2;
+
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+/**
+ * We want to be lenient and interpret "null" or empty responses (including 204) as the empty value if the expected
+ * type is a collection. Jackson can only do this for fields inside an object, but for top-level fields we have to do
+ * this manually.
+ * <p>
+ * {@link Converter.Factory} doesn't support handling the 204 response case, because retrofit will conveniently never
+ * call converters for 204/205 responses (see {@link retrofit2.OkHttpCall#parseResponse(Response)}) but instead
+ * returns a {code null} body.
+ * To handle 204s, we rely on {@link CoerceNullCollectionsCallAdapterFactory}.
+ */
+// TODO(dsanduleac): link to spec
+public final class CoerceNullCollectionsConverterFactory extends Converter.Factory {
+    private final Converter.Factory delegate;
+
+    CoerceNullCollectionsConverterFactory(Converter.Factory delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
+        Converter<ResponseBody, ?> responseBodyConverter = delegate.responseBodyConverter(type, annotations, retrofit);
+        return new Converter<ResponseBody, Object>() {
+            @Override
+            public Object convert(ResponseBody value) throws IOException {
+                Object object;
+                if (value.contentLength() == 0) {
+                    object = null;
+                } else {
+                    object = responseBodyConverter.convert(value);
+                }
+                if (object == null) {
+                    if (!(type instanceof ParameterizedType)) {
+                        throw new SafeIllegalStateException("Function must return a ParametrizedType",
+                                SafeArg.of("type", type));
+                    }
+                    Class<?> rawType = getRawType(getParameterUpperBound(0, (ParameterizedType) type));
+                    if (List.class.isAssignableFrom(rawType)) {
+                        return Collections.emptyList();
+                    } else if (Set.class.isAssignableFrom(rawType)) {
+                        return Collections.emptySet();
+                    } else if (Map.class.isAssignableFrom(rawType)) {
+                        return Collections.emptyMap();
+                    }
+                }
+                return object;
+            }
+        };
+    }
+
+    @Override
+    public Converter<?, RequestBody> requestBodyConverter(Type type, Annotation[] parameterAnnotations,
+            Annotation[] methodAnnotations, Retrofit retrofit) {
+        return delegate.requestBodyConverter(type, parameterAnnotations, methodAnnotations, retrofit);
+    }
+}

--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/CoerceNullCollectionsConverterFactory.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/CoerceNullCollectionsConverterFactory.java
@@ -16,11 +16,8 @@
 
 package com.palantir.remoting3.retrofit2;
 
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
@@ -63,11 +60,7 @@ public final class CoerceNullCollectionsConverterFactory extends Converter.Facto
                     object = responseBodyConverter.convert(value);
                 }
                 if (object == null) {
-                    if (!(type instanceof ParameterizedType)) {
-                        throw new SafeIllegalStateException("Function must return a ParametrizedType",
-                                SafeArg.of("type", type));
-                    }
-                    Class<?> rawType = getRawType(getParameterUpperBound(0, (ParameterizedType) type));
+                    Class<?> rawType = getRawType(type);
                     if (List.class.isAssignableFrom(rawType)) {
                         return Collections.emptyList();
                     } else if (Set.class.isAssignableFrom(rawType)) {

--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/NeverReturnNullConverterFactory.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/NeverReturnNullConverterFactory.java
@@ -26,11 +26,11 @@ import retrofit2.Converter;
 import retrofit2.Converter.Factory;
 import retrofit2.Retrofit;
 
-final class RejectNullConverterFactory extends Factory {
+final class NeverReturnNullConverterFactory extends Factory {
 
     private final Factory delegate;
 
-    RejectNullConverterFactory(Factory delegate) {
+    NeverReturnNullConverterFactory(Factory delegate) {
         this.delegate = delegate;
     }
 

--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2ClientBuilder.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2ClientBuilder.java
@@ -68,10 +68,12 @@ public final class Retrofit2ClientBuilder {
                 .addConverterFactory(
                         new CborConverterFactory(
                                 new RejectNullConverterFactory(
-                                        JacksonConverterFactory.create(OBJECT_MAPPER)),
+                                        new CoerceNullCollectionsConverterFactory(
+                                                JacksonConverterFactory.create(OBJECT_MAPPER))),
                                 CBOR_OBJECT_MAPPER))
                 .addConverterFactory(OptionalObjectToStringConverterFactory.INSTANCE)
                 .addCallAdapterFactory(AsyncSerializableErrorCallAdapterFactory.INSTANCE)
+                .addCallAdapterFactory(CoerceNullCollectionsCallAdapterFactory.INSTANCE)
                 .build();
         return retrofit.create(serviceClass);
     }

--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2ClientBuilder.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2ClientBuilder.java
@@ -67,7 +67,7 @@ public final class Retrofit2ClientBuilder {
                 .baseUrl(addTrailingSlash(config.uris().get(0)))
                 .addConverterFactory(
                         new CborConverterFactory(
-                                new RejectNullConverterFactory(
+                                new NeverReturnNullConverterFactory(
                                         new CoerceNullCollectionsConverterFactory(
                                                 JacksonConverterFactory.create(OBJECT_MAPPER))),
                                 CBOR_OBJECT_MAPPER))

--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2ClientBuilder.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2ClientBuilder.java
@@ -72,8 +72,8 @@ public final class Retrofit2ClientBuilder {
                                                 JacksonConverterFactory.create(OBJECT_MAPPER))),
                                 CBOR_OBJECT_MAPPER))
                 .addConverterFactory(OptionalObjectToStringConverterFactory.INSTANCE)
-                .addCallAdapterFactory(AsyncSerializableErrorCallAdapterFactory.INSTANCE)
-                .addCallAdapterFactory(CoerceNullCollectionsCallAdapterFactory.INSTANCE)
+                .addCallAdapterFactory(new CoerceNullCollectionsCallAdapterFactory(
+                        AsyncSerializableErrorCallAdapterFactory.INSTANCE))
                 .build();
         return retrofit.create(serviceClass);
     }

--- a/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/Retrofit2ClientApiTest.java
+++ b/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/Retrofit2ClientApiTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.google.common.net.HttpHeaders;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import com.palantir.logsafe.testing.Assertions;
@@ -123,7 +122,7 @@ public final class Retrofit2ClientApiTest extends TestBase {
     public void should_reject_body_containing_empty_string() {
         server.enqueue(new MockResponse().setBody(""));
         assertThatThrownBy(() -> service.getRelative().execute().body())
-                .isInstanceOf(MismatchedInputException.class);
+                .isInstanceOf(SafeNullPointerException.class);
     }
 
     @Test

--- a/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/Retrofit2ClientCollectionHandlingTest.java
+++ b/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/Retrofit2ClientCollectionHandlingTest.java
@@ -1,0 +1,107 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.retrofit2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.ws.rs.Path;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.http.GET;
+
+@RunWith(Parameterized.class)
+public final class Retrofit2ClientCollectionHandlingTest extends TestBase {
+
+    @Rule
+    public final MockWebServer server = new MockWebServer();
+
+    private HttpUrl url;
+    private Service proxy;
+
+    @Parameters(name = "{index}: code {0} body: \"{1}\"")
+    public static Collection<Object[]> responses() {
+        return Arrays.asList(new Object[][]{
+                { 200, "null" },
+                { 200, "" },
+                { 204, "" }
+        });
+    }
+
+    @Parameter
+    public int code;
+
+    @Parameter(1)
+    public String body;
+
+    @Before
+    public void before() {
+        url = server.url("/");
+        proxy = Retrofit2Client.create(Service.class, AGENT, createTestConfig(url.toString()));
+        MockResponse mockResponse = new MockResponse().setResponseCode(code).setBody(body);
+        server.enqueue(mockResponse);
+    }
+
+    @Path("/")
+    public interface Service {
+        @GET("/list")
+        Call<List<String>> getList();
+
+        @GET("/set")
+        Call<Set<String>> getSet();
+
+        @GET("/map")
+        Call<Map<String, String>> getMap();
+    }
+
+    @Test
+    public void testList() throws IOException {
+        assertCallBody(proxy.getList(), list -> assertThat(list).isEmpty());
+    }
+
+    @Test
+    public void testSet() throws IOException {
+        assertCallBody(proxy.getSet(), set -> assertThat(set).isEmpty());
+    }
+
+    @Test
+    public void testMap() throws IOException {
+        assertCallBody(proxy.getMap(), map -> assertThat(map).isEmpty());
+    }
+
+    private static <T> void assertCallBody(Call<T> call, Consumer<T> assertions) throws IOException {
+        Response<T> response = call.execute();
+        assertThat(response.isSuccessful()).isTrue();
+        assertions.accept(response.body());
+    }
+}

--- a/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/Retrofit2ClientCollectionHandlingTest.java
+++ b/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/Retrofit2ClientCollectionHandlingTest.java
@@ -24,6 +24,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.ws.rs.Path;
 import okhttp3.HttpUrl;
@@ -82,6 +84,15 @@ public final class Retrofit2ClientCollectionHandlingTest extends TestBase {
 
         @GET("/map")
         Call<Map<String, String>> getMap();
+
+        @GET("/listFuture")
+        CompletableFuture<List<String>> getListFuture();
+
+        @GET("/setFuture")
+        CompletableFuture<Set<String>> getSetFuture();
+
+        @GET("/mapFuture")
+        CompletableFuture<Map<String, String>> getMapFuture();
     }
 
     @Test
@@ -99,9 +110,29 @@ public final class Retrofit2ClientCollectionHandlingTest extends TestBase {
         assertCallBody(proxy.getMap(), map -> assertThat(map).isEmpty());
     }
 
+    @Test
+    public void testListFuture() throws Exception {
+        assertFuture(proxy.getListFuture(), list -> assertThat(list).isEmpty());
+    }
+
+    @Test
+    public void testSetFuture() throws Exception {
+        assertFuture(proxy.getSetFuture(), set -> assertThat(set).isEmpty());
+    }
+
+    @Test
+    public void testMapFuture() throws Exception {
+        assertFuture(proxy.getMapFuture(), map -> assertThat(map).isEmpty());
+    }
+
     private static <T> void assertCallBody(Call<T> call, Consumer<T> assertions) throws IOException {
         Response<T> response = call.execute();
         assertThat(response.isSuccessful()).isTrue();
         assertions.accept(response.body());
+    }
+
+    private static <T> void assertFuture(CompletableFuture<T> future, Consumer<T> assertions) throws Exception {
+        T value = future.get(1, TimeUnit.SECONDS);
+        assertions.accept(value);
     }
 }


### PR DESCRIPTION
Fixes the break introduced in #767 - namely, that servers returning `null` where a collection was expected suddenly started throwing.

However, whereas before a `null` response would convert into a java null, with this change we
* still blow up on nulls if not expecting a collection
* create an empty collection otherwise

We support deserializing an empty collection out of

| Response code | Body      |
|---------------|-----------|
| 200           | \<empty\> |
| 200           | `null`    |
| 204           | \<empty\> |

Sadly this is a bit more gross than #772 because retrofit2 doesn't run Converters if the response code was 204.
Instead, for that case, we had to add a `CallAdapter.Factory` that creates special Call instances which sneak in the default value if 
* the expected type was `SomeParametrizedType<List | Set | Map>` where currently the parametrized type can be only `Call<T>` or `CompletableFuture<T>`
* the delegate call returned `null`