### PR TITLE
[improvement] add a no-op host events sink

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/NoOpHostEventsSink.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/NoOpHostEventsSink.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+/**
+ * A no-op implementation of {@link HostEventsSink} - i.e. it discards all events.
+ */
+public enum NoOpHostEventsSink implements HostEventsSink {
+    INSTANCE;
+
+    @Override
+    public void record(String serviceName, String hostname, int port, int statusCode, long micros) {
+        // do nothing
+    }
+
+    @Override
+    public void recordIoException(String serviceName, String hostname, int port) {
+        // do nothing
+    }
+}


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
Various clients are constructed by constructing a brand new `HostMetricsRegistry` (because there is no appropriate existing host metrics registry, for example), even when no metrics collection is in fact desired. This is wasteful.

## After this PR
We can construct certain clients explicitly with a no-op events sink - this makes it explicit that the client will not be recording metrics.
