### PR TITLE
Enable stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,14 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels: []
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not been touched in the last 60 days. 
+  Please comment if you'd like to keep it open, otherwise it'll be closed in 7 days time.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
## Before this PR

Github issues could accumulate, when the owner has lost interest or the problem has actually been fixed.

## After this PR

[stalebot](https://github.com/apps/stale) will automatically comment on any issues that haven't been touched in 60 days, and auto-close them if nobody cares anymore.

Matches the config we already have running on https://github.com/palantir/gradle-baseline/pull/323