### PR TITLE
[fix] Empty bodies are appropriately accounted for.

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitingInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitingInterceptor.java
@@ -87,8 +87,13 @@ final class ConcurrencyLimitingInterceptor implements Interceptor {
         }
     }
 
-    private static Response wrapResponse(Limiter.Listener listener, Response response) {
+    private static Response wrapResponse(Limiter.Listener listener, Response response) throws IOException {
+        // OkHttp guarantees not-null to execute() and callbacks, but not at this level.
         if (response.body() == null) {
+            listener.onIgnore();
+            return response;
+        } else if (response.body().source().exhausted()) {
+            // this case exists for Feign, which does not properly close empty responses
             listener.onSuccess();
             return response;
         }

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitingInterceptorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitingInterceptorTest.java
@@ -126,10 +126,20 @@ public final class ConcurrencyLimitingInterceptorTest {
     }
 
     @Test
-    public void marksSuccessIfNoContent() throws IOException {
+    public void ignoresIfNoContent() throws IOException {
         Response noContent = response.newBuilder().code(204).build();
         when(chain.proceed(request)).thenReturn(noContent);
         assertThat(interceptor.intercept(chain)).isEqualTo(noContent);
+        verify(listener).onIgnore();
+    }
+
+    @Test
+    public void marksSuccessIfContentEmpty() throws IOException {
+        Response empty = response.newBuilder().code(204)
+                .body(ResponseBody.create(MediaType.parse("application/json"), new byte[0]))
+                .build();
+        when(chain.proceed(request)).thenReturn(empty);
+        assertThat(interceptor.intercept(chain)).isEqualTo(empty);
         verify(listener).onSuccess();
     }
 }


### PR DESCRIPTION
There exists a bug in the old version of Feign we use. If the body
is empty, Feign does not close it. In practice, this means that
zero-length responses are not closed,and so concurrency permits
are not returned.

We still need to handle the null case, but it should be an ignore,
not a success.

Additionally, we should probably consider having some better ETE style
tests for Conjure-java-runtime. This bug was trivial to reproduce
internally, but the tooling on OSS makes it quite hard.