### PR TITLE
[improvement] change the concurrency algorithm to AIMD

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -20,7 +20,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.netflix.concurrency.limits.Limiter;
-import com.netflix.concurrency.limits.limit.VegasLimit;
+import com.netflix.concurrency.limits.limit.AIMDLimit;
 import com.netflix.concurrency.limits.limiter.BlockingLimiter;
 import com.netflix.concurrency.limits.limiter.SimpleLimiter;
 import com.palantir.logsafe.SafeArg;
@@ -122,7 +122,7 @@ class ConcurrencyLimiters {
 
     private Limiter<Void> newLimiter() {
         Limiter<Void> limiter = SimpleLimiter.newBuilder()
-                .limit(new ConjureWindowedLimit(VegasLimit.newDefault()))
+                .limit(new ConjureWindowedLimit(AIMDLimit.newBuilder().build()))
                 .build();
         return BlockingLimiter.wrap(limiter, timeout);
     }

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/FlowControlTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/FlowControlTest.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
 public final class FlowControlTest {
     private static final Logger log = LoggerFactory.getLogger(FlowControlTest.class);
     private static final Duration GRACE = Duration.ofMinutes(2);
-    private static final int REQUESTS_PER_THREAD = 5;
+    private static final int REQUESTS_PER_THREAD = 50;
     private static ListeningExecutorService executorService;
 
     private final ConcurrencyLimiters limiters = new ConcurrencyLimiters(

--- a/readme.md
+++ b/readme.md
@@ -334,12 +334,9 @@ supported for media type `application/json`.
 
 Flow control in Conjure is a collaborative effort between servers and clients.
 
-Clients estimate the server's queue size using response delay and proactively throttle outgoing requests to minimize bottleneck queueing.  Servers may also advertise an overloaded state using 429/503 responses, which clients interpret with more drastic throttling. This results in a mechanism similar to TCP/IP flow-control and minimizes both client and server-side errors.
+Servers advertise an overloaded state using 429/503 responses, which clients interpret by throttling the number of in-flight requests they will send (currently according to an additive increase, multiplicative decrease based algorithm). Requests are retried a fixed number of times, scheduled with an exponential backoff algorithm.
 
-1. Client throttling is implemented using the TCP Vegas algorithm from Netflix's [concurrency-limits](https://github.com/Netflix/concurrency-limits/) library, which uses 200 -> 399 responses for determining new limits.
-1. Explicit 429/503 responses will result in a reduction in concurrency, and will be retried a fixed number of times, scheduled with an exponential backoff algorithm.
-
-All other responses codes are not factored into timings. Concurrency permits are only released when the response body is closed, so large streaming responses are correctly tracked.
+Concurrency permits are only released when the response body is closed, so large streaming responses are correctly tracked.
 
 conjure-java-runtime servers can use the `QosException` class to advertise the following conditions:
 


### PR DESCRIPTION
I've come to the conclusion that I don't trust the knobs and levers
available right now to properly tune this and investigate places where
it goes wrong.

This PR flips the algorithm to be AIMD; this means that it only does
stuff in response to explicit 429/503 responses and so makes it highly
unlikely to be problematic.