### PR TITLE
[fix] update message in uncaught exception handler

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -57,7 +57,8 @@ public final class OkHttpClients {
     private static final ThreadFactory executionThreads = new ThreadFactoryBuilder()
             .setUncaughtExceptionHandler((thread, uncaughtException) ->
                     log.error("An exception was uncaught in an execution thread. "
-                                    + "This implies a bug in conjure-java-runtime",
+                                    + "This likely left a thread blocked, and can be caused by a JVM environment "
+                                    + "issue (classpath conflicts, out of memory, etc) or a Conjure bug",
                             uncaughtException))
             .setNameFormat("remoting-okhttp-dispatcher-%d")
             .build();

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -57,8 +57,8 @@ public final class OkHttpClients {
     private static final ThreadFactory executionThreads = new ThreadFactoryBuilder()
             .setUncaughtExceptionHandler((thread, uncaughtException) ->
                     log.error("An exception was uncaught in an execution thread. "
-                                    + "This likely left a thread blocked, and can be caused by a JVM environment "
-                                    + "issue (classpath conflicts, out of memory, etc) or a Conjure bug",
+                                    + "This likely left a thread blocked, and is as such a serious bug "
+                                    + "which requires debugging.",
                             uncaughtException))
             .setNameFormat("remoting-okhttp-dispatcher-%d")
             .build();


### PR DESCRIPTION
Turns out OOM and NoSuchMethodError will also trigger this. The assertion that this is a bug seems to cause people to short circuit any debugging they might otherwise have done.