### PR TITLE
[fix] fix failover error message formatting

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -154,8 +154,8 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 }
                 Optional<HttpUrl> redirectTo = urls.redirectToNext(request().url());
                 if (!redirectTo.isPresent()) {
-                    callback.onFailure(call, new IOException("Failed to determine valid failover URL"
-                            + "for '" + request().url() + "' and base URLs " + urls.getBaseUrls()));
+                    callback.onFailure(call, new IOException("Failed to determine valid failover URL for '""
+                            + request().url() + "' and base URLs " + urls.getBaseUrls()));
                     return;
                 }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -154,7 +154,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 }
                 Optional<HttpUrl> redirectTo = urls.redirectToNext(request().url());
                 if (!redirectTo.isPresent()) {
-                    callback.onFailure(call, new IOException("Failed to determine valid failover URL for '""
+                    callback.onFailure(call, new IOException("Failed to determine valid failover URL for '"
                             + request().url() + "' and base URLs " + urls.getBaseUrls()));
                     return;
                 }


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
Bad formatting on error message I encountered:
```
java.io.IOException: Failed to determine valid failover URLfor 'https://hostname:8488/' and base URLs [https://hostname:8488/service/api]

	at com.palantir.remoting3.okhttp.RemotingOkHttpCall$2.onFailure(RemotingOkHttpCall.java:158)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:161)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at com.palantir.tracing.DeferredTracer.withTrace(DeferredTracer.java:53)
	at com.palantir.tracing.Tracers$TracingAwareCallable.call(Tracers.java:219)
	at com.palantir.tracing.WrappingExecutorService.lambda$wrapTask$0(WrappingExecutorService.java:68)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

## After this PR

Error message should be:
```
java.io.IOException: Failed to determine valid failover URL for 'https://hostname:8488/' and base URLs [https://hostname:8488/service/api]

	at com.palantir.remoting3.okhttp.RemotingOkHttpCall$2.onFailure(RemotingOkHttpCall.java:158)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:161)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at com.palantir.tracing.DeferredTracer.withTrace(DeferredTracer.java:53)
	at com.palantir.tracing.Tracers$TracingAwareCallable.call(Tracers.java:219)
	at com.palantir.tracing.WrappingExecutorService.lambda$wrapTask$0(WrappingExecutorService.java:68)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
