### PR TITLE
[fix] Empty responses now release concurrency permits 

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/ConcurrencyLimitingInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/ConcurrencyLimitingInterceptor.java
@@ -89,6 +89,7 @@ final class ConcurrencyLimitingInterceptor implements Interceptor {
 
     private static Response wrapResponse(Limiter.Listener listener, Response response) {
         if (response.body() == null) {
+            listener.onSuccess();
             return response;
         }
         ResponseBody currentBody = response.body();

--- a/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/ConcurrencyLimitingInterceptorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/remoting3/okhttp/ConcurrencyLimitingInterceptorTest.java
@@ -124,4 +124,12 @@ public final class ConcurrencyLimitingInterceptorTest {
         Response erroneousResponse = interceptor.intercept(chain);
         assertThatThrownBy(() -> erroneousResponse.body().source().readByteArray()).isEqualTo(exception);
     }
+
+    @Test
+    public void marksSuccessIfNoContent() throws IOException {
+        Response noContent = response.newBuilder().code(204).build();
+        when(chain.proceed(request)).thenReturn(noContent);
+        assertThat(interceptor.intercept(chain)).isEqualTo(noContent);
+        verify(listener).onSuccess();
+    }
 }


### PR DESCRIPTION
Sadly I accidentally skipped a line. Would like this merged + released
ASAP; can coordinate internally beyond that.