### PR TITLE
Make sure lock verification doesn't run with locks applied

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ subprojects {
     apply plugin: 'java'
 
     sourceCompatibility = 1.8
+    if (gradle.startParameter.taskNames.find {
+        it.endsWith('verifyDependencyLocksAreCurrent') || it.endsWith('build')}) {
+        gradle.startParameter.setTaskNames(gradle.startParameter.taskNames + ['generateLock'])
+    }
 
     apply plugin: 'nebula.dependency-lock'
     dependencyLock {

--- a/jetty-http2-agent/versions.lock
+++ b/jetty-http2-agent/versions.lock
@@ -4,7 +4,7 @@
             "locked": "1.0.3"
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {
-            "locked": "2.0.7"
+            "locked": "2.0.9"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.12"
@@ -15,7 +15,7 @@
             "locked": "1.0.3"
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {
-            "locked": "2.0.7"
+            "locked": "2.0.9"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.12"

--- a/pkcs1-reader-bouncy-castle/versions.lock
+++ b/pkcs1-reader-bouncy-castle/versions.lock
@@ -53,10 +53,10 @@
             "project": true
         },
         "org.bouncycastle:bcpkix-jdk15on": {
-            "locked": "1.54"
+            "locked": "1.60"
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.54",
+            "locked": "1.60",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
             ]
@@ -128,10 +128,10 @@
             "project": true
         },
         "org.bouncycastle:bcpkix-jdk15on": {
-            "locked": "1.54"
+            "locked": "1.60"
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.54",
+            "locked": "1.60",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
             ]


### PR DESCRIPTION
nebula.dependency-lock will check start parameters of your gradle invocation for existence of `generateLock` argument. In cases where we are running `verifyDependencyLocksAreCurrent` or `build` we add `generateLock` to the command line arguments.

https://github.com/nebula-plugins/gradle-dependency-lock-plugin/blob/master/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt#L129 for reference