### PR TITLE
Hide implementation dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'java'
+    apply plugin: 'java-library'
 
     sourceCompatibility = 1.8
     if (gradle.startParameter.taskNames.find {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
 
     // Ensure test behaves as a real user of a library, not having access to the libaries' implementation dependencies
     configurations {
-        testImplementation.extendsFrom = [api]
+        testImplementation.extendsFrom = [testCompile, api]
         testRuntimeClasspath.extendsFrom implementation
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,12 @@ allprojects {
 subprojects {
     apply plugin: 'java-library'
 
+    // Ensure test behaves as a real user of a library, not having access to the libaries' implementation dependencies
+    configurations {
+        testImplementation.extendsFrom = [api]
+        testRuntimeClasspath.extendsFrom implementation
+    }
+
     sourceCompatibility = 1.8
     if (gradle.startParameter.taskNames.find {
         it.endsWith('verifyDependencyLocksAreCurrent') || it.endsWith('build')}) {

--- a/build.gradle
+++ b/build.gradle
@@ -30,12 +30,6 @@ allprojects {
 subprojects {
     apply plugin: 'java-library'
 
-    // Ensure test behaves as a real user of a library, not having access to the libaries' implementation dependencies
-    configurations {
-        testImplementation.extendsFrom = [testCompile, api]
-        testRuntimeClasspath.extendsFrom implementation
-    }
-
     sourceCompatibility = 1.8
     if (gradle.startParameter.taskNames.find {
         it.endsWith('verifyDependencyLocksAreCurrent') || it.endsWith('build')}) {

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
     dependencyLock {
         includeTransitives = true
         lockFile = 'versions.lock'
-        configurationNames = ['runtime', 'compileClasspath']
+        configurationNames = ['runtimeClasspath', 'compileClasspath']
     }
 
     task verifyDependencyLocksAreCurrent {

--- a/client-config/build.gradle
+++ b/client-config/build.gradle
@@ -2,13 +2,15 @@ apply plugin: "org.inferred.processors"
 apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
-    compile project(":keystores")
-    compile 'com.palantir.conjure.java.api:service-config'
-    compile 'com.palantir.safe-logging:safe-logging'
+    api 'com.palantir.conjure.java.api:service-config'
+    implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'com.google.guava:guava'
+    implementation project(":keystores")
 
-    testCompile "junit:junit"
-    testCompile "org.assertj:assertj-core"
-    testCompile "org.mockito:mockito-core"
+    testImplementation "junit:junit"
+    testImplementation 'com.google.guava:guava'
+    testImplementation "org.assertj:assertj-core"
+    testImplementation "org.mockito:mockito-core"
 
     annotationProcessor "org.immutables:value"
     compileOnly 'org.immutables:value::annotations'

--- a/client-config/versions.lock
+++ b/client-config/versions.lock
@@ -9,23 +9,14 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.9.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.9.7",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.palantir.conjure.java.api:ssl-config",
-                "com.palantir.conjure.java.runtime:keystores",
-                "com.palantir.tokens:auth-tokens"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.9.7",
-            "transitive": [
-                "com.palantir.tokens:auth-tokens"
+                "com.palantir.conjure.java.runtime:keystores"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -99,15 +90,9 @@
         },
         "org.immutables:value": {
             "locked": "2.7.1"
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.12",
-            "transitive": [
-                "com.palantir.tokens:auth-tokens"
-            ]
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.7",
             "transitive": [

--- a/client-config/versions.lock
+++ b/client-config/versions.lock
@@ -33,10 +33,7 @@
             ]
         },
         "com.google.guava:guava": {
-            "locked": "23.6.1-jre",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:keystores"
-            ]
+            "locked": "23.6.1-jre"
         },
         "com.google.j2objc:j2objc-annotations": {
             "locked": "1.1",

--- a/conjure-java-client-verifier/build.gradle
+++ b/conjure-java-client-verifier/build.gradle
@@ -5,10 +5,13 @@ dependencies {
     verificationApi 'com.palantir.conjure.verification:verification-server-api'
     verifier "com.palantir.conjure.verification:verification-server::${osClassifier}@tgz"
 
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile project(':conjure-java-jaxrs-client')
-    testCompile project(':conjure-java-retrofit2-client')
-    testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    testCompile 'org.apache.commons:commons-lang3'
+    testImplementation project(':conjure-java-jaxrs-client')
+    testImplementation project(':conjure-java-retrofit2-client')
+    testImplementation project(':conjure-java-jackson-serialization')
+    testImplementation project(':keystores')
+    testImplementation 'junit:junit'
+    testImplementation "org.slf4j:slf4j-api"
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+    testImplementation 'org.apache.commons:commons-lang3'
 }

--- a/conjure-java-jackson-serialization/versions.lock
+++ b/conjure-java-jackson-serialization/versions.lock
@@ -79,7 +79,7 @@
             ]
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.7",
             "transitive": [

--- a/conjure-java-jaxrs-client/build.gradle
+++ b/conjure-java-jaxrs-client/build.gradle
@@ -10,9 +10,10 @@ dependencies {
 
     api "com.google.code.findbugs:jsr305"
     api "javax.ws.rs:javax.ws.rs-api"
+    // TODO(dsanduleac): Should be implementation, but can't because we expose feign.TextDelegateEncoder
+    api "com.netflix.feign:feign-core"
     implementation "com.google.guava:guava"
     implementation "com.netflix.feign:feign-jackson"
-    implementation "com.netflix.feign:feign-core"
     implementation("com.netflix.feign:feign-jaxrs") {
         // the shipped version clashes with the newer javax.ws.rs:javax.ws.rs-api used by (e.g.) dropwizard
         exclude group: "javax.ws.rs", module: "jsr311-api"
@@ -24,6 +25,7 @@ dependencies {
 
     testImplementation project(":conjure-java-retrofit2-client")
     testImplementation project(":conjure-java-jersey-server")
+    testImplementation "com.netflix.feign:feign-jackson"
     testImplementation "com.squareup.okhttp3:mockwebserver"
     testImplementation "io.dropwizard:dropwizard-testing"
     testImplementation "junit:junit"

--- a/conjure-java-jaxrs-client/build.gradle
+++ b/conjure-java-jaxrs-client/build.gradle
@@ -5,14 +5,15 @@ dependencies {
     api project(":extras:refresh-utils")
     api project(":client-config")
     api project(":okhttp-clients")
-    implementation project(":conjure-java-jackson-serialization")
-    implementation project(":keystores")
-
     api "com.google.code.findbugs:jsr305"
     api "javax.ws.rs:javax.ws.rs-api"
     // TODO(dsanduleac): Should be implementation, but can't because we expose feign.TextDelegateEncoder
     api "com.netflix.feign:feign-core"
+
+    implementation project(":conjure-java-jackson-serialization")
+    implementation project(":keystores")
     implementation "com.google.guava:guava"
+    implementation "com.github.ben-manes.caffeine:caffeine"
     implementation "com.netflix.feign:feign-jackson"
     implementation("com.netflix.feign:feign-jaxrs") {
         // the shipped version clashes with the newer javax.ws.rs:javax.ws.rs-api used by (e.g.) dropwizard
@@ -25,6 +26,7 @@ dependencies {
 
     testImplementation project(":conjure-java-retrofit2-client")
     testImplementation project(":conjure-java-jersey-server")
+    testImplementation project(':keystores')
     testImplementation "com.netflix.feign:feign-jackson"
     testImplementation "com.squareup.okhttp3:mockwebserver"
     testImplementation "io.dropwizard:dropwizard-testing"

--- a/conjure-java-jaxrs-client/build.gradle
+++ b/conjure-java-jaxrs-client/build.gradle
@@ -2,31 +2,31 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 apply from: "${rootDir}/gradle/publish-bom.gradle"
 
 dependencies {
-    compile project(":conjure-java-jackson-serialization")
-    compile project(":extras:refresh-utils")
-    compile project(":client-config")
-    compile project(":keystores")
-    compile project(":okhttp-clients")
+    api project(":extras:refresh-utils")
+    api project(":client-config")
+    api project(":okhttp-clients")
+    implementation project(":conjure-java-jackson-serialization")
+    implementation project(":keystores")
 
-    compile "com.google.code.findbugs:jsr305"
-    compile "com.google.guava:guava"
-    compile "com.netflix.feign:feign-jackson"
-    compile("com.netflix.feign:feign-jaxrs") {
+    api "com.google.code.findbugs:jsr305"
+    api "javax.ws.rs:javax.ws.rs-api"
+    implementation "com.google.guava:guava"
+    implementation "com.netflix.feign:feign-jackson"
+    implementation("com.netflix.feign:feign-jaxrs") {
         // the shipped version clashes with the newer javax.ws.rs:javax.ws.rs-api used by (e.g.) dropwizard
         exclude group: "javax.ws.rs", module: "jsr311-api"
     }
-    compile "com.netflix.feign:feign-okhttp"
-    compile "com.netflix.feign:feign-slf4j"
-    compile "com.palantir.tracing:tracing-okhttp3"
-    compile "javax.ws.rs:javax.ws.rs-api"
-    compile "org.slf4j:slf4j-api"
+    implementation "com.netflix.feign:feign-okhttp"
+    implementation "com.netflix.feign:feign-slf4j"
+    implementation "com.palantir.tracing:tracing-okhttp3"
+    implementation "org.slf4j:slf4j-api"
 
-    testCompile project(":conjure-java-retrofit2-client")
-    testCompile project(":conjure-java-jersey-server")
-    testCompile "com.squareup.okhttp3:mockwebserver"
-    testCompile "io.dropwizard:dropwizard-testing"
-    testCompile "junit:junit"
-    testCompile "org.hamcrest:hamcrest-all"
-    testCompile "org.mockito:mockito-core"
-    testCompile "com.palantir.safe-logging:preconditions-assertj"
+    testImplementation project(":conjure-java-retrofit2-client")
+    testImplementation project(":conjure-java-jersey-server")
+    testImplementation "com.squareup.okhttp3:mockwebserver"
+    testImplementation "io.dropwizard:dropwizard-testing"
+    testImplementation "junit:junit"
+    testImplementation "org.hamcrest:hamcrest-all"
+    testImplementation "org.mockito:mockito-core"
+    testImplementation "com.palantir.safe-logging:preconditions-assertj"
 }

--- a/conjure-java-jaxrs-client/build.gradle
+++ b/conjure-java-jaxrs-client/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     api "javax.ws.rs:javax.ws.rs-api"
     implementation "com.google.guava:guava"
     implementation "com.netflix.feign:feign-jackson"
+    implementation "com.netflix.feign:feign-core"
     implementation("com.netflix.feign:feign-jaxrs") {
         // the shipped version clashes with the newer javax.ws.rs:javax.ws.rs-api used by (e.g.) dropwizard
         exclude group: "javax.ws.rs", module: "jsr311-api"

--- a/conjure-java-jaxrs-client/versions.lock
+++ b/conjure-java-jaxrs-client/versions.lock
@@ -67,10 +67,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.6.2",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
+            "locked": "2.6.2"
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.2",
@@ -91,8 +88,6 @@
             "locked": "23.6.1-jre",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.conjure.java.runtime:keystores",
-                "com.palantir.conjure.java.runtime:okhttp-clients",
                 "com.palantir.conjure.java.runtime:refresh-utils",
                 "com.palantir.tracing:tracing"
             ]
@@ -101,12 +96,6 @@
             "locked": "1.1",
             "transitive": [
                 "com.google.guava:guava"
-            ]
-        },
-        "com.netflix.concurrency-limits:concurrency-limits-core": {
-            "locked": "0.1.3",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
             ]
         },
         "com.netflix.feign:feign-core": {
@@ -150,16 +139,10 @@
             ]
         },
         "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization": {
-            "project": true,
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
+            "project": true
         },
         "com.palantir.conjure.java.runtime:keystores": {
-            "project": true,
-            "transitive": [
-                "com.palantir.conjure.java.runtime:client-config"
-            ]
+            "project": true
         },
         "com.palantir.conjure.java.runtime:okhttp-clients": {
             "project": true
@@ -170,8 +153,7 @@
         "com.palantir.safe-logging:preconditions": {
             "locked": "1.5.1",
             "transitive": [
-                "com.palantir.conjure.java.api:service-config",
-                "com.palantir.conjure.java.runtime:okhttp-clients"
+                "com.palantir.conjure.java.api:service-config"
             ]
         },
         "com.palantir.safe-logging:safe-logging": {
@@ -179,10 +161,8 @@
             "transitive": [
                 "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:service-config",
-                "com.palantir.conjure.java.runtime:client-config",
                 "com.palantir.safe-logging:preconditions",
-                "com.palantir.tracing:tracing",
-                "com.palantir.tritium:tritium-registry"
+                "com.palantir.tracing:tracing"
             ]
         },
         "com.palantir.tokens:auth-tokens": {
@@ -204,42 +184,19 @@
             ]
         },
         "com.palantir.tracing:tracing-okhttp3": {
-            "locked": "1.2.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
-        },
-        "com.palantir.tritium:tritium-registry": {
-            "locked": "0.8.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
-        },
-        "com.squareup.okhttp3:logging-interceptor": {
-            "locked": "3.11.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
+            "locked": "1.2.0"
         },
         "com.squareup.okhttp3:okhttp": {
             "locked": "3.11.0",
             "transitive": [
                 "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.tracing:tracing-okhttp3",
-                "com.squareup.okhttp3:logging-interceptor"
+                "com.palantir.tracing:tracing-okhttp3"
             ]
         },
         "com.squareup.okio:okio": {
             "locked": "1.14.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.5",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.tritium:tritium-registry"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -263,10 +220,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.12",
             "transitive": [
-                "com.netflix.concurrency-limits:concurrency-limits-core",
-                "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.tracing:tracing",
-                "io.dropwizard.metrics:metrics-core"
+                "com.palantir.tracing:tracing"
             ]
         }
     },
@@ -365,6 +319,7 @@
             "locked": "23.6.1-jre",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.conjure.java.runtime:client-config",
                 "com.palantir.conjure.java.runtime:keystores",
                 "com.palantir.conjure.java.runtime:okhttp-clients",
                 "com.palantir.conjure.java.runtime:refresh-utils",

--- a/conjure-java-jaxrs-client/versions.lock
+++ b/conjure-java-jaxrs-client/versions.lock
@@ -25,12 +25,10 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.netflix.feign:feign-jackson",
                 "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:ssl-config",
                 "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
                 "com.palantir.conjure.java.runtime:keystores",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tracing:tracing-api"
             ]
@@ -52,7 +50,6 @@
             "locked": "2.9.7",
             "transitive": [
                 "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing"
             ]
         },
@@ -113,13 +110,7 @@
             ]
         },
         "com.netflix.feign:feign-core": {
-            "locked": "8.18.0",
-            "transitive": [
-                "com.netflix.feign:feign-jackson",
-                "com.netflix.feign:feign-jaxrs",
-                "com.netflix.feign:feign-okhttp",
-                "com.netflix.feign:feign-slf4j"
-            ]
+            "locked": "8.18.0"
         },
         "com.netflix.feign:feign-jackson": {
             "locked": "8.18.0"
@@ -179,7 +170,6 @@
         "com.palantir.safe-logging:preconditions": {
             "locked": "1.5.1",
             "transitive": [
-                "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:service-config",
                 "com.palantir.conjure.java.runtime:okhttp-clients"
             ]
@@ -234,7 +224,6 @@
         "com.squareup.okhttp3:okhttp": {
             "locked": "3.11.0",
             "transitive": [
-                "com.netflix.feign:feign-okhttp",
                 "com.palantir.conjure.java.runtime:okhttp-clients",
                 "com.palantir.tracing:tracing-okhttp3",
                 "com.squareup.okhttp3:logging-interceptor"
@@ -271,25 +260,17 @@
                 "com.google.guava:guava"
             ]
         },
-        "org.jvnet:animal-sniffer-annotation": {
-            "locked": "1.0",
-            "transitive": [
-                "com.netflix.feign:feign-core"
-            ]
-        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.12",
             "transitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core",
-                "com.netflix.feign:feign-slf4j",
                 "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.7",
             "transitive": [

--- a/conjure-java-jersey-server/build.gradle
+++ b/conjure-java-jersey-server/build.gradle
@@ -2,18 +2,22 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 apply from: "${rootDir}/gradle/publish-bom.gradle"
 
 dependencies {
-    compile project(':conjure-java-jackson-serialization')
-    compile "com.fasterxml.jackson.jaxrs:jackson-jaxrs-cbor-provider"
-    compile "com.fasterxml.jackson.module:jackson-module-afterburner"
-    compile "com.jcraft:jzlib"
-    compile "com.palantir.conjure.java.api:errors"
-    compile "com.palantir.safe-logging:safe-logging"
-    compile "com.palantir.tracing:tracing-jersey"
-    compile "org.glassfish.jersey.core:jersey-server"
+    api "com.palantir.conjure.java.api:errors"
+    api "org.glassfish.jersey.core:jersey-server"
 
-    testCompile "com.palantir.conjure.java.api:ssl-config"
-    testCompile "io.dropwizard:dropwizard-testing"
-    testCompile "junit:junit"
-    testCompile "org.hamcrest:hamcrest-all"
-    testCompile "org.mockito:mockito-core"
+    implementation project(':conjure-java-jackson-serialization')
+    implementation "com.fasterxml.jackson.jaxrs:jackson-jaxrs-cbor-provider"
+    implementation "com.fasterxml.jackson.module:jackson-module-afterburner"
+    implementation "com.jcraft:jzlib"
+    implementation "com.palantir.safe-logging:safe-logging"
+    implementation "com.palantir.tracing:tracing-jersey"
+
+    testImplementation project(':conjure-java-jackson-serialization')
+    testImplementation "com.fasterxml.jackson.core:jackson-databind"
+    testImplementation "com.palantir.tracing:tracing"
+    testImplementation "com.palantir.conjure.java.api:ssl-config"
+    testImplementation "io.dropwizard:dropwizard-testing"
+    testImplementation "junit:junit"
+    testImplementation "org.hamcrest:hamcrest-all"
+    testImplementation "org.mockito:mockito-core"
 }

--- a/conjure-java-jersey-server/versions.lock
+++ b/conjure-java-jersey-server/versions.lock
@@ -95,8 +95,7 @@
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.1.3",
             "transitive": [
-                "com.google.guava:guava",
-                "com.palantir.safe-logging:preconditions"
+                "com.google.guava:guava"
             ]
         },
         "com.google.guava:guava": {
@@ -121,17 +120,10 @@
         "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization": {
             "project": true
         },
-        "com.palantir.safe-logging:preconditions": {
-            "locked": "1.5.1",
-            "transitive": [
-                "com.palantir.conjure.java.api:errors"
-            ]
-        },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "1.5.1",
             "transitive": [
                 "com.palantir.conjure.java.api:errors",
-                "com.palantir.safe-logging:preconditions",
                 "com.palantir.tracing:tracing"
             ]
         },
@@ -286,7 +278,7 @@
             ]
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.7",
             "transitive": [

--- a/conjure-java-retrofit2-client/build.gradle
+++ b/conjure-java-retrofit2-client/build.gradle
@@ -11,15 +11,16 @@ dependencies {
     api project(":extras:refresh-utils")
     api project(":client-config")
     api project(":okhttp-clients")
+    api "com.squareup.retrofit2:retrofit"
+
     implementation project(":conjure-java-jackson-serialization")
     implementation project(":keystores")
-
-    api "com.squareup.retrofit2:retrofit"
     implementation "com.fasterxml.jackson.module:jackson-module-afterburner"
     implementation "com.palantir.tracing:tracing-okhttp3"
     implementation "com.squareup.retrofit2:converter-jackson"
     implementation "org.slf4j:slf4j-api"
 
+    testImplementation project(":keystores")
     testImplementation "com.squareup.okhttp3:mockwebserver"
     testImplementation "junit:junit"
     testImplementation "org.assertj:assertj-core"

--- a/conjure-java-retrofit2-client/build.gradle
+++ b/conjure-java-retrofit2-client/build.gradle
@@ -8,24 +8,24 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 apply from: "${rootDir}/gradle/publish-bom.gradle"
 
 dependencies {
-    compile project(":conjure-java-jackson-serialization")
-    compile project(":extras:refresh-utils")
-    compile project(":client-config")
-    compile project(":keystores")
-    compile project(":okhttp-clients")
+    api project(":extras:refresh-utils")
+    api project(":client-config")
+    api project(":okhttp-clients")
+    implementation project(":conjure-java-jackson-serialization")
+    implementation project(":keystores")
 
-    compile "com.fasterxml.jackson.module:jackson-module-afterburner"
-    compile "com.palantir.tracing:tracing-okhttp3"
-    compile "com.squareup.retrofit2:converter-jackson"
-    compile "com.squareup.retrofit2:retrofit"
-    compile "org.slf4j:slf4j-api"
+    api "com.squareup.retrofit2:retrofit"
+    implementation "com.fasterxml.jackson.module:jackson-module-afterburner"
+    implementation "com.palantir.tracing:tracing-okhttp3"
+    implementation "com.squareup.retrofit2:converter-jackson"
+    implementation "org.slf4j:slf4j-api"
 
-    testCompile "com.squareup.okhttp3:mockwebserver"
-    testCompile "junit:junit"
-    testCompile "org.assertj:assertj-core"
-    testCompile "org.hamcrest:hamcrest-all"
-    testCompile "org.mockito:mockito-core"
-    testCompile "com.palantir.safe-logging:preconditions-assertj"
+    testImplementation "com.squareup.okhttp3:mockwebserver"
+    testImplementation "junit:junit"
+    testImplementation "org.assertj:assertj-core"
+    testImplementation "org.hamcrest:hamcrest-all"
+    testImplementation "org.mockito:mockito-core"
+    testImplementation "com.palantir.safe-logging:preconditions-assertj"
 
     annotationProcessor "org.immutables:value"
     compileOnly 'org.immutables:value::annotations'

--- a/conjure-java-retrofit2-client/versions.lock
+++ b/conjure-java-retrofit2-client/versions.lock
@@ -29,7 +29,6 @@
                 "com.palantir.conjure.java.api:ssl-config",
                 "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
                 "com.palantir.conjure.java.runtime:keystores",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tracing:tracing-api",
                 "com.squareup.retrofit2:converter-jackson"
@@ -52,7 +51,6 @@
             "locked": "2.9.7",
             "transitive": [
                 "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing"
             ]
         },
@@ -158,7 +156,6 @@
         "com.palantir.safe-logging:preconditions": {
             "locked": "1.5.1",
             "transitive": [
-                "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:service-config",
                 "com.palantir.conjure.java.runtime:okhttp-clients"
             ]
@@ -267,13 +264,12 @@
             "transitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core",
                 "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.7",
             "transitive": [

--- a/conjure-java-retrofit2-client/versions.lock
+++ b/conjure-java-retrofit2-client/versions.lock
@@ -67,12 +67,6 @@
                 "com.palantir.tracing:tracing"
             ]
         },
-        "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.6.2",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
-        },
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.2",
             "transitive": [
@@ -92,8 +86,6 @@
             "locked": "23.6.1-jre",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.conjure.java.runtime:keystores",
-                "com.palantir.conjure.java.runtime:okhttp-clients",
                 "com.palantir.conjure.java.runtime:refresh-utils",
                 "com.palantir.tracing:tracing"
             ]
@@ -102,12 +94,6 @@
             "locked": "1.1",
             "transitive": [
                 "com.google.guava:guava"
-            ]
-        },
-        "com.netflix.concurrency-limits:concurrency-limits-core": {
-            "locked": "0.1.3",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
             ]
         },
         "com.palantir.conjure.java.api:errors": {
@@ -136,16 +122,10 @@
             ]
         },
         "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization": {
-            "project": true,
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
+            "project": true
         },
         "com.palantir.conjure.java.runtime:keystores": {
-            "project": true,
-            "transitive": [
-                "com.palantir.conjure.java.runtime:client-config"
-            ]
+            "project": true
         },
         "com.palantir.conjure.java.runtime:okhttp-clients": {
             "project": true
@@ -156,8 +136,7 @@
         "com.palantir.safe-logging:preconditions": {
             "locked": "1.5.1",
             "transitive": [
-                "com.palantir.conjure.java.api:service-config",
-                "com.palantir.conjure.java.runtime:okhttp-clients"
+                "com.palantir.conjure.java.api:service-config"
             ]
         },
         "com.palantir.safe-logging:safe-logging": {
@@ -165,10 +144,8 @@
             "transitive": [
                 "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:service-config",
-                "com.palantir.conjure.java.runtime:client-config",
                 "com.palantir.safe-logging:preconditions",
-                "com.palantir.tracing:tracing",
-                "com.palantir.tritium:tritium-registry"
+                "com.palantir.tracing:tracing"
             ]
         },
         "com.palantir.tokens:auth-tokens": {
@@ -190,29 +167,13 @@
             ]
         },
         "com.palantir.tracing:tracing-okhttp3": {
-            "locked": "1.2.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
-        },
-        "com.palantir.tritium:tritium-registry": {
-            "locked": "0.8.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
-        },
-        "com.squareup.okhttp3:logging-interceptor": {
-            "locked": "3.11.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
+            "locked": "1.2.0"
         },
         "com.squareup.okhttp3:okhttp": {
             "locked": "3.11.0",
             "transitive": [
                 "com.palantir.conjure.java.runtime:okhttp-clients",
                 "com.palantir.tracing:tracing-okhttp3",
-                "com.squareup.okhttp3:logging-interceptor",
                 "com.squareup.retrofit2:retrofit"
             ]
         },
@@ -229,13 +190,6 @@
             "locked": "2.4.0",
             "transitive": [
                 "com.squareup.retrofit2:converter-jackson"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.5",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.tritium:tritium-registry"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -262,10 +216,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.12",
             "transitive": [
-                "com.netflix.concurrency-limits:concurrency-limits-core",
-                "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.tracing:tracing",
-                "io.dropwizard.metrics:metrics-core"
+                "com.palantir.tracing:tracing"
             ]
         }
     },
@@ -364,6 +315,7 @@
             "locked": "23.6.1-jre",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.conjure.java.runtime:client-config",
                 "com.palantir.conjure.java.runtime:keystores",
                 "com.palantir.conjure.java.runtime:okhttp-clients",
                 "com.palantir.conjure.java.runtime:refresh-utils",

--- a/conjure-java-server-verifier/build.gradle
+++ b/conjure-java-server-verifier/build.gradle
@@ -5,10 +5,12 @@ dependencies {
     verificationApi 'com.palantir.conjure.verification:verification-client-api'
     verifier "com.palantir.conjure.verification:verification-client::${osClassifier}@tgz"
 
-    testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    testCompile 'io.dropwizard:dropwizard-testing'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile project(':conjure-java-jaxrs-client')
-    testCompile project(':conjure-java-jersey-server')
+    testImplementation project(':conjure-java-jaxrs-client')
+    testImplementation project(':conjure-java-jersey-server')
+    testImplementation project(':keystores')
+    testImplementation project(':conjure-java-jackson-serialization')
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+    testImplementation 'io.dropwizard:dropwizard-testing'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
 }

--- a/conjure-scala-jaxrs-client/build.gradle
+++ b/conjure-scala-jaxrs-client/build.gradle
@@ -1,6 +1,7 @@
 apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
-    compile project(':conjure-java-jaxrs-client')
-    compile 'com.fasterxml.jackson.module:jackson-module-scala_2.11'
+    api project(':conjure-java-jaxrs-client')
+    implementation project(':conjure-java-jackson-serialization')
+    implementation 'com.fasterxml.jackson.module:jackson-module-scala_2.11'
 }

--- a/conjure-scala-jaxrs-client/versions.lock
+++ b/conjure-scala-jaxrs-client/versions.lock
@@ -31,10 +31,7 @@
                 "com.fasterxml.jackson.module:jackson-module-scala_2.11",
                 "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:ssl-config",
-                "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
-                "com.palantir.conjure.java.runtime:keystores",
-                "com.palantir.tracing:tracing",
-                "com.palantir.tracing:tracing-api"
+                "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization"
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
@@ -46,15 +43,13 @@
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
             "locked": "2.9.7",
             "transitive": [
-                "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
-                "com.palantir.tracing:tracing"
+                "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.9.7",
             "transitive": [
-                "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
-                "com.palantir.tracing:tracing"
+                "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
@@ -66,8 +61,7 @@
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
             "locked": "2.9.7",
             "transitive": [
-                "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
-                "com.palantir.tracing:tracing"
+                "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-paranamer": {
@@ -78,12 +72,6 @@
         },
         "com.fasterxml.jackson.module:jackson-module-scala_2.11": {
             "locked": "2.9.7"
-        },
-        "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.6.2",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.2",
@@ -105,22 +93,13 @@
             "locked": "23.6.1-jre",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.conjure.java.runtime:keystores",
-                "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.conjure.java.runtime:refresh-utils",
-                "com.palantir.tracing:tracing"
+                "com.palantir.conjure.java.runtime:refresh-utils"
             ]
         },
         "com.google.j2objc:j2objc-annotations": {
             "locked": "1.1",
             "transitive": [
                 "com.google.guava:guava"
-            ]
-        },
-        "com.netflix.concurrency-limits:concurrency-limits-core": {
-            "locked": "0.1.3",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
             ]
         },
         "com.netflix.feign:feign-core": {
@@ -144,8 +123,7 @@
         "com.palantir.conjure.java.api:ssl-config": {
             "locked": "2.0.0",
             "transitive": [
-                "com.palantir.conjure.java.api:service-config",
-                "com.palantir.conjure.java.runtime:keystores"
+                "com.palantir.conjure.java.api:service-config"
             ]
         },
         "com.palantir.conjure.java.runtime:client-config": {
@@ -156,19 +134,10 @@
             ]
         },
         "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization": {
-            "project": true,
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
+            "project": true
         },
         "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client": {
             "project": true
-        },
-        "com.palantir.conjure.java.runtime:keystores": {
-            "project": true,
-            "transitive": [
-                "com.palantir.conjure.java.runtime:client-config"
-            ]
         },
         "com.palantir.conjure.java.runtime:okhttp-clients": {
             "project": true,
@@ -185,8 +154,7 @@
         "com.palantir.safe-logging:preconditions": {
             "locked": "1.5.1",
             "transitive": [
-                "com.palantir.conjure.java.api:service-config",
-                "com.palantir.conjure.java.runtime:okhttp-clients"
+                "com.palantir.conjure.java.api:service-config"
             ]
         },
         "com.palantir.safe-logging:safe-logging": {
@@ -194,10 +162,7 @@
             "transitive": [
                 "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:service-config",
-                "com.palantir.conjure.java.runtime:client-config",
-                "com.palantir.safe-logging:preconditions",
-                "com.palantir.tracing:tracing",
-                "com.palantir.tritium:tritium-registry"
+                "com.palantir.safe-logging:preconditions"
             ]
         },
         "com.palantir.tokens:auth-tokens": {
@@ -206,42 +171,10 @@
                 "com.palantir.conjure.java.api:service-config"
             ]
         },
-        "com.palantir.tracing:tracing": {
-            "locked": "1.2.0",
-            "transitive": [
-                "com.palantir.tracing:tracing-okhttp3"
-            ]
-        },
-        "com.palantir.tracing:tracing-api": {
-            "locked": "1.2.0",
-            "transitive": [
-                "com.palantir.tracing:tracing"
-            ]
-        },
-        "com.palantir.tracing:tracing-okhttp3": {
-            "locked": "1.2.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
-        },
-        "com.palantir.tritium:tritium-registry": {
-            "locked": "0.8.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
-        },
-        "com.squareup.okhttp3:logging-interceptor": {
-            "locked": "3.11.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients"
-            ]
-        },
         "com.squareup.okhttp3:okhttp": {
             "locked": "3.11.0",
             "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.tracing:tracing-okhttp3",
-                "com.squareup.okhttp3:logging-interceptor"
+                "com.palantir.conjure.java.runtime:okhttp-clients"
             ]
         },
         "com.squareup.okio:okio": {
@@ -254,13 +187,6 @@
             "locked": "2.8",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-paranamer"
-            ]
-        },
-        "io.dropwizard.metrics:metrics-core": {
-            "locked": "3.2.5",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.tritium:tritium-registry"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -286,15 +212,6 @@
             "locked": "2.11.12",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-scala_2.11"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "1.7.12",
-            "transitive": [
-                "com.netflix.concurrency-limits:concurrency-limits-core",
-                "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.tracing:tracing",
-                "io.dropwizard.metrics:metrics-core"
             ]
         }
     },
@@ -384,6 +301,7 @@
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "2.6.2",
             "transitive": [
+                "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client",
                 "com.palantir.conjure.java.runtime:okhttp-clients"
             ]
         },
@@ -407,6 +325,7 @@
             "locked": "23.6.1-jre",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.conjure.java.runtime:client-config",
                 "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client",
                 "com.palantir.conjure.java.runtime:keystores",
                 "com.palantir.conjure.java.runtime:okhttp-clients",

--- a/conjure-scala-jaxrs-client/versions.lock
+++ b/conjure-scala-jaxrs-client/versions.lock
@@ -29,12 +29,10 @@
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
                 "com.fasterxml.jackson.module:jackson-module-paranamer",
                 "com.fasterxml.jackson.module:jackson-module-scala_2.11",
-                "com.netflix.feign:feign-jackson",
                 "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:ssl-config",
                 "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
                 "com.palantir.conjure.java.runtime:keystores",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tracing:tracing-api"
             ]
@@ -56,7 +54,6 @@
             "locked": "2.9.7",
             "transitive": [
                 "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing"
             ]
         },
