### PR TITLE
Expose HostMetricsRegistry record methods

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/HostMetricsRegistry.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/HostMetricsRegistry.java
@@ -48,7 +48,7 @@ public final class HostMetricsRegistry {
                 });
     }
 
-    void record(String serviceName, String hostname, int port, int statusCode, long micros) {
+    public void record(String serviceName, String hostname, int port, int statusCode, long micros) {
         try {
             hostMetrics.getUnchecked(
                     ImmutableServiceHostAndPort.of(serviceName, hostname, port)).record(statusCode, micros);
@@ -59,7 +59,7 @@ public final class HostMetricsRegistry {
         }
     }
 
-    void recordIoException(String serviceName, String hostname, int port) {
+    public void recordIoException(String serviceName, String hostname, int port) {
         try {
             hostMetrics.getUnchecked(ImmutableServiceHostAndPort.of(serviceName, hostname, port)).recordIoException();
         } catch (Exception e) {


### PR DESCRIPTION
This is so that we can separately implement a HostMetricsSink for it (see https://github.com/palantir/http-remoting/pull/779) such that we can share host metrics when constructing both conjure and remoting3 clients