### PR TITLE
Stop propagating RemoteExceptions

### DIFF
--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
@@ -109,19 +109,19 @@ public final class ExceptionMappingTest {
     @Test
     public void testRemoteException() throws IOException {
         Response response = target.path("throw-remote-exception").request().get();
-        assertThat(response.getStatus(), is(REMOTE_EXCEPTION_STATUS_CODE));
+        assertThat(response.getStatus(), is(ErrorType.INTERNAL.httpErrorCode()));
         String body =
                 new String(ByteStreams.toByteArray(response.readEntity(InputStream.class)), StandardCharsets.UTF_8);
 
         SerializableError error = ObjectMappers.newClientObjectMapper().readValue(body, SerializableError.class);
-        assertThat(error.errorCode(), is("errorCode"));
-        assertThat(error.errorName(), is("errorName"));
+        assertThat(error.errorCode(), is(ErrorType.INTERNAL.code().toString()));
+        assertThat(error.errorName(), is(ErrorType.INTERNAL.name()));
     }
 
     @Test
     public void testServiceException() throws IOException {
         Response response = target.path("throw-service-exception").request().get();
-        assertThat(response.getStatus(), is(REMOTE_EXCEPTION_STATUS_CODE));
+        assertThat(response.getStatus(), is(ErrorType.INVALID_ARGUMENT.httpErrorCode()));
         String body =
                 new String(ByteStreams.toByteArray(response.readEntity(InputStream.class)), StandardCharsets.UTF_8);
 

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
@@ -114,6 +114,7 @@ public final class ExceptionMappingTest {
                 new String(ByteStreams.toByteArray(response.readEntity(InputStream.class)), StandardCharsets.UTF_8);
 
         SerializableError error = ObjectMappers.newClientObjectMapper().readValue(body, SerializableError.class);
+        assertThat(error.errorInstanceId(), is("errorInstanceId"));
         assertThat(error.errorCode(), is(ErrorType.INTERNAL.code().toString()));
         assertThat(error.errorName(), is(ErrorType.INTERNAL.name()));
     }
@@ -188,6 +189,7 @@ public final class ExceptionMappingTest {
         @Override
         public String throwRemoteException() {
             throw new RemoteException(SerializableError.builder()
+                    .errorInstanceId("errorInstanceId")
                     .errorCode("errorCode")
                     .errorName("errorName")
                     .build(),


### PR DESCRIPTION
## What is happening

We have concerns that people are introspecting RemoteExceptions that are not actually part of a server's API but instead came from a further upstream server and are propagated by the server's `RemoteExceptionMapper` when one of the server's clients encountered a failed HTTP call.

## What should happen

Instead of blindly propagating uncaught RemoteExceptions, this library should always send 500 responses corresponding to an INTERNAL error.

If devs actually wanted this to be part of the API, they should wrap their client in a `catch` block and re-throw one of their own _ServiceExceptions_.