### PR TITLE
Re-add WebApplicationExceptionMapper

### DIFF
--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaOptionalAwareDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaOptionalAwareDecoderTest.java
@@ -78,9 +78,31 @@ public final class GuavaOptionalAwareDecoderTest extends TestBase {
     }
 
     @Test
-    public void testThrowsPermissionDenied() {
+    public void testThrowsNotAuthorized() {
         try {
-            service.getThrowsPermissionDenied(null);
+            service.getThrowsNotAuthorized(null);
+            fail();
+        } catch (RemoteException e) {
+            assertThat(e.getMessage(), containsString("RemoteException: javax.ws.rs.NotAuthorizedException"));
+            assertThat(e.getError().errorCode(), is("javax.ws.rs.NotAuthorizedException"));
+        }
+    }
+
+    @Test
+    public void testOptionalThrowsNotAuthorized() {
+        try {
+            service.getOptionalThrowsNotAuthorized(null);
+            fail();
+        } catch (RemoteException e) {
+            assertThat(e.getMessage(), containsString("RemoteException: javax.ws.rs.NotAuthorizedException"));
+            assertThat(e.getError().errorCode(), is("javax.ws.rs.NotAuthorizedException"));
+        }
+    }
+
+    @Test
+    public void testThrowsFordidden() {
+        try {
+            service.getThrowsForbidden(null);
             fail();
         } catch (RemoteException e) {
             assertThat(e.getMessage(), containsString("RemoteException: PERMISSION_DENIED (Default:PermissionDenied)"));
@@ -89,9 +111,9 @@ public final class GuavaOptionalAwareDecoderTest extends TestBase {
     }
 
     @Test
-    public void testOptionalThrowsPermissionDenied() {
+    public void testOptionalThrowsForbbbden() {
         try {
-            service.getOptionalThrowsPermissionDenied(null);
+            service.getOptionalThrowsForbidden(null);
             fail();
         } catch (RemoteException e) {
             assertThat(e.getMessage(), containsString("RemoteException: PERMISSION_DENIED (Default:PermissionDenied)"));

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaTestServer.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaTestServer.java
@@ -18,8 +18,6 @@ package com.palantir.conjure.java.client.jaxrs.feignimpl;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.conjure.java.api.errors.ErrorType;
-import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.conjure.java.server.jersey.ConjureJerseyFeature;
 import feign.Util;
@@ -33,7 +31,10 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -71,25 +72,43 @@ public class GuavaTestServer extends Application<Configuration> {
         @Override
         public ImmutableMap<String, String> getThrowsNotFound(@Nullable String value) {
             if (Strings.isNullOrEmpty(value)) {
-                throw new ServiceException(ErrorType.NOT_FOUND);
+                throw new NotFoundException("Not found");
             } else {
                 return ImmutableMap.of(value, value);
             }
         }
 
         @Override
-        public ImmutableMap<String, String> getThrowsPermissionDenied(@Nullable String value) {
+        public ImmutableMap<String, String> getThrowsNotAuthorized(@Nullable String value) {
             if (Strings.isNullOrEmpty(value)) {
-                throw new ServiceException(ErrorType.PERMISSION_DENIED);
+                throw new NotAuthorizedException("Not authorized");
             } else {
                 return ImmutableMap.of(value, value);
             }
         }
 
         @Override
-        public Optional<ImmutableMap<String, String>> getOptionalThrowsPermissionDenied(@Nullable String value) {
+        public Optional<ImmutableMap<String, String>> getOptionalThrowsNotAuthorized(@Nullable String value) {
             if (Strings.isNullOrEmpty(value)) {
-                throw new ServiceException(ErrorType.PERMISSION_DENIED);
+                throw new NotAuthorizedException("Not authorized");
+            } else {
+                return Optional.of(ImmutableMap.of(value, value));
+            }
+        }
+
+        @Override
+        public ImmutableMap<String, String> getThrowsForbidden(@Nullable String value) {
+            if (Strings.isNullOrEmpty(value)) {
+                throw new ForbiddenException("Forbidden");
+            } else {
+                return ImmutableMap.of(value, value);
+            }
+        }
+
+        @Override
+        public Optional<ImmutableMap<String, String>> getOptionalThrowsForbidden(@Nullable String value) {
+            if (Strings.isNullOrEmpty(value)) {
+                throw new ForbiddenException("Forbidden");
             } else {
                 return Optional.of(ImmutableMap.of(value, value));
             }
@@ -164,17 +183,29 @@ public class GuavaTestServer extends Application<Configuration> {
         ImmutableMap<String, String> getThrowsNotFound(@QueryParam("value") @Nullable String value);
 
         @GET
-        @Path("/throwsPermissionDenied")
+        @Path("/throwsNotAuthorized")
         @Consumes(MediaType.APPLICATION_JSON)
         @Produces(MediaType.APPLICATION_JSON)
-        ImmutableMap<String, String> getThrowsPermissionDenied(@QueryParam("value") @Nullable String value);
+        ImmutableMap<String, String> getThrowsNotAuthorized(@QueryParam("value") @Nullable String value);
 
         @GET
-        @Path("/optionalThrowsPermissionDenied")
+        @Path("/optionalThrowsNotAuthorized")
         @Consumes(MediaType.APPLICATION_JSON)
         @Produces(MediaType.APPLICATION_JSON)
-        Optional<ImmutableMap<String, String>> getOptionalThrowsPermissionDenied(
+        Optional<ImmutableMap<String, String>> getOptionalThrowsNotAuthorized(
                 @QueryParam("value") @Nullable String value);
+
+        @GET
+        @Path("/throwsForbidden")
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        ImmutableMap<String, String> getThrowsForbidden(@QueryParam("value") @Nullable String value);
+
+        @GET
+        @Path("/optionalThrowsForbidden")
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        Optional<ImmutableMap<String, String>> getOptionalThrowsForbidden(@QueryParam("value") @Nullable String value);
 
         @GET
         @Path("/jsonString")

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8OptionalAwareDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8OptionalAwareDecoderTest.java
@@ -81,9 +81,31 @@ public final class Java8OptionalAwareDecoderTest extends TestBase {
     }
 
     @Test
-    public void testThrowsPermissionDenied() {
+    public void testThrowsNotAuthorized() {
         try {
-            service.getThrowsPermissionDenied(null);
+            service.getThrowsNotAuthorized(null);
+            fail();
+        } catch (RemoteException e) {
+            assertThat(e.getMessage(), containsString("RemoteException: javax.ws.rs.NotAuthorizedException"));
+            assertThat(e.getError().errorCode(), is("javax.ws.rs.NotAuthorizedException"));
+        }
+    }
+
+    @Test
+    public void testOptionalThrowsNotAuthorized() {
+        try {
+            service.getOptionalThrowsNotAuthorized(null);
+            fail();
+        } catch (RemoteException e) {
+            assertThat(e.getMessage(), containsString("RemoteException: javax.ws.rs.NotAuthorizedException"));
+            assertThat(e.getError().errorCode(), is("javax.ws.rs.NotAuthorizedException"));
+        }
+    }
+
+    @Test
+    public void testThrowsFordidden() {
+        try {
+            service.getThrowsForbidden(null);
             fail();
         } catch (RemoteException e) {
             assertThat(e.getMessage(), containsString("RemoteException: PERMISSION_DENIED (Default:PermissionDenied)"));
@@ -92,9 +114,9 @@ public final class Java8OptionalAwareDecoderTest extends TestBase {
     }
 
     @Test
-    public void testOptionalThrowsPermissionDenied() {
+    public void testOptionalThrowsFordidden() {
         try {
-            service.getOptionalThrowsPermissionDenied(null);
+            service.getOptionalThrowsForbidden(null);
             fail();
         } catch (RemoteException e) {
             assertThat(e.getMessage(), containsString("RemoteException: PERMISSION_DENIED (Default:PermissionDenied)"));

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8TestServer.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8TestServer.java
@@ -18,8 +18,6 @@ package com.palantir.conjure.java.client.jaxrs.feignimpl;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.conjure.java.api.errors.ErrorType;
-import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.conjure.java.server.jersey.ConjureJerseyFeature;
 import feign.Util;
@@ -38,7 +36,10 @@ import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -88,25 +89,43 @@ public class Java8TestServer extends Application<Configuration> {
         @Override
         public ImmutableMap<String, String> getThrowsNotFound(@Nullable String value) {
             if (Strings.isNullOrEmpty(value)) {
-                throw new ServiceException(ErrorType.NOT_FOUND);
+                throw new NotFoundException("Not found");
             } else {
                 return ImmutableMap.of(value, value);
             }
         }
 
         @Override
-        public ImmutableMap<String, String> getThrowsPermissionDenied(@Nullable String value) {
+        public ImmutableMap<String, String> getThrowsNotAuthorized(@Nullable String value) {
             if (Strings.isNullOrEmpty(value)) {
-                throw new ServiceException(ErrorType.PERMISSION_DENIED);
+                throw new NotAuthorizedException("Not authorized");
             } else {
                 return ImmutableMap.of(value, value);
             }
         }
 
         @Override
-        public Optional<ImmutableMap<String, String>> getOptionalThrowsPermissionDenied(@Nullable String value) {
+        public Optional<ImmutableMap<String, String>> getOptionalThrowsNotAuthorized(@Nullable String value) {
             if (Strings.isNullOrEmpty(value)) {
-                throw new ServiceException(ErrorType.PERMISSION_DENIED);
+                throw new NotAuthorizedException("Not authorized");
+            } else {
+                return Optional.of(ImmutableMap.of(value, value));
+            }
+        }
+
+        @Override
+        public ImmutableMap<String, String> getThrowsForbidden(@Nullable String value) {
+            if (Strings.isNullOrEmpty(value)) {
+                throw new ForbiddenException("Forbidden");
+            } else {
+                return ImmutableMap.of(value, value);
+            }
+        }
+
+        @Override
+        public Optional<ImmutableMap<String, String>> getOptionalThrowsForbidden(@Nullable String value) {
+            if (Strings.isNullOrEmpty(value)) {
+                throw new ForbiddenException("Forbidden");
             } else {
                 return Optional.of(ImmutableMap.of(value, value));
             }
@@ -181,17 +200,29 @@ public class Java8TestServer extends Application<Configuration> {
         ImmutableMap<String, String> getThrowsNotFound(@QueryParam("value") @Nullable String value);
 
         @GET
-        @Path("/throwsPermissionDenied")
+        @Path("/throwsNotAuthorized")
         @Consumes(MediaType.APPLICATION_JSON)
         @Produces(MediaType.APPLICATION_JSON)
-        ImmutableMap<String, String> getThrowsPermissionDenied(@QueryParam("value") @Nullable String value);
+        ImmutableMap<String, String> getThrowsNotAuthorized(@QueryParam("value") @Nullable String value);
 
         @GET
-        @Path("/optionalThrowsPermissionDenied")
+        @Path("/optionalThrowsNotAuthorized")
         @Consumes(MediaType.APPLICATION_JSON)
         @Produces(MediaType.APPLICATION_JSON)
-        Optional<ImmutableMap<String, String>> getOptionalThrowsPermissionDenied(
+        Optional<ImmutableMap<String, String>> getOptionalThrowsNotAuthorized(
                 @QueryParam("value") @Nullable String value);
+
+        @GET
+        @Path("/throwsForbidden")
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        ImmutableMap<String, String> getThrowsForbidden(@QueryParam("value") @Nullable String value);
+
+        @GET
+        @Path("/optionalThrowsForbidden")
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        Optional<ImmutableMap<String, String>> getOptionalThrowsForbidden(@QueryParam("value") @Nullable String value);
 
         @GET
         @Path("/string")

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
@@ -35,6 +35,7 @@ public enum ConjureJerseyFeature implements Feature {
         context.register(new IllegalArgumentExceptionMapper());
         context.register(new NoContentExceptionMapper());
         context.register(new RuntimeExceptionMapper());
+        context.register(new WebApplicationExceptionMapper());
         context.register(new RemoteExceptionMapper());
         context.register(new ServiceExceptionMapper());
         context.register(new QosExceptionMapper());

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapper.java
@@ -47,8 +47,6 @@ final class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicat
 
     @Override
     public Response toResponse(WebApplicationException exception) {
-        log.error(this.getClass().getSimpleName() + " is deprecated. Servers should throw ServiceExceptions instead.");
-
         String errorInstanceId = UUID.randomUUID().toString();
         if (exception.getResponse().getStatus() / 100 == 4 /* client error */) {
             log.info("Error handling request", SafeArg.of("errorInstanceId", errorInstanceId), exception);

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapper.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.server.jersey;
 
 import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.SafeArg;
 import java.util.UUID;
 import javax.ws.rs.BadRequestException;
@@ -27,14 +28,19 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.server.ParamException;
+import org.glassfish.jersey.server.ServerRuntime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @deprecated Services should throw {@link com.palantir.conjure.java.api.errors.ServiceException}s instead.
+ * While we strongly recommend that users throw {@link ServiceException}s and not {@link WebApplicationException}s,
+ * these exceptions are part of the JAX-RS standard and a server such as Jersey will throw them even if user code
+ * doesn't.
+ * For instance, {@link ServerRuntime} will throw {@link NotFoundException} if a request couldn't be routed, and if we
+ * don't handle that in this way, then when using {@link ConjureJerseyFeature} it will get caught by
+ * {@link RuntimeExceptionMapper} and transformed into a 500 internal exception, which is not what we want.
  */
 @Provider
-@Deprecated
 final class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {
 
     private static final Logger log = LoggerFactory.getLogger(WebApplicationExceptionMapper.class);

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
@@ -42,7 +42,9 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.ServerErrorException;
@@ -76,32 +78,36 @@ public final class ExceptionMappingTest {
         target = client.target(endpointUri);
     }
 
+    /**
+     * These tests confirm that {@link WebApplicationException}s are handled by the {@link
+     * WebApplicationExceptionMapper} rather than the {@link RuntimeExceptionMapper}
+     */
     @Test
-    public void testPermissionDeniedException() throws SecurityException {
-        Response response = target.path("throw-permission-denied").request().get();
+    public void testForbiddenException() throws NoSuchMethodException, SecurityException {
+        Response response = target.path("throw-forbidden-exception").request().get();
         assertThat(response.getStatus(), is(Status.FORBIDDEN.getStatusCode()));
     }
 
     @Test
-    public void testNotFoundException() throws SecurityException {
+    public void testNotFoundException() throws NoSuchMethodException, SecurityException {
         Response response = target.path("throw-not-found-exception").request().get();
         assertThat(response.getStatus(), is(Status.NOT_FOUND.getStatusCode()));
     }
 
     @Test
-    public void testServerErrorException() throws SecurityException {
+    public void testServerErrorException() throws NoSuchMethodException, SecurityException {
         Response response = target.path("throw-server-error-exception").request().get();
         assertThat(response.getStatus(), is(SERVER_EXCEPTION_STATUS.getStatusCode()));
     }
 
     @Test
-    public void testWebApplicationException() throws SecurityException {
+    public void testWebApplicationException() throws NoSuchMethodException, SecurityException {
         Response response = target.path("throw-web-application-exception").request().get();
         assertThat(response.getStatus(), is(WEB_EXCEPTION_STATUS.getStatusCode()));
     }
 
     @Test
-    public void testRemoteException() throws SecurityException, IOException {
+    public void testRemoteException() throws NoSuchMethodException, SecurityException, IOException {
         Response response = target.path("throw-remote-exception").request().get();
         assertThat(response.getStatus(), is(REMOTE_EXCEPTION_STATUS_CODE));
         String body =
@@ -113,7 +119,7 @@ public final class ExceptionMappingTest {
     }
 
     @Test
-    public void testServiceException() throws SecurityException, IOException {
+    public void testServiceException() throws NoSuchMethodException, SecurityException, IOException {
         Response response = target.path("throw-service-exception").request().get();
         assertThat(response.getStatus(), is(REMOTE_EXCEPTION_STATUS_CODE));
         String body =
@@ -148,13 +154,13 @@ public final class ExceptionMappingTest {
 
     public static final class ExceptionTestResource implements ExceptionTestService {
         @Override
-        public String throwPermissionDenied() {
-            throw new ServiceException(ErrorType.PERMISSION_DENIED);
+        public String throwForbiddenException() {
+            throw new ForbiddenException();
         }
 
         @Override
         public String throwNotFoundException() {
-            throw new ServiceException(ErrorType.NOT_FOUND);
+            throw new NotFoundException();
         }
 
         @Override
@@ -196,8 +202,8 @@ public final class ExceptionMappingTest {
     @Produces(MediaType.APPLICATION_JSON)
     public interface ExceptionTestService {
         @GET
-        @Path("/throw-permission-denied")
-        String throwPermissionDenied();
+        @Path("/throw-forbidden-exception")
+        String throwForbiddenException();
 
         @GET
         @Path("/throw-not-found-exception")

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/JerseyExceptionMapperTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/JerseyExceptionMapperTest.java
@@ -56,21 +56,13 @@ public final class JerseyExceptionMapperTest extends JerseyTest {
     @Test
     public void testWebException() {
         Response response = target("/angry/web").request().get();
-        // not service exception type, treat it as 500
-        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getStatus()).isEqualTo(403);
         assertThat(response.readEntity(String.class)).doesNotContain("secret");
-
-        // verify that it is of SerializableError type
-        response = target("/angry/web").request().get();
-        SerializableError entity = response.readEntity(SerializableError.class);
-        assertThat(entity.errorCode()).isEqualTo("INTERNAL");
-        assertThat(entity.errorName()).isEqualTo("Default:Internal");
     }
 
     @Test
     public void testRuntimeException() {
         Response response = target("/angry/runtime").request().get();
-        response = target("/angry/runtime").request().get();
         assertThat(response.getStatus()).isEqualTo(500);
         SerializableError entity = response.readEntity(SerializableError.class);
         assertThat(entity.errorCode()).isEqualTo("INTERNAL");

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/JerseyExceptionMapperTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/JerseyExceptionMapperTest.java
@@ -69,6 +69,18 @@ public final class JerseyExceptionMapperTest extends JerseyTest {
         assertThat(entity.errorName()).isEqualTo("Default:Internal");
     }
 
+    /**
+     * Tests the exception that we get when we couldn't find a route to the target is correct.
+     */
+    @Test
+    public void testRoutingException() {
+        Response response = target("/angry/cant-route").request().get();
+        assertThat(response.getStatus()).isEqualTo(404);
+        SerializableError entity = response.readEntity(SerializableError.class);
+        assertThat(entity.errorCode()).isEqualTo("NOT_FOUND");
+        assertThat(entity.errorName()).isEqualTo("Default:NotFound");
+    }
+
     @Path("angry")
     @Produces(MediaType.TEXT_PLAIN)
     public static final class AngryResource {

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapperTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapperTest.java
@@ -1,0 +1,91 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.server.jersey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ServiceUnavailableException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.server.ParamException;
+import org.junit.Test;
+
+public final class WebApplicationExceptionMapperTest {
+
+    private final WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper();
+    private final ObjectMapper objectMapper = ObjectMappers.newServerObjectMapper()
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    @Test
+    public void testExplicitlyHandledExceptions() throws Exception {
+        Response response;
+
+        response = mapper.toResponse(new ForbiddenException("secret"));
+        String entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity).contains("\"errorCode\" : \"PERMISSION_DENIED\"");
+        assertThat(entity).contains("\"errorName\" : \"Default:PermissionDenied\"");
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(entity).doesNotContain("secret");
+
+        response = mapper.toResponse(new NotFoundException());
+        entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity).contains("\"errorCode\" : \"NOT_FOUND\"");
+        assertThat(entity).contains("\"errorName\" : \"Default:NotFound\"");
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(entity).doesNotContain("secret");
+
+        response = mapper.toResponse(new BadRequestException());
+        entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity).contains("\"errorCode\" : \"INVALID_ARGUMENT\"");
+        assertThat(entity).contains("\"errorName\" : \"Default:InvalidArgument\"");
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(entity).doesNotContain("secret");
+
+        response = mapper.toResponse(new ParamException.CookieParamException(null, null, null));
+        entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity).contains("\"errorCode\" : \"INVALID_ARGUMENT\"");
+        assertThat(entity).contains("\"errorName\" : \"Default:InvalidArgument\"");
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(entity).doesNotContain("secret");
+    }
+
+    @Test
+    public void testNotExplicitlyHandledExceptions() throws Exception {
+        Response response;
+
+        response = mapper.toResponse(new WebApplicationException("secret", 503));
+        String entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity).contains("\"errorCode\" : \"javax.ws.rs.WebApplicationException\"");
+        assertThat(entity).contains("\"errorName\" : \"WebApplicationException\"");
+        assertThat(response.getStatus()).isEqualTo(503);
+        assertThat(entity).doesNotContain("secret");
+
+        response = mapper.toResponse(new ServiceUnavailableException("secret"));
+        entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity)
+                .contains("\"errorCode\" : \"javax.ws.rs.ServiceUnavailableException\"");
+        assertThat(entity).contains("\"errorName\" : \"ServiceUnavailableException\"");
+        assertThat(response.getStatus()).isEqualTo(503);
+        assertThat(entity).doesNotContain("secret");
+    }
+}


### PR DESCRIPTION
Without this, we won't special-handle exceptions coming from jersey (e.g. routing failure, where jersey throws `NotFoundException`), so they instead get mapped by the less specific `RuntimeExceptionMapper` and incorrectly turned into internal exceptions.