### PR TITLE
Use BINTRAY_*_REMOTING envs

### DIFF
--- a/gradle/publish-jar.gradle
+++ b/gradle/publish-jar.gradle
@@ -12,8 +12,8 @@ jar {
 }
 
 bintray {
-    user = System.env.BINTRAY_USERNAME
-    key = System.env.BINTRAY_PASSWORD
+    user = System.env.BINTRAY_USERNAME_REMOTING
+    key = System.env.BINTRAY_PASSWORD_REMOTING
     publish = true
     pkg {
         repo = 'releases'


### PR DESCRIPTION
The project's default bintray creds are currently set up to publish to `conjure-java-runtime`.
Use these custom env vars to maintain ability to publish http-remoting.