### PR TITLE
[improvement] Lower the max requests per host

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -81,7 +81,8 @@ public final class OkHttpClients {
     static {
         dispatcher = new Dispatcher(executionExecutor);
         dispatcher.setMaxRequests(256);
-        dispatcher.setMaxRequestsPerHost(256);
+        // Must be less than maxRequests so a single slow host does not block all requests
+        dispatcher.setMaxRequestsPerHost(64);
         // metrics
         registry.gauge(
                 MetricName.builder().safeName("com.palantir.conjure.java.dispatcher.calls.queued").build(),


### PR DESCRIPTION
## Before this PR
A single slow host could block requests to other hosts. This manifested as a result of rate limiting, where a requests would get scheduled to run, then block client side due to exceeding the server's rate limit. Because the OkHttp client is shared across hosts and services, requests to the single host that was rate limiting a client took up all 256 slots in the dispatcher which meant requests to other hosts that were not rate limited were not scheduled.

## After this PR
A single host is only able to take up 1/4th of the dispatcher slots which means whether it's slow or rate limited, requests to other hosts will continue to be executed.