### PR TITLE
Log error names in exception mappers

### DIFF
--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
@@ -53,9 +53,15 @@ abstract class JsonExceptionMapper<T extends Throwable> implements ExceptionMapp
         ErrorType errorType = getErrorType(exception);
 
         if (errorType.httpErrorCode() / 100 == 4 /* client error */) {
-            log.info("Error handling request", SafeArg.of("errorInstanceId", errorInstanceId), exception);
+            log.info("Error handling request",
+                    SafeArg.of("errorInstanceId", errorInstanceId),
+                    SafeArg.of("errorName", errorType.name()),
+                    exception);
         } else {
-            log.error("Error handling request", SafeArg.of("errorInstanceId", errorInstanceId), exception);
+            log.error("Error handling request",
+                    SafeArg.of("errorInstanceId", errorInstanceId),
+                    SafeArg.of("errorName", errorType.name()),
+                    exception);
         }
 
         return createResponse(errorType, errorInstanceId);
@@ -77,7 +83,9 @@ abstract class JsonExceptionMapper<T extends Throwable> implements ExceptionMapp
                     .type(MediaType.APPLICATION_JSON);
         } catch (RuntimeException e) {
             log.warn("Unable to translate exception to json",
-                    SafeArg.of("errorInstanceId", errorInstanceId), e);
+                    SafeArg.of("errorInstanceId", errorInstanceId),
+                    SafeArg.of("errorName", errorName),
+                    e);
             builder = Response.status(httpErrorCode);
             builder.type(MediaType.TEXT_PLAIN);
             builder.entity("Unable to translate exception to json. Refer to the server logs with this errorInstanceId: "

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
@@ -70,7 +70,9 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
             builder.entity(error);
         } catch (RuntimeException e) {
             log.warn("Unable to translate exception to json",
-                    SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()), e);
+                    SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
+                    SafeArg.of("errorName", exception.getError().errorName()),
+                    e);
             // simply write out the exception message
             builder.type(MediaType.TEXT_PLAIN);
             builder.entity("Unable to translate exception to json. Refer to the server logs with this errorInstanceId: "

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
@@ -40,10 +40,14 @@ final class ServiceExceptionMapper implements ExceptionMapper<ServiceException> 
         int httpStatus = exception.getErrorType().httpErrorCode();
         if (httpStatus / 100 == 4 /* client error */) {
             log.info("Error handling request",
-                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()), exception);
+                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
+                    SafeArg.of("errorName", exception.getErrorType().name()),
+                    exception);
         } else {
             log.error("Error handling request",
-                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()), exception);
+                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
+                    SafeArg.of("errorName", exception.getErrorType().name()),
+                    exception);
         }
 
         ResponseBuilder builder = Response.status(httpStatus);


### PR DESCRIPTION
Alternative to https://github.com/palantir/conjure-java-runtime-api/pull/131

This implementation matches what we currently do for `errorInstanceId` and is less hacky than adding the errorType information to the `ServiceException` args.