@@ -108,7 +105,6 @@
             "locked": "23.6.1-jre",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client",
                 "com.palantir.conjure.java.runtime:keystores",
                 "com.palantir.conjure.java.runtime:okhttp-clients",
                 "com.palantir.conjure.java.runtime:refresh-utils",
@@ -128,33 +124,6 @@
             ]
         },
         "com.netflix.feign:feign-core": {
-            "locked": "8.18.0",
-            "transitive": [
-                "com.netflix.feign:feign-jackson",
-                "com.netflix.feign:feign-jaxrs",
-                "com.netflix.feign:feign-okhttp",
-                "com.netflix.feign:feign-slf4j"
-            ]
-        },
-        "com.netflix.feign:feign-jackson": {
-            "locked": "8.18.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client"
-            ]
-        },
-        "com.netflix.feign:feign-jaxrs": {
-            "locked": "8.18.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client"
-            ]
-        },
-        "com.netflix.feign:feign-okhttp": {
-            "locked": "8.18.0",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client"
-            ]
-        },
-        "com.netflix.feign:feign-slf4j": {
             "locked": "8.18.0",
             "transitive": [
                 "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client"
@@ -189,7 +158,6 @@
         "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization": {
             "project": true,
             "transitive": [
-                "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client",
                 "com.palantir.conjure.java.runtime:okhttp-clients"
             ]
         },
@@ -199,8 +167,7 @@
         "com.palantir.conjure.java.runtime:keystores": {
             "project": true,
             "transitive": [
-                "com.palantir.conjure.java.runtime:client-config",
-                "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client"
+                "com.palantir.conjure.java.runtime:client-config"
             ]
         },
         "com.palantir.conjure.java.runtime:okhttp-clients": {
@@ -218,7 +185,6 @@
         "com.palantir.safe-logging:preconditions": {
             "locked": "1.5.1",
             "transitive": [
-                "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:service-config",
                 "com.palantir.conjure.java.runtime:okhttp-clients"
             ]
@@ -255,7 +221,6 @@
         "com.palantir.tracing:tracing-okhttp3": {
             "locked": "1.2.0",
             "transitive": [
-                "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client",
                 "com.palantir.conjure.java.runtime:okhttp-clients"
             ]
         },
@@ -274,7 +239,6 @@
         "com.squareup.okhttp3:okhttp": {
             "locked": "3.11.0",
             "transitive": [
-                "com.netflix.feign:feign-okhttp",
                 "com.palantir.conjure.java.runtime:okhttp-clients",
                 "com.palantir.tracing:tracing-okhttp3",
                 "com.squareup.okhttp3:logging-interceptor"
@@ -318,12 +282,6 @@
                 "com.google.guava:guava"
             ]
         },
-        "org.jvnet:animal-sniffer-annotation": {
-            "locked": "1.0",
-            "transitive": [
-                "com.netflix.feign:feign-core"
-            ]
-        },
         "org.scala-lang:scala-library": {
             "locked": "2.11.12",
             "transitive": [
@@ -334,16 +292,13 @@
             "locked": "1.7.12",
             "transitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core",
-                "com.netflix.feign:feign-slf4j",
-                "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client",
                 "com.palantir.conjure.java.runtime:okhttp-clients",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.7",
             "transitive": [
@@ -477,7 +432,8 @@
                 "com.netflix.feign:feign-jackson",
                 "com.netflix.feign:feign-jaxrs",
                 "com.netflix.feign:feign-okhttp",
-                "com.netflix.feign:feign-slf4j"
+                "com.netflix.feign:feign-slf4j",
+                "com.palantir.conjure.java.runtime:conjure-java-jaxrs-client"
             ]
         },
         "com.netflix.feign:feign-jackson": {

--- a/extras/refresh-utils/versions.lock
+++ b/extras/refresh-utils/versions.lock
@@ -34,7 +34,7 @@
             ]
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.2",
             "transitive": [

--- a/jetty-http2-agent/versions.lock
+++ b/jetty-http2-agent/versions.lock
@@ -10,7 +10,7 @@
             "locked": "1.7.12"
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.ea.agentloader:ea-agent-loader": {
             "locked": "1.0.3"
         },

--- a/keystores/build.gradle
+++ b/keystores/build.gradle
@@ -12,7 +12,9 @@ dependencies {
         // the shipped version clashes with the newer javax.ws.rs:javax.ws.rs-api used by (e.g.) dropwizard
         exclude group: "javax.ws.rs", module: "jsr311-api"
     }
+    testCompile("com.netflix.feign:feign-core")
     testCompile "com.netflix.feign:feign-okhttp"
+    testCompile "com.squareup.okhttp3:okhttp"
     testCompile "org.hamcrest:hamcrest-all"
     testCompile "io.dropwizard:dropwizard-core"
     testCompile "io.dropwizard:dropwizard-testing"

--- a/keystores/build.gradle
+++ b/keystores/build.gradle
@@ -3,22 +3,22 @@ apply plugin: 'org.inferred.processors'
 apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
-    compile "com.fasterxml.jackson.core:jackson-databind"
-    compile "com.google.guava:guava"
-    compile "com.palantir.conjure.java.api:ssl-config"
+    api "com.fasterxml.jackson.core:jackson-databind"
+    api "com.palantir.conjure.java.api:ssl-config"
+    implementation "com.google.guava:guava"
 
-    testCompile project(":conjure-java-jackson-serialization")
-    testCompile("com.netflix.feign:feign-jaxrs") {
+    testImplementation project(":conjure-java-jackson-serialization")
+    testImplementation("com.netflix.feign:feign-jaxrs") {
         // the shipped version clashes with the newer javax.ws.rs:javax.ws.rs-api used by (e.g.) dropwizard
         exclude group: "javax.ws.rs", module: "jsr311-api"
     }
-    testCompile("com.netflix.feign:feign-core")
-    testCompile "com.netflix.feign:feign-okhttp"
-    testCompile "com.squareup.okhttp3:okhttp"
-    testCompile "org.hamcrest:hamcrest-all"
-    testCompile "io.dropwizard:dropwizard-core"
-    testCompile "io.dropwizard:dropwizard-testing"
-    testCompile "junit:junit"
+    testImplementation("com.netflix.feign:feign-core")
+    testImplementation "com.netflix.feign:feign-okhttp"
+    testImplementation "com.squareup.okhttp3:okhttp"
+    testImplementation "org.hamcrest:hamcrest-all"
+    testImplementation "io.dropwizard:dropwizard-core"
+    testImplementation "io.dropwizard:dropwizard-testing"
+    testImplementation "junit:junit"
 
     annotationProcessor "org.immutables:value"
     compileOnly 'org.immutables:value::annotations'

--- a/keystores/versions.lock
+++ b/keystores/versions.lock
@@ -58,7 +58,7 @@
             "locked": "2.7.1"
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.7",
             "transitive": [

--- a/okhttp-clients/build.gradle
+++ b/okhttp-clients/build.gradle
@@ -3,27 +3,28 @@ apply plugin: "org.inferred.processors"
 apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
-    compile project(':conjure-java-jackson-serialization')
-    compile project(':client-config')
-    compile "com.palantir.tracing:tracing-okhttp3"
-    compile 'com.google.guava:guava'
-    compile 'com.github.ben-manes.caffeine:caffeine'
-    compile 'com.netflix.concurrency-limits:concurrency-limits-core'
-    compile "com.palantir.conjure.java.api:errors"
-    compile 'com.palantir.safe-logging:preconditions'
-    compile 'com.palantir.tritium:tritium-registry'
-    compile 'com.squareup.okhttp3:logging-interceptor'
-    compile 'com.squareup.okhttp3:okhttp'
-    compile 'io.dropwizard.metrics:metrics-core'
-    compile 'org.slf4j:slf4j-api'
+    api project(':client-config')
+    api "com.palantir.conjure.java.api:errors"
+    api 'com.squareup.okhttp3:okhttp'
+    implementation project(':conjure-java-jackson-serialization')
+    implementation "com.palantir.tracing:tracing-okhttp3"
+    implementation 'com.google.guava:guava'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'com.netflix.concurrency-limits:concurrency-limits-core'
+    implementation 'com.palantir.safe-logging:preconditions'
+    implementation 'com.palantir.tritium:tritium-registry'
+    implementation 'com.squareup.okhttp3:logging-interceptor'
+    implementation 'io.dropwizard.metrics:metrics-core'
+    implementation 'org.slf4j:slf4j-api'
 
-    testCompile project(":conjure-java-jersey-server")
-    testCompile "com.squareup.okhttp3:mockwebserver"
-    testCompile "javax.ws.rs:javax.ws.rs-api"
-    testCompile "junit:junit"
-    testCompile "org.assertj:assertj-core"
-    testCompile "org.jmock:jmock"
-    testCompile "org.mockito:mockito-core"
+    testImplementation project(":conjure-java-jersey-server")
+    testImplementation project(":keystores")
+    testImplementation "com.squareup.okhttp3:mockwebserver"
+    testImplementation "javax.ws.rs:javax.ws.rs-api"
+    testImplementation "junit:junit"
+    testImplementation "org.assertj:assertj-core"
+    testImplementation "org.jmock:jmock"
+    testImplementation "org.mockito:mockito-core"
 
     annotationProcessor "org.immutables:value"
     compileOnly 'org.immutables:value::annotations'

--- a/okhttp-clients/versions.lock
+++ b/okhttp-clients/versions.lock
@@ -28,7 +28,6 @@
                 "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:ssl-config",
                 "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
-                "com.palantir.conjure.java.runtime:keystores",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tracing:tracing-api"
             ]
@@ -87,7 +86,6 @@
             "locked": "23.6.1-jre",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.conjure.java.runtime:keystores",
                 "com.palantir.tracing:tracing"
             ]
         },
@@ -112,8 +110,7 @@
         "com.palantir.conjure.java.api:ssl-config": {
             "locked": "2.0.0",
             "transitive": [
-                "com.palantir.conjure.java.api:service-config",
-                "com.palantir.conjure.java.runtime:keystores"
+                "com.palantir.conjure.java.api:service-config"
             ]
         },
         "com.palantir.conjure.java.runtime:client-config": {
@@ -121,12 +118,6 @@
         },
         "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization": {
             "project": true
-        },
-        "com.palantir.conjure.java.runtime:keystores": {
-            "project": true,
-            "transitive": [
-                "com.palantir.conjure.java.runtime:client-config"
-            ]
         },
         "com.palantir.safe-logging:preconditions": {
             "locked": "1.5.1",
@@ -139,7 +130,6 @@
             "transitive": [
                 "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:service-config",
-                "com.palantir.conjure.java.runtime:client-config",
                 "com.palantir.safe-logging:preconditions",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tritium:tritium-registry"
@@ -311,6 +301,7 @@
             "locked": "23.6.1-jre",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.conjure.java.runtime:client-config",
                 "com.palantir.conjure.java.runtime:keystores",
                 "com.palantir.tracing:tracing"
             ]

--- a/okhttp-clients/versions.lock
+++ b/okhttp-clients/versions.lock
@@ -29,7 +29,6 @@
                 "com.palantir.conjure.java.api:ssl-config",
                 "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
                 "com.palantir.conjure.java.runtime:keystores",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tracing:tracing-api"
             ]
@@ -51,7 +50,6 @@
             "locked": "2.9.7",
             "transitive": [
                 "com.palantir.conjure.java.runtime:conjure-java-jackson-serialization",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing"
             ]
         },
@@ -133,7 +131,6 @@
         "com.palantir.safe-logging:preconditions": {
             "locked": "1.5.1",
             "transitive": [
-                "com.palantir.conjure.java.api:errors",
                 "com.palantir.conjure.java.api:service-config"
             ]
         },
@@ -219,13 +216,12 @@
             "locked": "1.7.12",
             "transitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core",
-                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tracing:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.7",
             "transitive": [

--- a/pkcs1-reader-bouncy-castle/build.gradle
+++ b/pkcs1-reader-bouncy-castle/build.gradle
@@ -1,9 +1,10 @@
 apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
-    compile project(":keystores")
-    compile "org.bouncycastle:bcpkix-jdk15on"
+    api project(":keystores")
+    implementation "org.bouncycastle:bcpkix-jdk15on"
 
-    testCompile "junit:junit"
-    testCompile "org.hamcrest:hamcrest-all"
+    testImplementation "junit:junit"
+    testImplementation "org.hamcrest:hamcrest-all"
+    testImplementation 'com.google.guava:guava'
 }

--- a/pkcs1-reader-bouncy-castle/versions.lock
+++ b/pkcs1-reader-bouncy-castle/versions.lock
@@ -74,7 +74,7 @@
             ]
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.7",
             "transitive": [

--- a/pkcs1-reader-bouncy-castle/versions.lock
+++ b/pkcs1-reader-bouncy-castle/versions.lock
@@ -19,30 +19,6 @@
                 "com.palantir.conjure.java.runtime:keystores"
             ]
         },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.3",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "23.6.1-jre",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:keystores"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.palantir.conjure.java.api:ssl-config": {
             "locked": "2.0.0",
             "transitive": [
@@ -59,18 +35,6 @@
             "locked": "1.60",
             "transitive": [
                 "org.bouncycastle:bcpkix-jdk15on"
-            ]
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
             ]
         }
     },

