### PR TITLE
Builders take a HostEventsSink (that HostMetricsRegistry impls)

### DIFF
--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -62,7 +62,7 @@ abstract class AbstractFeignJaxRsClientBuilder {
      */
     private final String primaryUri;
 
-    private HostMetricsSink hostMetricsRegistry;
+    private HostMetricsSink hostEventsSink;
 
     AbstractFeignJaxRsClientBuilder(ClientConfiguration config) {
         Preconditions.checkArgument(!config.uris().isEmpty(), "Must provide at least one service URI");
@@ -77,17 +77,17 @@ abstract class AbstractFeignJaxRsClientBuilder {
     /**
      * Set the host metrics registry to use when constructing the OkHttp client.
      */
-    public final AbstractFeignJaxRsClientBuilder hostMetricsRegistry(HostMetricsSink newHostMetricsRegistry) {
-        Preconditions.checkNotNull(newHostMetricsRegistry, "hostMetricsRegistry can't be null");
-        hostMetricsRegistry = newHostMetricsRegistry;
+    public final AbstractFeignJaxRsClientBuilder hostEventsSink(HostMetricsSink newHostEventsSink) {
+        Preconditions.checkNotNull(newHostEventsSink, "hostEventsSink can't be null");
+        hostEventsSink = newHostEventsSink;
         return this;
     }
 
     public final <T> T build(Class<T> serviceClass, UserAgent userAgent) {
         ObjectMapper objectMapper = getObjectMapper();
         ObjectMapper cborObjectMapper = getCborObjectMapper();
-        Preconditions.checkNotNull(hostMetricsRegistry, "hostMetricsRegistry must be set");
-        okhttp3.OkHttpClient okHttpClient = OkHttpClients.create(config, userAgent, hostMetricsRegistry, serviceClass);
+        Preconditions.checkNotNull(hostEventsSink, "hostEventsSink must be set");
+        okhttp3.OkHttpClient okHttpClient = OkHttpClients.create(config, userAgent, hostEventsSink, serviceClass);
 
         return Feign.builder()
                 .contract(createContract())

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -24,7 +24,7 @@ import com.palantir.conjure.java.client.jaxrs.feignimpl.Java8OptionalAwareContra
 import com.palantir.conjure.java.client.jaxrs.feignimpl.PathTemplateHeaderEnrichmentContract;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.PathTemplateHeaderRewriter;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.SlashEncodingContract;
-import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import com.palantir.conjure.java.okhttp.HostMetricsSink;
 import com.palantir.conjure.java.okhttp.OkHttpClients;
 import com.palantir.logsafe.Preconditions;
 import feign.CborDelegateDecoder;
@@ -62,7 +62,7 @@ abstract class AbstractFeignJaxRsClientBuilder {
      */
     private final String primaryUri;
 
-    private HostMetricsRegistry hostMetricsRegistry;
+    private HostMetricsSink hostMetricsRegistry;
 
     AbstractFeignJaxRsClientBuilder(ClientConfiguration config) {
         Preconditions.checkArgument(!config.uris().isEmpty(), "Must provide at least one service URI");
@@ -77,7 +77,7 @@ abstract class AbstractFeignJaxRsClientBuilder {
     /**
      * Set the host metrics registry to use when constructing the OkHttp client.
      */
-    public final AbstractFeignJaxRsClientBuilder hostMetricsRegistry(HostMetricsRegistry newHostMetricsRegistry) {
+    public final AbstractFeignJaxRsClientBuilder hostMetricsRegistry(HostMetricsSink newHostMetricsRegistry) {
         Preconditions.checkNotNull(newHostMetricsRegistry, "hostMetricsRegistry can't be null");
         hostMetricsRegistry = newHostMetricsRegistry;
         return this;

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -24,7 +24,7 @@ import com.palantir.conjure.java.client.jaxrs.feignimpl.Java8OptionalAwareContra
 import com.palantir.conjure.java.client.jaxrs.feignimpl.PathTemplateHeaderEnrichmentContract;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.PathTemplateHeaderRewriter;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.SlashEncodingContract;
-import com.palantir.conjure.java.okhttp.HostMetricsSink;
+import com.palantir.conjure.java.okhttp.HostEventsSink;
 import com.palantir.conjure.java.okhttp.OkHttpClients;
 import com.palantir.logsafe.Preconditions;
 import feign.CborDelegateDecoder;
@@ -62,7 +62,7 @@ abstract class AbstractFeignJaxRsClientBuilder {
      */
     private final String primaryUri;
 
-    private HostMetricsSink hostEventsSink;
+    private HostEventsSink hostEventsSink;
 
     AbstractFeignJaxRsClientBuilder(ClientConfiguration config) {
         Preconditions.checkArgument(!config.uris().isEmpty(), "Must provide at least one service URI");
@@ -77,7 +77,7 @@ abstract class AbstractFeignJaxRsClientBuilder {
     /**
      * Set the host metrics registry to use when constructing the OkHttp client.
      */
-    public final AbstractFeignJaxRsClientBuilder hostEventsSink(HostMetricsSink newHostEventsSink) {
+    public final AbstractFeignJaxRsClientBuilder hostEventsSink(HostEventsSink newHostEventsSink) {
         Preconditions.checkNotNull(newHostEventsSink, "hostEventsSink can't be null");
         hostEventsSink = newHostEventsSink;
         return this;

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
@@ -37,11 +37,11 @@ public final class JaxRsClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostMetricsRegistry,
+            HostMetricsSink hostEventsSink,
             ClientConfiguration config) {
         // TODO(rfink): Add http-remoting agent as informational
         return new FeignJaxRsClientBuilder(config)
-                .hostMetricsRegistry(hostMetricsRegistry)
+                .hostEventsSink(hostEventsSink)
                 .build(serviceClass, userAgent);
     }
 
@@ -53,10 +53,10 @@ public final class JaxRsClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostMetricsRegistry,
+            HostMetricsSink hostEventsSink,
             Refreshable<ClientConfiguration> config) {
         return Reflection.newProxy(serviceClass, RefreshableProxyInvocationHandler.create(
                 config,
-                serviceConfiguration -> create(serviceClass, userAgent, hostMetricsRegistry, serviceConfiguration)));
+                serviceConfiguration -> create(serviceClass, userAgent, hostEventsSink, serviceConfiguration)));
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
@@ -21,7 +21,7 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.ext.refresh.Refreshable;
 import com.palantir.conjure.java.ext.refresh.RefreshableProxyInvocationHandler;
-import com.palantir.conjure.java.okhttp.HostMetricsSink;
+import com.palantir.conjure.java.okhttp.HostEventsSink;
 
 /**
  * Static factory methods for producing creating JAX-RS HTTP proxies.
@@ -37,7 +37,7 @@ public final class JaxRsClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostEventsSink,
+            HostEventsSink hostEventsSink,
             ClientConfiguration config) {
         // TODO(rfink): Add http-remoting agent as informational
         return new FeignJaxRsClientBuilder(config)
@@ -46,14 +46,14 @@ public final class JaxRsClient {
     }
 
     /**
-     * Similar to {@link #create(Class, UserAgent, HostMetricsSink, ClientConfiguration)}, but creates a mutable
+     * Similar to {@link #create(Class, UserAgent, HostEventsSink, ClientConfiguration)}, but creates a mutable
      * client that updates its configuration transparently whenever the given {@link Refreshable refreshable}
      * {@link ClientConfiguration} changes.
      */
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostEventsSink,
+            HostEventsSink hostEventsSink,
             Refreshable<ClientConfiguration> config) {
         return Reflection.newProxy(serviceClass, RefreshableProxyInvocationHandler.create(
                 config,

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
@@ -21,7 +21,7 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.ext.refresh.Refreshable;
 import com.palantir.conjure.java.ext.refresh.RefreshableProxyInvocationHandler;
-import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import com.palantir.conjure.java.okhttp.HostMetricsSink;
 
 /**
  * Static factory methods for producing creating JAX-RS HTTP proxies.
@@ -37,7 +37,7 @@ public final class JaxRsClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetricsRegistry,
+            HostMetricsSink hostMetricsRegistry,
             ClientConfiguration config) {
         // TODO(rfink): Add http-remoting agent as informational
         return new FeignJaxRsClientBuilder(config)
@@ -46,14 +46,14 @@ public final class JaxRsClient {
     }
 
     /**
-     * Similar to {@link #create(Class, UserAgent, HostMetricsRegistry, ClientConfiguration)}, but creates a mutable
+     * Similar to {@link #create(Class, UserAgent, HostMetricsSink, ClientConfiguration)}, but creates a mutable
      * client that updates its configuration transparently whenever the given {@link Refreshable refreshable}
      * {@link ClientConfiguration} changes.
      */
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetricsRegistry,
+            HostMetricsSink hostMetricsRegistry,
             Refreshable<ClientConfiguration> config) {
         return Reflection.newProxy(serviceClass, RefreshableProxyInvocationHandler.create(
                 config,

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2Client.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2Client.java
@@ -21,7 +21,7 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.ext.refresh.Refreshable;
 import com.palantir.conjure.java.ext.refresh.RefreshableProxyInvocationHandler;
-import com.palantir.conjure.java.okhttp.HostMetricsSink;
+import com.palantir.conjure.java.okhttp.HostEventsSink;
 
 /**
  * Static factory methods for producing creating Retrofit2 HTTP proxies.
@@ -37,7 +37,7 @@ public final class Retrofit2Client {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostEventsSink,
+            HostEventsSink hostEventsSink,
             ClientConfiguration config) {
         return new Retrofit2ClientBuilder(config)
                 .hostEventsSink(hostEventsSink)
@@ -45,14 +45,14 @@ public final class Retrofit2Client {
     }
 
     /**
-     * Similar to {@link #create(Class, UserAgent, HostMetricsSink, ClientConfiguration)}, but creates a mutable
+     * Similar to {@link #create(Class, UserAgent, HostEventsSink, ClientConfiguration)}, but creates a mutable
      * client that updates its configuration transparently whenever the given {@link Refreshable refreshable}
      * {@link ClientConfiguration} changes.
      */
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostEventsSink,
+            HostEventsSink hostEventsSink,
             Refreshable<ClientConfiguration> config) {
         return Reflection.newProxy(serviceClass, RefreshableProxyInvocationHandler.create(
                 config,

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2Client.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2Client.java
@@ -21,7 +21,7 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.ext.refresh.Refreshable;
 import com.palantir.conjure.java.ext.refresh.RefreshableProxyInvocationHandler;
-import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import com.palantir.conjure.java.okhttp.HostMetricsSink;
 
 /**
  * Static factory methods for producing creating Retrofit2 HTTP proxies.
@@ -37,7 +37,7 @@ public final class Retrofit2Client {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetricsRegistry,
+            HostMetricsSink hostMetricsRegistry,
             ClientConfiguration config) {
         return new Retrofit2ClientBuilder(config)
                 .hostMetricsRegistry(hostMetricsRegistry)
@@ -45,14 +45,14 @@ public final class Retrofit2Client {
     }
 
     /**
-     * Similar to {@link #create(Class, UserAgent, HostMetricsRegistry, ClientConfiguration)}, but creates a mutable
+     * Similar to {@link #create(Class, UserAgent, HostMetricsSink, ClientConfiguration)}, but creates a mutable
      * client that updates its configuration transparently whenever the given {@link Refreshable refreshable}
      * {@link ClientConfiguration} changes.
      */
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetricsRegistry,
+            HostMetricsSink hostMetricsRegistry,
             Refreshable<ClientConfiguration> config) {
         return Reflection.newProxy(serviceClass, RefreshableProxyInvocationHandler.create(
                 config,

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2Client.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2Client.java
@@ -37,10 +37,10 @@ public final class Retrofit2Client {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostMetricsRegistry,
+            HostMetricsSink hostEventsSink,
             ClientConfiguration config) {
         return new Retrofit2ClientBuilder(config)
-                .hostMetricsRegistry(hostMetricsRegistry)
+                .hostEventsSink(hostEventsSink)
                 .build(serviceClass, userAgent);
     }
 
@@ -52,10 +52,10 @@ public final class Retrofit2Client {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostMetricsRegistry,
+            HostMetricsSink hostEventsSink,
             Refreshable<ClientConfiguration> config) {
         return Reflection.newProxy(serviceClass, RefreshableProxyInvocationHandler.create(
                 config,
-                serviceConfiguration -> create(serviceClass, userAgent, hostMetricsRegistry, serviceConfiguration)));
+                serviceConfiguration -> create(serviceClass, userAgent, hostEventsSink, serviceConfiguration)));
     }
 }

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
@@ -19,7 +19,7 @@ package com.palantir.conjure.java.client.retrofit2;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
-import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import com.palantir.conjure.java.okhttp.HostMetricsSink;
 import com.palantir.conjure.java.okhttp.OkHttpClients;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.logsafe.Preconditions;
@@ -32,7 +32,7 @@ public final class Retrofit2ClientBuilder {
 
     private final ClientConfiguration config;
 
-    private HostMetricsRegistry hostMetricsRegistry;
+    private HostMetricsSink hostMetricsRegistry;
 
     public Retrofit2ClientBuilder(ClientConfiguration config) {
         Preconditions.checkArgument(!config.uris().isEmpty(), "Cannot construct retrofit client with empty URI list");
@@ -42,7 +42,7 @@ public final class Retrofit2ClientBuilder {
     /**
      * Set the host metrics registry to use when constructing the OkHttp client.
      */
-    public Retrofit2ClientBuilder hostMetricsRegistry(HostMetricsRegistry newHostMetricsRegistry) {
+    public Retrofit2ClientBuilder hostMetricsRegistry(HostMetricsSink newHostMetricsRegistry) {
         Preconditions.checkNotNull(newHostMetricsRegistry, "hostMetricsRegistry can't be null");
         hostMetricsRegistry = newHostMetricsRegistry;
         return this;

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
@@ -32,7 +32,7 @@ public final class Retrofit2ClientBuilder {
 
     private final ClientConfiguration config;
 
-    private HostMetricsSink hostMetricsRegistry;
+    private HostMetricsSink hostEventsSink;
 
     public Retrofit2ClientBuilder(ClientConfiguration config) {
         Preconditions.checkArgument(!config.uris().isEmpty(), "Cannot construct retrofit client with empty URI list");
@@ -42,15 +42,15 @@ public final class Retrofit2ClientBuilder {
     /**
      * Set the host metrics registry to use when constructing the OkHttp client.
      */
-    public Retrofit2ClientBuilder hostMetricsRegistry(HostMetricsSink newHostMetricsRegistry) {
-        Preconditions.checkNotNull(newHostMetricsRegistry, "hostMetricsRegistry can't be null");
-        hostMetricsRegistry = newHostMetricsRegistry;
+    public Retrofit2ClientBuilder hostEventsSink(HostMetricsSink newHostEventsSink) {
+        Preconditions.checkNotNull(newHostEventsSink, "hostEventsSink can't be null");
+        hostEventsSink = newHostEventsSink;
         return this;
     }
 
     public <T> T build(Class<T> serviceClass, UserAgent userAgent) {
-        Preconditions.checkNotNull(hostMetricsRegistry, "hostMetricsRegistry must be set");
-        okhttp3.OkHttpClient client = OkHttpClients.create(config, userAgent, hostMetricsRegistry, serviceClass);
+        Preconditions.checkNotNull(hostEventsSink, "hostEventsSink must be set");
+        okhttp3.OkHttpClient client = OkHttpClients.create(config, userAgent, hostEventsSink, serviceClass);
 
         Retrofit retrofit = new Retrofit.Builder()
                 .client(client)

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
@@ -19,7 +19,7 @@ package com.palantir.conjure.java.client.retrofit2;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
-import com.palantir.conjure.java.okhttp.HostMetricsSink;
+import com.palantir.conjure.java.okhttp.HostEventsSink;
 import com.palantir.conjure.java.okhttp.OkHttpClients;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.logsafe.Preconditions;
@@ -32,7 +32,7 @@ public final class Retrofit2ClientBuilder {
 
     private final ClientConfiguration config;
 
-    private HostMetricsSink hostEventsSink;
+    private HostEventsSink hostEventsSink;
 
     public Retrofit2ClientBuilder(ClientConfiguration config) {
         Preconditions.checkArgument(!config.uris().isEmpty(), "Cannot construct retrofit client with empty URI list");
@@ -42,7 +42,7 @@ public final class Retrofit2ClientBuilder {
     /**
      * Set the host metrics registry to use when constructing the OkHttp client.
      */
-    public Retrofit2ClientBuilder hostEventsSink(HostMetricsSink newHostEventsSink) {
+    public Retrofit2ClientBuilder hostEventsSink(HostEventsSink newHostEventsSink) {
         Preconditions.checkNotNull(newHostEventsSink, "hostEventsSink can't be null");
         hostEventsSink = newHostEventsSink;
         return this;

--- a/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsScalaClient.java
+++ b/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsScalaClient.java
@@ -36,10 +36,10 @@ public final class JaxRsScalaClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostMetricsRegistry,
+            HostMetricsSink hostEventsSink,
             ClientConfiguration config) {
         return new FeignJaxRsScalaClientBuilder(config)
-                .hostMetricsRegistry(hostMetricsRegistry)
+                .hostEventsSink(hostEventsSink)
                 .build(serviceClass, userAgent);
     }
 
@@ -47,10 +47,10 @@ public final class JaxRsScalaClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostMetricsRegistry,
+            HostMetricsSink hostEventsSink,
             Refreshable<ClientConfiguration> config) {
         return Reflection.newProxy(serviceClass, RefreshableProxyInvocationHandler.create(
                 config,
-                serviceConfiguration -> create(serviceClass, userAgent, hostMetricsRegistry, serviceConfiguration)));
+                serviceConfiguration -> create(serviceClass, userAgent, hostEventsSink, serviceConfiguration)));
     }
 }

--- a/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsScalaClient.java
+++ b/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsScalaClient.java
@@ -21,7 +21,7 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.ext.refresh.Refreshable;
 import com.palantir.conjure.java.ext.refresh.RefreshableProxyInvocationHandler;
-import com.palantir.conjure.java.okhttp.HostMetricsSink;
+import com.palantir.conjure.java.okhttp.HostEventsSink;
 
 /**
  * Variant of {@link JaxRsClient} with additional scala serialization support.
@@ -36,7 +36,7 @@ public final class JaxRsScalaClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostEventsSink,
+            HostEventsSink hostEventsSink,
             ClientConfiguration config) {
         return new FeignJaxRsScalaClientBuilder(config)
                 .hostEventsSink(hostEventsSink)
@@ -47,7 +47,7 @@ public final class JaxRsScalaClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsSink hostEventsSink,
+            HostEventsSink hostEventsSink,
             Refreshable<ClientConfiguration> config) {
         return Reflection.newProxy(serviceClass, RefreshableProxyInvocationHandler.create(
                 config,

--- a/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsScalaClient.java
+++ b/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsScalaClient.java
@@ -21,7 +21,7 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.ext.refresh.Refreshable;
 import com.palantir.conjure.java.ext.refresh.RefreshableProxyInvocationHandler;
-import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import com.palantir.conjure.java.okhttp.HostMetricsSink;
 
 /**
  * Variant of {@link JaxRsClient} with additional scala serialization support.
@@ -36,7 +36,7 @@ public final class JaxRsScalaClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetricsRegistry,
+            HostMetricsSink hostMetricsRegistry,
             ClientConfiguration config) {
         return new FeignJaxRsScalaClientBuilder(config)
                 .hostMetricsRegistry(hostMetricsRegistry)
@@ -47,7 +47,7 @@ public final class JaxRsScalaClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetricsRegistry,
+            HostMetricsSink hostMetricsRegistry,
             Refreshable<ClientConfiguration> config) {
         return Reflection.newProxy(serviceClass, RefreshableProxyInvocationHandler.create(
                 config,

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
@@ -5,9 +5,9 @@
 package com.palantir.conjure.java.okhttp;
 
 /**
- * A destination for recording host metrics.
+ * A destination for recording host events.
  */
-public interface HostMetricsSink {
+public interface HostEventsSink {
     void record(String serviceName, String hostname, int port, int statusCode, long micros);
 
     void recordIoException(String serviceName, String hostname, int port);

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
@@ -5,7 +5,10 @@
 package com.palantir.conjure.java.okhttp;
 
 /**
- * A destination for recording host events.
+ * A listener for responses / exceptions coming from remote hosts when using clients created from {@link OkHttpClients}.
+ * <p>
+ * We provide a {@link HostMetricsRegistry} implementation of this that turns these events into {@link HostMetrics}
+ * for each remote host.
  */
 public interface HostEventsSink {
     void record(String serviceName, String hostname, int port, int statusCode, long micros);

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetricsRegistry.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetricsRegistry.java
@@ -30,7 +30,7 @@ import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class HostMetricsRegistry implements HostMetricsSink {
+public final class HostMetricsRegistry implements HostEventsSink {
 
     private static final Logger log = LoggerFactory.getLogger(HostMetricsRegistry.class);
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetricsRegistry.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetricsRegistry.java
@@ -30,7 +30,7 @@ import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class HostMetricsRegistry {
+public final class HostMetricsRegistry implements HostMetricsSink {
 
     private static final Logger log = LoggerFactory.getLogger(HostMetricsRegistry.class);
 
@@ -48,7 +48,8 @@ public final class HostMetricsRegistry {
                 });
     }
 
-    void record(String serviceName, String hostname, int port, int statusCode, long micros) {
+    @Override
+    public void record(String serviceName, String hostname, int port, int statusCode, long micros) {
         try {
             hostMetrics.getUnchecked(
                     ImmutableServiceHostAndPort.of(serviceName, hostname, port)).record(statusCode, micros);
@@ -59,7 +60,8 @@ public final class HostMetricsRegistry {
         }
     }
 
-    void recordIoException(String serviceName, String hostname, int port) {
+    @Override
+    public void recordIoException(String serviceName, String hostname, int port) {
         try {
             hostMetrics.getUnchecked(ImmutableServiceHostAndPort.of(serviceName, hostname, port)).recordIoException();
         } catch (Exception e) {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetricsSink.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetricsSink.java
@@ -1,0 +1,14 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+/**
+ * A destination for recording host metrics.
+ */
+public interface HostMetricsSink {
+    void record(String serviceName, String hostname, int port, int statusCode, long micros);
+
+    void recordIoException(String serviceName, String hostname, int port);
+}

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
@@ -34,11 +34,11 @@ final class InstrumentedInterceptor implements Interceptor {
     static final String CLIENT_RESPONSE_METRIC_NAME = "client.response";
     static final String SERVICE_NAME_TAG = "service-name";
 
-    private final HostMetricsRegistry hostMetrics;
+    private final HostMetricsSink hostMetrics;
     private final String serviceName;
     private final Timer responseTimer;
 
-    InstrumentedInterceptor(TaggedMetricRegistry registry, HostMetricsRegistry hostMetrics, String serviceName) {
+    InstrumentedInterceptor(TaggedMetricRegistry registry, HostMetricsSink hostMetrics, String serviceName) {
         this.hostMetrics = hostMetrics;
         this.serviceName = serviceName;
         this.responseTimer = registry.timer(name());
@@ -68,7 +68,7 @@ final class InstrumentedInterceptor implements Interceptor {
     }
 
     static InstrumentedInterceptor create(
-            TaggedMetricRegistry registry, HostMetricsRegistry hostMetrics, Class<?> serviceClass) {
+            TaggedMetricRegistry registry, HostMetricsSink hostMetrics, Class<?> serviceClass) {
         return new InstrumentedInterceptor(registry, hostMetrics, serviceClass.getSimpleName());
     }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
@@ -34,11 +34,11 @@ final class InstrumentedInterceptor implements Interceptor {
     static final String CLIENT_RESPONSE_METRIC_NAME = "client.response";
     static final String SERVICE_NAME_TAG = "service-name";
 
-    private final HostMetricsSink hostMetrics;
+    private final HostEventsSink hostEventsSink;
     private final String serviceName;
     private final Timer responseTimer;
 
-    InstrumentedInterceptor(TaggedMetricRegistry registry, HostMetricsSink hostMetrics, String serviceName) {
+    InstrumentedInterceptor(TaggedMetricRegistry registry, HostEventsSink hostEventsSink, String serviceName) {
         this.hostMetrics = hostMetrics;
         this.serviceName = serviceName;
         this.responseTimer = registry.timer(name());
@@ -68,7 +68,7 @@ final class InstrumentedInterceptor implements Interceptor {
     }
 
     static InstrumentedInterceptor create(
-            TaggedMetricRegistry registry, HostMetricsSink hostMetrics, Class<?> serviceClass) {
+            TaggedMetricRegistry registry, HostEventsSink hostEventsSink, Class<?> serviceClass) {
         return new InstrumentedInterceptor(registry, hostMetrics, serviceClass.getSimpleName());
     }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -113,20 +113,20 @@ public final class OkHttpClients {
      * ClientConfiguration#uris URIs} are initialized in random order.
      */
     public static OkHttpClient create(
-            ClientConfiguration config, UserAgent userAgent, HostMetricsSink hostMetrics, Class<?> serviceClass) {
+            ClientConfiguration config, UserAgent userAgent, HostEventsSink hostEventsSink, Class<?> serviceClass) {
         return createInternal(config, userAgent, hostMetrics, serviceClass, true /* randomize URLs */);
     }
 
     @VisibleForTesting
     static RemotingOkHttpClient withStableUris(
-            ClientConfiguration config, UserAgent userAgent, HostMetricsSink hostMetrics, Class<?> serviceClass) {
+            ClientConfiguration config, UserAgent userAgent, HostEventsSink hostEventsSink, Class<?> serviceClass) {
         return createInternal(config, userAgent, hostMetrics, serviceClass, false);
     }
 
     private static RemotingOkHttpClient createInternal(
             ClientConfiguration config,
             UserAgent userAgent,
-            HostMetricsSink hostMetrics,
+            HostEventsSink hostEventsSink,
             Class<?> serviceClass,
             boolean randomizeUrlOrder) {
         OkHttpClient.Builder client = new OkHttpClient.Builder();

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -113,20 +113,20 @@ public final class OkHttpClients {
      * ClientConfiguration#uris URIs} are initialized in random order.
      */
     public static OkHttpClient create(
-            ClientConfiguration config, UserAgent userAgent, HostMetricsRegistry hostMetrics, Class<?> serviceClass) {
+            ClientConfiguration config, UserAgent userAgent, HostMetricsSink hostMetrics, Class<?> serviceClass) {
         return createInternal(config, userAgent, hostMetrics, serviceClass, true /* randomize URLs */);
     }
 
     @VisibleForTesting
     static RemotingOkHttpClient withStableUris(
-            ClientConfiguration config, UserAgent userAgent, HostMetricsRegistry hostMetrics, Class<?> serviceClass) {
+            ClientConfiguration config, UserAgent userAgent, HostMetricsSink hostMetrics, Class<?> serviceClass) {
         return createInternal(config, userAgent, hostMetrics, serviceClass, false);
     }
 
     private static RemotingOkHttpClient createInternal(
             ClientConfiguration config,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetrics,
+            HostMetricsSink hostMetrics,
             Class<?> serviceClass,
             boolean randomizeUrlOrder) {
         OkHttpClient.Builder client = new OkHttpClient.Builder();

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -114,13 +114,13 @@ public final class OkHttpClients {
      */
     public static OkHttpClient create(
             ClientConfiguration config, UserAgent userAgent, HostEventsSink hostEventsSink, Class<?> serviceClass) {
-        return createInternal(config, userAgent, hostMetrics, serviceClass, true /* randomize URLs */);
+        return createInternal(config, userAgent, hostEventsSink, serviceClass, true /* randomize URLs */);
     }
 
     @VisibleForTesting
     static RemotingOkHttpClient withStableUris(
             ClientConfiguration config, UserAgent userAgent, HostEventsSink hostEventsSink, Class<?> serviceClass) {
-        return createInternal(config, userAgent, hostMetrics, serviceClass, false);
+        return createInternal(config, userAgent, hostEventsSink, serviceClass, false);
     }
 
     private static RemotingOkHttpClient createInternal(
@@ -154,7 +154,7 @@ public final class OkHttpClients {
         client.sslSocketFactory(config.sslSocketFactory(), config.trustManager());
 
         // Intercept calls to augment request meta data
-        client.addInterceptor(InstrumentedInterceptor.create(registry, hostMetrics, serviceClass));
+        client.addInterceptor(InstrumentedInterceptor.create(registry, hostEventsSink, serviceClass));
         client.addInterceptor(OkhttpTraceInterceptor.INSTANCE);
         client.addInterceptor(UserAgentInterceptor.of(augmentUserAgent(userAgent, serviceClass)));
 


### PR DESCRIPTION
### Before this PR

Client builders take a [`HostMetricsRegistry`](https://github.com/palantir/http-remoting/blob/6693b375aab63fe34a7ac1f824c4e25c28636292/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetricsRegistry.java), which accepts marking host response / exception events as well as getting per-host metrics computed from those events.

### After this PR

Client builders take a `HostEventsSink`, which is just an interface that allows one to mark events. This interface doesn't need to concern itself with metrics at all, it just gets told when certain events have occurred.

This would allow us to pass a remoting3 HostMetricsRegistry into conjure client builders, by allowing us to manually implement `HostEventsSink` for the remoting3 HostMetricsRegistry, so that we can share a metrics registry between conjure and remoting3 clients.

However, it requires that remoting3 HostMetricsRegistry also makes its `record`/`recordIoException` methods public, so that we can delegate to them (https://github.com/palantir/http-remoting/pull/780)