### PR TITLE
Fix develop (stopgap only)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2
 jobs:
   build:
-    docker: [{ image: 'circleci/openjdk:8u181-jdk' }]
+    docker: [{ image: 'circleci/openjdk:8u171-jdk' }]
     resource_class: xlarge
     environment:
       GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false


### PR DESCRIPTION
All PRs currently targeting develop are red (with the same `:jetty-http2-agent` test failures).

Here's the perplexing situation though:

- the last build on develop (10 days ago) is green: https://circleci.com/gh/palantir/conjure-java-runtime/2740
```
Build-agent version 0.1.900-892a9f73 (2018-10-25T15:49:42+0000)
Starting container circleci/openjdk:8u181-jdk
  image cache not found on this host, downloading circleci/openjdk:8u181-jdk
8u181-jdk: Pulling from circleci/openjdk
...
Digest: sha256:13389d32dcfc87ca6dc0d15b2becd742385220633627d804687f9b381790d3e4
Status: Downloaded newer image for circleci/openjdk:8u181-jdk
  using image circleci/openjdk@sha256:13389d32dcfc87ca6dc0d15b2becd742385220633627d804687f9b381790d3e4
```
- an empty commit on top of develop is red: https://circleci.com/gh/palantir/conjure-java-runtime/2771
```
Build-agent version 0.1.953-81328d36 (2018-10-31T20:07:21+0000)
Starting container circleci/openjdk:8u181-jdk
  image cache not found on this host, downloading circleci/openjdk:8u181-jdk
8u181-jdk: Pulling from circleci/openjdk
Digest: sha256:a5f2d429af80165bafc07bb862bb1e4f0a5605008d641c83b72f2ae361f89884
Status: Downloaded newer image for circleci/openjdk:8u181-jdk
  using image circleci/openjdk@sha256:a5f2d429af80165bafc07bb862bb1e4f0a5605008d641c83b72f2ae361f89884
```

It seems the underlying circleci/openjdk:8u181-jdk build changed in the last 10 days and actually violated our reproducible builds :/