--- a/pkcs1-reader-sun/build.gradle
+++ b/pkcs1-reader-sun/build.gradle
@@ -1,8 +1,9 @@
 apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
-    compile project(":keystores")
+    api project(":keystores")
 
-    testCompile "junit:junit"
-    testCompile "org.hamcrest:hamcrest-all"
+    testImplementation "junit:junit"
+    testImplementation "org.hamcrest:hamcrest-all"
+    testImplementation 'com.google.guava:guava'
 }

--- a/pkcs1-reader-sun/versions.lock
+++ b/pkcs1-reader-sun/versions.lock
@@ -19,30 +19,6 @@
                 "com.palantir.conjure.java.runtime:keystores"
             ]
         },
-        "com.google.code.findbugs:jsr305": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.3",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "23.6.1-jre",
-            "transitive": [
-                "com.palantir.conjure.java.runtime:keystores"
-            ]
-        },
-        "com.google.j2objc:j2objc-annotations": {
-            "locked": "1.1",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
         "com.palantir.conjure.java.api:ssl-config": {
             "locked": "2.0.0",
             "transitive": [
@@ -51,18 +27,6 @@
         },
         "com.palantir.conjure.java.runtime:keystores": {
             "project": true
-        },
-        "org.checkerframework:checker-compat-qual": {
-            "locked": "2.0.0",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
-        },
-        "org.codehaus.mojo:animal-sniffer-annotations": {
-            "locked": "1.14",
-            "transitive": [
-                "com.google.guava:guava"
-            ]
         }
     },
     "runtimeClasspath": {

--- a/pkcs1-reader-sun/versions.lock
+++ b/pkcs1-reader-sun/versions.lock
@@ -65,7 +65,7 @@
             ]
         }
     },
-    "runtime": {
+    "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.7",
             "transitive": [

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
+enableFeaturePreview('IMPROVED_POM_SUPPORT')
 enableFeaturePreview('STABLE_PUBLISHING')
 rootProject.name = 'conjure-java-runtime'
 
@@ -15,3 +16,4 @@ include 'keystores'
 include 'okhttp-clients'
 include 'pkcs1-reader-bouncy-castle'
 include 'pkcs1-reader-sun'
+


### PR DESCRIPTION
## Before this PR

Clients and servers were exposing their implementation dependencies in the POM.

## After this PR

All projects now hide their implementation dependencies (as in, they show up under scope `runtime` in the POM).

Also, we now use gradle's IMPROVED_POM_SUPPORT to achieve [compile/runtime-scope-separation-in-pom-consumption](https://docs.gradle.org/4.6/release-notes.html#compile/runtime-scope-separation-in-pom-consumption) for the dependencies of this repo's projects.

