### PR TITLE
[improvement] Hide mutable HostMetricRegistry methods behind HostEventsSink interface

### DIFF
--- a/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -26,7 +26,7 @@ import com.palantir.remoting3.jaxrs.feignimpl.Java8OptionalAwareContract;
 import com.palantir.remoting3.jaxrs.feignimpl.PathTemplateHeaderEnrichmentContract;
 import com.palantir.remoting3.jaxrs.feignimpl.PathTemplateHeaderRewriter;
 import com.palantir.remoting3.jaxrs.feignimpl.SlashEncodingContract;
-import com.palantir.remoting3.okhttp.HostMetricsRegistry;
+import com.palantir.remoting3.okhttp.HostEventsSink;
 import com.palantir.remoting3.okhttp.OkHttpClients;
 import feign.CborDelegateDecoder;
 import feign.CborDelegateEncoder;
@@ -64,7 +64,7 @@ abstract class AbstractFeignJaxRsClientBuilder {
      */
     private final String primaryUri;
 
-    private HostMetricsRegistry hostMetricsRegistry;
+    private HostEventsSink hostEventsSink;
 
     AbstractFeignJaxRsClientBuilder(ClientConfiguration config) {
         Preconditions.checkArgument(!config.uris().isEmpty(), "Must provide at least one service URI");
@@ -79,8 +79,8 @@ abstract class AbstractFeignJaxRsClientBuilder {
     /**
      * Set the host metrics registry to use when constructing the OkHttp client.
      */
-    public final AbstractFeignJaxRsClientBuilder hostMetricsRegistry(HostMetricsRegistry newHostMetricsRegistry) {
-        hostMetricsRegistry = newHostMetricsRegistry;
+    public final AbstractFeignJaxRsClientBuilder hostMetricsRegistry(HostEventsSink newHostEventsSink) {
+        hostEventsSink = newHostEventsSink;
         return this;
     }
 
@@ -95,8 +95,8 @@ abstract class AbstractFeignJaxRsClientBuilder {
     public final <T> T build(Class<T> serviceClass, UserAgent userAgent) {
         ObjectMapper objectMapper = getObjectMapper();
         ObjectMapper cborObjectMapper = getCborObjectMapper();
-        okhttp3.OkHttpClient okHttpClient = Optional.ofNullable(hostMetricsRegistry)
-                .map(hostMetrics -> OkHttpClients.create(config, userAgent, hostMetrics, serviceClass))
+        okhttp3.OkHttpClient okHttpClient = Optional.ofNullable(hostEventsSink)
+                .map(hostEvents -> OkHttpClients.create(config, userAgent, hostEvents, serviceClass))
                 .orElseGet(() -> OkHttpClients.create(config, userAgent, serviceClass));
 
         return Feign.builder()

--- a/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/JaxRsClient.java
+++ b/jaxrs-clients/src/main/java/com/palantir/remoting3/jaxrs/JaxRsClient.java
@@ -22,7 +22,7 @@ import com.palantir.remoting3.clients.UserAgent;
 import com.palantir.remoting3.clients.UserAgents;
 import com.palantir.remoting3.ext.refresh.Refreshable;
 import com.palantir.remoting3.ext.refresh.RefreshableProxyInvocationHandler;
-import com.palantir.remoting3.okhttp.HostMetricsRegistry;
+import com.palantir.remoting3.okhttp.HostEventsSink;
 
 /**
  * Static factory methods for producing creating JAX-RS HTTP proxies.
@@ -38,11 +38,11 @@ public final class JaxRsClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetricsRegistry,
+            HostEventsSink hostEventsSink,
             ClientConfiguration config) {
         // TODO(rfink): Add http-remoting agent as informational
         return new FeignJaxRsClientBuilder(config)
-                .hostMetricsRegistry(hostMetricsRegistry)
+                .hostMetricsRegistry(hostEventsSink)
                 .build(serviceClass, userAgent);
     }
 
@@ -73,11 +73,11 @@ public final class JaxRsClient {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetricsRegistry,
+            HostEventsSink hostEventsSink,
             Refreshable<ClientConfiguration> config) {
         return Reflection.newProxy(serviceClass, RefreshableProxyInvocationHandler.create(
                 config,
-                serviceConfiguration -> create(serviceClass, userAgent, hostMetricsRegistry, serviceConfiguration)));
+                serviceConfiguration -> create(serviceClass, userAgent, hostEventsSink, serviceConfiguration)));
     }
 
     /**

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/HostEventsSink.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/HostEventsSink.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.remoting3.okhttp;
+
+/**
+ * A listener for responses / exceptions coming from remote hosts when using clients created from {@link OkHttpClients}.
+ * <p>
+ * We provide a {@link HostMetricsRegistry} implementation of this that turns these events into {@link HostMetrics}
+ * for each remote host.
+ */
+public interface HostEventsSink {
+    void record(String serviceName, String hostname, int port, int statusCode, long micros);
+
+    void recordIoException(String serviceName, String hostname, int port);
+}

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/HostMetricsRegistry.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/HostMetricsRegistry.java
@@ -30,7 +30,7 @@ import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class HostMetricsRegistry {
+public final class HostMetricsRegistry implements HostEventsSink {
 
     private static final Logger log = LoggerFactory.getLogger(HostMetricsRegistry.class);
 

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/InstrumentedInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/InstrumentedInterceptor.java
@@ -34,11 +34,11 @@ final class InstrumentedInterceptor implements Interceptor {
     static final String CLIENT_RESPONSE_METRIC_NAME = "client.response";
     static final String SERVICE_NAME_TAG = "service-name";
 
-    private final HostMetricsRegistry hostMetrics;
+    private final HostEventsSink hostMetrics;
     private final String serviceName;
     private final Timer responseTimer;
 
-    InstrumentedInterceptor(TaggedMetricRegistry registry, HostMetricsRegistry hostMetrics, String serviceName) {
+    InstrumentedInterceptor(TaggedMetricRegistry registry, HostEventsSink hostMetrics, String serviceName) {
         this.hostMetrics = hostMetrics;
         this.serviceName = serviceName;
         this.responseTimer = registry.timer(name());
@@ -68,7 +68,7 @@ final class InstrumentedInterceptor implements Interceptor {
     }
 
     static InstrumentedInterceptor create(
-            TaggedMetricRegistry registry, HostMetricsRegistry hostMetrics, Class<?> serviceClass) {
+            TaggedMetricRegistry registry, HostEventsSink hostMetrics, Class<?> serviceClass) {
         return new InstrumentedInterceptor(registry, hostMetrics, serviceClass.getSimpleName());
     }
 

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
@@ -118,7 +118,7 @@ public final class OkHttpClients {
      * ClientConfiguration#uris URIs} are initialized in random order.
      */
     public static OkHttpClient create(
-            ClientConfiguration config, UserAgent userAgent, HostMetricsRegistry hostMetrics, Class<?> serviceClass) {
+            ClientConfiguration config, UserAgent userAgent, HostEventsSink hostMetrics, Class<?> serviceClass) {
         return createInternal(config, userAgent, hostMetrics, serviceClass, true /* randomize URLs */);
     }
 
@@ -126,7 +126,7 @@ public final class OkHttpClients {
      * Creates an OkHttp client from the given {@link ClientConfiguration}. Note that the configured {@link
      * ClientConfiguration#uris URIs} are initialized in random order.
      *
-     * @deprecated Use {@link #create(ClientConfiguration, UserAgent, HostMetricsRegistry, Class)}
+     * @deprecated Use {@link #create(ClientConfiguration, UserAgent, HostEventsSink, Class)}
      */
     @Deprecated
     public static OkHttpClient create(ClientConfiguration config, UserAgent userAgent, Class<?> serviceClass) {
@@ -146,7 +146,7 @@ public final class OkHttpClients {
     /**
      * Return the per service and host metrics for all clients created by {@link OkHttpClients}.
      *
-     * @deprecated Pass in a {@link HostMetricsRegistry} when creating a client.
+     * @deprecated Pass in a {@link HostEventsSink} when creating a client.
      */
     @Deprecated
     public static Collection<HostMetrics> hostMetrics() {
@@ -155,14 +155,14 @@ public final class OkHttpClients {
 
     @VisibleForTesting
     static RemotingOkHttpClient withStableUris(
-            ClientConfiguration config, UserAgent userAgent, HostMetricsRegistry hostMetrics, Class<?> serviceClass) {
+            ClientConfiguration config, UserAgent userAgent, HostEventsSink hostMetrics, Class<?> serviceClass) {
         return createInternal(config, userAgent, hostMetrics, serviceClass, false);
     }
 
     private static RemotingOkHttpClient createInternal(
             ClientConfiguration config,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetrics,
+            HostEventsSink hostMetrics,
             Class<?> serviceClass,
             boolean randomizeUrlOrder) {
         OkHttpClient.Builder client = new OkHttpClient.Builder();

--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2Client.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2Client.java
@@ -22,7 +22,7 @@ import com.palantir.remoting3.clients.UserAgent;
 import com.palantir.remoting3.clients.UserAgents;
 import com.palantir.remoting3.ext.refresh.Refreshable;
 import com.palantir.remoting3.ext.refresh.RefreshableProxyInvocationHandler;
-import com.palantir.remoting3.okhttp.HostMetricsRegistry;
+import com.palantir.remoting3.okhttp.HostEventsSink;
 
 /**
  * Static factory methods for producing creating Retrofit2 HTTP proxies.
@@ -38,10 +38,10 @@ public final class Retrofit2Client {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetricsRegistry,
+            HostEventsSink hostEventsSink,
             ClientConfiguration config) {
         return new Retrofit2ClientBuilder(config)
-                .hostMetricsRegistry(hostMetricsRegistry)
+                .hostMetricsRegistry(hostEventsSink)
                 .build(serviceClass, userAgent);
     }
 
@@ -71,11 +71,11 @@ public final class Retrofit2Client {
     public static <T> T create(
             Class<T> serviceClass,
             UserAgent userAgent,
-            HostMetricsRegistry hostMetricsRegistry,
+            HostEventsSink hostEventsSink,
             Refreshable<ClientConfiguration> config) {
         return Reflection.newProxy(serviceClass, RefreshableProxyInvocationHandler.create(
                 config,
-                serviceConfiguration -> create(serviceClass, userAgent, hostMetricsRegistry, serviceConfiguration)));
+                serviceConfiguration -> create(serviceClass, userAgent, hostEventsSink, serviceConfiguration)));
     }
 
     /**

--- a/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2ClientBuilder.java
+++ b/retrofit2-clients/src/main/java/com/palantir/remoting3/retrofit2/Retrofit2ClientBuilder.java
@@ -22,7 +22,7 @@ import com.palantir.remoting3.clients.ClientConfiguration;
 import com.palantir.remoting3.clients.UserAgent;
 import com.palantir.remoting3.clients.UserAgents;
 import com.palantir.remoting3.ext.jackson.ObjectMappers;
-import com.palantir.remoting3.okhttp.HostMetricsRegistry;
+import com.palantir.remoting3.okhttp.HostEventsSink;
 import com.palantir.remoting3.okhttp.OkHttpClients;
 import java.util.Optional;
 import retrofit2.Retrofit;
@@ -34,7 +34,7 @@ public final class Retrofit2ClientBuilder {
 
     private final ClientConfiguration config;
 
-    private HostMetricsRegistry hostMetricsRegistry;
+    private HostEventsSink hostEventsSink;
 
     public Retrofit2ClientBuilder(ClientConfiguration config) {
         Preconditions.checkArgument(!config.uris().isEmpty(), "Cannot construct retrofit client with empty URI list");
@@ -44,8 +44,8 @@ public final class Retrofit2ClientBuilder {
     /**
      * Set the host metrics registry to use when constructing the OkHttp client.
      */
-    public Retrofit2ClientBuilder hostMetricsRegistry(HostMetricsRegistry newHostMetricsRegistry) {
-        hostMetricsRegistry = newHostMetricsRegistry;
+    public Retrofit2ClientBuilder hostMetricsRegistry(HostEventsSink newHostEventsSink) {
+        hostEventsSink = newHostEventsSink;
         return this;
     }
 
@@ -58,8 +58,8 @@ public final class Retrofit2ClientBuilder {
     }
 
     public <T> T build(Class<T> serviceClass, UserAgent userAgent) {
-        okhttp3.OkHttpClient client = Optional.ofNullable(hostMetricsRegistry)
-                .map(hostMetrics -> OkHttpClients.create(config, userAgent, hostMetrics, serviceClass))
+        okhttp3.OkHttpClient client = Optional.ofNullable(hostEventsSink)
+                .map(hostEvents -> OkHttpClients.create(config, userAgent, hostEvents, serviceClass))
                 .orElseGet(() -> OkHttpClients.create(config, userAgent, serviceClass));
 
         Retrofit retrofit = new Retrofit.Builder()


### PR DESCRIPTION
## Before this PR

It is not possible to build a back-compat layer to take in conjure-java-runtime config and build remoting3 clients because the new clients only take a minimal `HostEventsSink` interface (refactored here: https://github.com/palantir/conjure-java-runtime/pull/779) and the old remoting3 clients take a big mutable `HostMetricsRegistry`.

## After this PR

Both old and new use a very similar looking interface, making backporting convenient.