### PR TITLE
Revert "Stop propagating RemoteExceptions (#801)"

### DIFF
--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
@@ -16,12 +16,12 @@
 
 package com.palantir.conjure.java.server.jersey;
 
-import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.logsafe.SafeArg;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -40,8 +40,8 @@ import org.slf4j.LoggerFactory;
  * response is then thrown as a {@link RemoteException} at the call point in server A.  If server A does not catch this
  * exception and it raises up the call stack back into Jersey, execution enters this {@link RemoteExceptionMapper}.
  * <p>
- * To preserve debuggability, the exception and HTTP status code from B's exception are logged at WARN level, but not
- * propagated to caller to avoid an unintentional dependency on the remote exception.
+ * To preserve debuggability, the exception and HTTP status code from B's exception are logged at WARN level and
+ * returned back to the caller/browser.
  */
 @Provider
 final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
@@ -52,20 +52,14 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
     public Response toResponse(RemoteException exception) {
         Status status = Status.fromStatusCode(exception.getStatus());
 
-        // log at WARN instead of ERROR because although this indicates an issue in a remote server
-        log.warn("Encountered a remote exception. Mapping to an internal error before propagating",
+        // log at WARN instead of ERROR because although this indicates an issue in a remote server, it is not
+        log.warn("Forwarding response and status code from remote server back to caller",
                 SafeArg.of("statusCode", status.getStatusCode()),
                 exception);
 
-        ErrorType errorType = ErrorType.INTERNAL;
-        Response.ResponseBuilder builder = Response.status(errorType.httpErrorCode());
+        SerializableError error = exception.getError();
+        ResponseBuilder builder = Response.status(status);
         try {
-            // Override only the name and code of the error
-            SerializableError error = SerializableError.builder()
-                    .from(exception.getError())
-                    .errorName(errorType.name())
-                    .errorCode(errorType.code().toString())
-                    .build();
             builder.type(MediaType.APPLICATION_JSON);
             builder.entity(error);
         } catch (RuntimeException e) {
@@ -74,9 +68,9 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
                     SafeArg.of("errorName", exception.getError().errorName()),
                     e);
             // simply write out the exception message
+            builder = Response.status(status);
             builder.type(MediaType.TEXT_PLAIN);
-            builder.entity("Unable to translate exception to json. Refer to the server logs with this errorInstanceId: "
-                    + exception.getError().errorInstanceId());
+            builder.entity(error.errorCode() + ": " + error.errorName());
         }
         return builder.build();
     }

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
@@ -109,20 +109,19 @@ public final class ExceptionMappingTest {
     @Test
     public void testRemoteException() throws IOException {
         Response response = target.path("throw-remote-exception").request().get();
-        assertThat(response.getStatus(), is(ErrorType.INTERNAL.httpErrorCode()));
+        assertThat(response.getStatus(), is(REMOTE_EXCEPTION_STATUS_CODE));
         String body =
                 new String(ByteStreams.toByteArray(response.readEntity(InputStream.class)), StandardCharsets.UTF_8);
 
         SerializableError error = ObjectMappers.newClientObjectMapper().readValue(body, SerializableError.class);
-        assertThat(error.errorInstanceId(), is("errorInstanceId"));
-        assertThat(error.errorCode(), is(ErrorType.INTERNAL.code().toString()));
-        assertThat(error.errorName(), is(ErrorType.INTERNAL.name()));
+        assertThat(error.errorCode(), is("errorCode"));
+        assertThat(error.errorName(), is("errorName"));
     }
 
     @Test
     public void testServiceException() throws IOException {
         Response response = target.path("throw-service-exception").request().get();
-        assertThat(response.getStatus(), is(ErrorType.INVALID_ARGUMENT.httpErrorCode()));
+        assertThat(response.getStatus(), is(REMOTE_EXCEPTION_STATUS_CODE));
         String body =
                 new String(ByteStreams.toByteArray(response.readEntity(InputStream.class)), StandardCharsets.UTF_8);
 
@@ -189,7 +188,6 @@ public final class ExceptionMappingTest {
         @Override
         public String throwRemoteException() {
             throw new RemoteException(SerializableError.builder()
-                    .errorInstanceId("errorInstanceId")
                     .errorCode("errorCode")
                     .errorName("errorName")
                     .build(),


### PR DESCRIPTION
This was a behavioral change without a major version bump and it's effects are far-reaching (clients will no longer get the exception names/codes they expect)