### PR TITLE
--scan on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - checkout
       - restore_cache: { key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
       - restore_cache: { key: 'gradle-cache-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
-      - run: ./gradlew --profile --stacktrace --parallel --continue --no-daemon --max-workers=8 build
+      - run: ./gradlew --scan --stacktrace --parallel --continue --no-daemon --max-workers=8 build
       - save_cache:
           key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}'
           paths: [ ~/.gradle/wrapper ]
@@ -30,9 +30,9 @@ jobs:
           command: |
             # publishing snapshots to bintray does not work, so we only publish from tag builds (not develop)
             if [[ "${CIRCLE_TAG}" =~ [0-9]+(\.[0-9]+)+(-[a-zA-Z]+[0-9]*)* ]]; then
-              ./gradlew --profile --stacktrace --parallel --continue --no-daemon --max-workers=8 publish
+              ./gradlew --scan --stacktrace --parallel --continue --no-daemon --max-workers=8 publish
             else
-              ./gradlew --profile --stacktrace --parallel --continue --no-daemon --max-workers=8 publishToMavenLocal
+              ./gradlew --scan --stacktrace --parallel --continue --no-daemon --max-workers=8 publishToMavenLocal
               mkdir -p $CIRCLE_ARTIFACTS/poms
               find . -name 'pom-default.xml' -exec cp --parents {} $CIRCLE_ARTIFACTS/poms \;
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker: [{ image: 'circleci/openjdk:8u181-jdk' }]
-    resource_class: medium
+    resource_class: medium+
     environment:
       GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
       CIRCLE_TEST_REPORTS: /home/circleci/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker: [{ image: 'circleci/openjdk:8u181-jdk' }]
-    resource_class: xlarge
+    resource_class: medium
     environment:
       GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
       CIRCLE_TEST_REPORTS: /home/circleci/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - checkout
       - restore_cache: { key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
       - restore_cache: { key: 'gradle-cache-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
-      - run: ./gradlew --scan --stacktrace --parallel --continue --no-daemon --max-workers=8 build
+      - run: ./gradlew --scan --stacktrace --parallel --continue --no-daemon build
       - save_cache:
           key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}'
           paths: [ ~/.gradle/wrapper ]
@@ -30,9 +30,9 @@ jobs:
           command: |
             # publishing snapshots to bintray does not work, so we only publish from tag builds (not develop)
             if [[ "${CIRCLE_TAG}" =~ [0-9]+(\.[0-9]+)+(-[a-zA-Z]+[0-9]*)* ]]; then
-              ./gradlew --scan --stacktrace --parallel --continue --no-daemon --max-workers=8 publish
+              ./gradlew --scan --stacktrace --parallel --continue --no-daemon publish
             else
-              ./gradlew --scan --stacktrace --parallel --continue --no-daemon --max-workers=8 publishToMavenLocal
+              ./gradlew --scan --stacktrace --parallel --continue --no-daemon publishToMavenLocal
               mkdir -p $CIRCLE_ARTIFACTS/poms
               find . -name 'pom-default.xml' -exec cp --parents {} $CIRCLE_ARTIFACTS/poms \;
             fi

--- a/build.gradle
+++ b/build.gradle
@@ -105,3 +105,8 @@ subprojects {
         options.compilerArgs += ['-XepDisableWarningsInGeneratedCode']
     }
 }
+
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+}


### PR DESCRIPTION
This PR is just intended to demonstrate how gradle spins up too many workers on CI by default.