### PR TITLE
[fix] Change rate limits to be asynchronous

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiterListener.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiterListener.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import com.google.common.util.concurrent.SettableFuture;
+import com.netflix.concurrency.limits.Limiter;
+import com.palantir.conjure.java.client.config.ImmutablesStyle;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutablesStyle
+public interface ConcurrencyLimiterListener {
+
+    @Value.Parameter
+    SettableFuture<Limiter.Listener> limiterListener();
+
+    static ConcurrencyLimiterListener of(SettableFuture<Limiter.Listener> limiterListener) {
+        return ImmutableConcurrencyLimiterListener.of(limiterListener);
+    }
+
+}

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -26,7 +26,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.limit.AIMDLimit;
-import com.netflix.concurrency.limits.limiter.BlockingLimiter;
 import com.netflix.concurrency.limits.limiter.SimpleLimiter;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.tracing.okhttp3.OkhttpTraceInterceptor;

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -19,27 +19,35 @@ package com.palantir.conjure.java.okhttp;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
 import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.limit.AIMDLimit;
 import com.netflix.concurrency.limits.limiter.BlockingLimiter;
 import com.netflix.concurrency.limits.limiter.SimpleLimiter;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.tracing.CloseableTracer;
 import com.palantir.tracing.okhttp3.OkhttpTraceInterceptor;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import javax.annotation.concurrent.GuardedBy;
 import okhttp3.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("DesignForExtension")
-class ConcurrencyLimiters {
+final class ConcurrencyLimiters {
     private static final Logger log = LoggerFactory.getLogger(ConcurrencyLimiters.class);
     private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(1);
     private static final Void NO_CONTEXT = null;
@@ -51,80 +59,49 @@ class ConcurrencyLimiters {
 
     private final Timer slowAcquire;
     private final Meter leakSuspected;
-    private final ConcurrentMap<String, Limiter<Void>> limiters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ConcurrencyLimiter> limiters = new ConcurrentHashMap<>();
     private final Duration timeout;
     private final Class<?> serviceClass;
+    private final ScheduledExecutorService scheduledExecutorService;
 
     @VisibleForTesting
-    ConcurrencyLimiters(TaggedMetricRegistry taggedMetricRegistry, Duration timeout, Class<?> serviceClass) {
+    ConcurrencyLimiters(
+            ScheduledExecutorService scheduledExecutorService,
+            TaggedMetricRegistry taggedMetricRegistry,
+            Duration timeout,
+            Class<?> serviceClass) {
         this.slowAcquire = taggedMetricRegistry.timer(SLOW_ACQUIRE);
         this.leakSuspected = taggedMetricRegistry.meter(LEAK_SUSPECTED);
         this.timeout = timeout;
         this.serviceClass = serviceClass;
+        this.scheduledExecutorService = scheduledExecutorService;
     }
 
-    ConcurrencyLimiters(TaggedMetricRegistry taggedMetricRegistry, Class<?> serviceClass) {
-        this(taggedMetricRegistry, DEFAULT_TIMEOUT, serviceClass);
+    ConcurrencyLimiters(
+            ScheduledExecutorService scheduledExecutorService,
+            TaggedMetricRegistry taggedMetricRegistry,
+            Class<?> serviceClass) {
+        this(scheduledExecutorService, taggedMetricRegistry, DEFAULT_TIMEOUT, serviceClass);
     }
 
     /**
-     * Blocks until the request should be allowed to proceed.
-     * Caller must notify the listener to release the permit.
+     * Returns async limiter that users can subscribe to be notified when limit permit has been granted. Caller must
+     * notify the listener to release the permit.
      */
-    @SuppressWarnings("unused")
-    Limiter.Listener acquireLimiter(Request request) throws IOException {
-        long start = System.nanoTime();
-        try (CloseableTracer unused = CloseableTracer.startSpan("acquireLimiter")) {
-            return acquireLimiterInternal(limiterKey(request), 0);
-        } finally {
-            long end = System.nanoTime();
-            long durationNanos = end - start;
-
-            // acquire calls that take less than a millisecond are considered to be successful, so we exclude
-            // them from the 'slow acquire' metric
-            if (TimeUnit.NANOSECONDS.toMillis(durationNanos) > 1) {
-                slowAcquire.update(durationNanos, TimeUnit.NANOSECONDS);
-            }
-        }
+    ConcurrencyLimiter acquireLimiter(Request request) {
+        return acquireLimiterInternal(limiterKey(request));
     }
 
     @VisibleForTesting
-    Limiter.Listener acquireLimiterInternal(String limiterKey, int attemptsSoFar) throws IOException {
-        Limiter<Void> limiter = limiters.computeIfAbsent(limiterKey, key -> newLimiter());
-        Optional<Limiter.Listener> listener = limiter.acquire(NO_CONTEXT);
-
-        if (listener.isPresent()) {
-            if (attemptsSoFar > 0) {
-                log.info("Eventually acquired concurrency permit",
-                        SafeArg.of("serviceClass", serviceClass),
-                        SafeArg.of("limiterKey", limiterKey),
-                        SafeArg.of("attemptsSoFar", attemptsSoFar + 1));
-            }
-
-            return listener.get();
-        } else {
-            // it returns empty if we've timed out, or we've been interrupted
-            if (Thread.currentThread().isInterrupted()) {
-                throw new IOException("Thread was interrupted");
-            }
-            log.warn("Timed out waiting to get permits for concurrency. In most cases this would indicate "
-                            + "some kind of deadlock. We expect that either this is caused by not closing response "
-                            + "bodies (there should be OkHttp log lines indicating this), or service overloading.",
-                    SafeArg.of("serviceClass", serviceClass),
-                    SafeArg.of("limiterKey", limiterKey),
-                    SafeArg.of("attemptsSoFar", attemptsSoFar + 1),
-                    SafeArg.of("timeout", timeout));
-            leakSuspected.mark();
-            limiters.replace(limiterKey, limiter, newLimiter());
-            return acquireLimiterInternal(limiterKey, attemptsSoFar + 1);
-        }
+    ConcurrencyLimiter acquireLimiterInternal(String limiterKey) {
+        return limiters.computeIfAbsent(limiterKey, this::newLimiter);
     }
 
-    private Limiter<Void> newLimiter() {
-        Limiter<Void> limiter = SimpleLimiter.newBuilder()
+    private ConcurrencyLimiter newLimiter(String limiterKey) {
+        Supplier<Limiter<Void>> limiter = () -> SimpleLimiter.newBuilder()
                 .limit(new ConjureWindowedLimit(AIMDLimit.newBuilder().build()))
                 .build();
-        return BlockingLimiter.wrap(limiter, timeout);
+        return new ConcurrencyLimiter(limiterKey, limiter);
     }
 
     private static String limiterKey(Request request) {
@@ -133,6 +110,121 @@ class ConcurrencyLimiters {
             return FALLBACK;
         } else {
             return request.method() + " " + pathTemplate;
+        }
+    }
+
+    /**
+     * The Netflix library provides either a blocking approach or a non-blocking approach which might say you can't be
+     * scheduled at this time. All of our HTTP calls are asynchronous, so we really want to get a
+     * {@link ListenableFuture} that we can add a callback to. This class then is a translation of
+     * {@link com.netflix.concurrency.limits.limiter.BlockingLimiter} to be asynchronous, maintaining a queue of
+     * currently waiting requests.
+     * <p>
+     * Upon a request finishing, we check if there are any waiting requests, and if there are we attempt to trigger some
+     * more.
+     */
+    final class ConcurrencyLimiter {
+        @GuardedBy("this")
+        private final Queue<SettableFuture<Limiter.Listener>> waitingRequests = new ArrayDeque<>();
+        @GuardedBy("this")
+        private Limiter<Void> limiter;
+        @GuardedBy("this")
+        private ScheduledFuture<?> timeoutCleanup;
+        private final String limiterKey;
+        private final Supplier<Limiter<Void>> limiterFactory;
+
+        ConcurrencyLimiter(String limiterKey, Supplier<Limiter<Void>> limiterFactory) {
+            this.limiterKey = limiterKey;
+            this.limiterFactory = limiterFactory;
+            this.limiter = limiterFactory.get();
+        }
+
+        synchronized ListenableFuture<Limiter.Listener> acquire() {
+            SettableFuture<Limiter.Listener> future = SettableFuture.create();
+            addSlowAcquireMarker(future);
+            waitingRequests.add(future);
+            processQueue();
+            return future;
+        }
+
+        synchronized void processQueue() {
+            while (!waitingRequests.isEmpty()) {
+                Optional<Limiter.Listener> maybeAcquired = limiter.acquire(NO_CONTEXT);
+                if (!maybeAcquired.isPresent()) {
+                    if (!timeoutScheduled()) {
+                        timeoutCleanup = scheduledExecutorService.schedule(
+                                this::resetLimiter, timeout.toMillis(), TimeUnit.MILLISECONDS);
+                    }
+                    return;
+                }
+                Limiter.Listener acquired = maybeAcquired.get();
+                SettableFuture<Limiter.Listener> head = waitingRequests.remove();
+                head.set(wrap(acquired));
+            }
+
+            if (timeoutScheduled()) {
+                timeoutCleanup.cancel(true);
+            }
+        }
+
+        private synchronized boolean timeoutScheduled() {
+            return timeoutCleanup != null && !timeoutCleanup.isDone() && !timeoutCleanup.isCancelled();
+        }
+
+        private synchronized void resetLimiter() {
+            log.warn("Timed out waiting to get permits for concurrency. In most cases this would indicate some kind of "
+                            + "deadlock. We expect that either this is caused by not closing response bodies "
+                            + "(there should be OkHttp log lines indicating this), or service overloading.",
+                    SafeArg.of("serviceClass", serviceClass),
+                    SafeArg.of("limiterKey", limiterKey),
+                    SafeArg.of("timeout", timeout));
+            leakSuspected.mark();
+            limiter = limiterFactory.get();
+            processQueue();
+        }
+
+        private void addSlowAcquireMarker(ListenableFuture<Limiter.Listener> future) {
+            long start = System.nanoTime();
+            Futures.addCallback(future, new FutureCallback<Limiter.Listener>() {
+                @Override
+                public void onSuccess(Limiter.Listener result) {
+                    long end = System.nanoTime();
+                    long durationNanos = end - start;
+
+                    // acquire calls that take less than a millisecond are considered to be successful, so we exclude
+                    // them from the 'slow acquire' metric
+                    if (TimeUnit.NANOSECONDS.toMillis(durationNanos) > 1) {
+                        slowAcquire.update(durationNanos, TimeUnit.NANOSECONDS);
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable error) {
+
+                }
+            }, MoreExecutors.directExecutor());
+        }
+
+        private Limiter.Listener wrap(Limiter.Listener listener) {
+            return new Limiter.Listener() {
+                @Override
+                public void onSuccess() {
+                    listener.onSuccess();
+                    processQueue();
+                }
+
+                @Override
+                public void onIgnore() {
+                    listener.onIgnore();
+                    processQueue();
+                }
+
+                @Override
+                public void onDropped() {
+                    listener.onDropped();
+                    processQueue();
+                }
+            };
         }
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitingInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitingInterceptor.java
@@ -16,10 +16,11 @@
 
 package com.palantir.conjure.java.okhttp;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.netflix.concurrency.limits.Limiter;
-import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import com.palantir.logsafe.Preconditions;
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -56,20 +57,15 @@ import okio.BufferedSource;
 final class ConcurrencyLimitingInterceptor implements Interceptor {
     private static final ImmutableSet<Integer> DROPPED_CODES = ImmutableSet.of(429, 503);
 
-    private final ConcurrencyLimiters limiters;
-
-    @VisibleForTesting
-    ConcurrencyLimitingInterceptor(ConcurrencyLimiters limiters) {
-        this.limiters = limiters;
-    }
-
-    ConcurrencyLimitingInterceptor(TaggedMetricRegistry taggedMetricRegistry, Class<?> serviceClass) {
-        this(new ConcurrencyLimiters(taggedMetricRegistry, serviceClass));
-    }
+    ConcurrencyLimitingInterceptor() { }
 
     @Override
     public Response intercept(Chain chain) throws IOException {
-        Limiter.Listener listener = limiters.acquireLimiter(chain.request());
+        ListenableFuture<Limiter.Listener> limiterFuture = chain.request().tag(ConcurrencyLimiterListener.class)
+                .limiterListener();
+        Preconditions.checkState(limiterFuture.isDone(), "Limit listener future should have been fulfilled.");
+        Limiter.Listener listener = Futures.getUnchecked(limiterFuture);
+
         try {
             Response response = chain.proceed(chain.request());
             if (DROPPED_CODES.contains(response.code())) {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -84,13 +84,12 @@ final class RemotingOkHttpCall extends ForwardingCall {
         this.client = client;
         this.schedulingExecutor = schedulingExecutor;
         this.executionExecutor = executionExecutor;
-        this.limiter = limiter;
         this.maxNumRelocations = maxNumRelocations;
     }
 
     /**
-     * Process the call. If an IOException is encountered, mark the URL as failed, which indicates that it should be
-     * avoided for subsequent calls (if {@link UrlSelector} was initialized with a positive
+     * Process the call. If an IOException is encountered, mark the URL as failed, which indicates that it should
+     * be avoided for subsequent calls (if {@link UrlSelector} was initialized with a positive
      * {@link ClientConfiguration#failedUrlCooldown()}.
      */
     @Override

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -84,6 +84,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
         this.client = client;
         this.schedulingExecutor = schedulingExecutor;
         this.executionExecutor = executionExecutor;
+        this.limiter = limiter;
         this.maxNumRelocations = maxNumRelocations;
     }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -16,7 +16,12 @@
 
 package com.palantir.conjure.java.okhttp;
 
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import com.netflix.concurrency.limits.Limiter;
 import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
@@ -60,6 +65,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
     private final RemotingOkHttpClient client;
     private final ScheduledExecutorService schedulingExecutor;
     private final ExecutorService executionExecutor;
+    private final ConcurrencyLimiters.ConcurrencyLimiter limiter;
 
     private final int maxNumRelocations;
 
@@ -70,6 +76,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
             RemotingOkHttpClient client,
             ScheduledExecutorService schedulingExecutor,
             ExecutorService executionExecutor,
+            ConcurrencyLimiters.ConcurrencyLimiter limiter,
             int maxNumRelocations) {
         super(delegate);
         this.backoffStrategy = backoffStrategy;
@@ -77,12 +84,13 @@ final class RemotingOkHttpCall extends ForwardingCall {
         this.client = client;
         this.schedulingExecutor = schedulingExecutor;
         this.executionExecutor = executionExecutor;
+        this.limiter = limiter;
         this.maxNumRelocations = maxNumRelocations;
     }
 
     /**
-     * Process the call. If an IOException is encountered, mark the URL as failed, which indicates that it should
-     * be avoided for subsequent calls (if {@link UrlSelector} was initialized with a positive
+     * Process the call. If an IOException is encountered, mark the URL as failed, which indicates that it should be
+     * avoided for subsequent calls (if {@link UrlSelector} was initialized with a positive
      * {@link ClientConfiguration#failedUrlCooldown()}.
      */
     @Override
@@ -95,7 +103,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
             }
 
             @Override
-            public void onResponse(Call call, Response response) throws IOException {
+            public void onResponse(Call call, Response response) {
                 future.set(response);
             }
         });
@@ -140,6 +148,25 @@ final class RemotingOkHttpCall extends ForwardingCall {
 
     @Override
     public void enqueue(Callback callback) {
+        ListenableFuture<Limiter.Listener> limiterListener = limiter.acquire();
+        request().tag(ConcurrencyLimiterListener.class).limiterListener().setFuture(limiterListener);
+        Futures.addCallback(limiterListener, new FutureCallback<Limiter.Listener>() {
+            @Override
+            public void onSuccess(Limiter.Listener listener) {
+                enqueueInternal(callback);
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                callback.onFailure(
+                        RemotingOkHttpCall.this,
+                        new IOException(new AssertionError("This should never happen, since it implies "
+                                + "we failed when using the concurrency limiter", throwable)));
+            }
+        }, MoreExecutors.directExecutor());
+    }
+
+    private void enqueueInternal(Callback callback) {
         super.enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException exception) {
@@ -299,6 +326,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
     @Override
     public RemotingOkHttpCall doClone() {
         return new RemotingOkHttpCall(getDelegate().clone(), backoffStrategy, urls, client, schedulingExecutor,
-                executionExecutor, maxNumRelocations);
+                executionExecutor, limiter, maxNumRelocations);
     }
 }

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/FlowControlTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/FlowControlTest.java
@@ -48,11 +48,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class is a simulation of the flow control primitives used by this library, in order to allow the developer to
- * try different strategies.
+ * This class is a simulation of the flow control primitives used by this library, in order to allow the developer
+ * to try different strategies.
  * <p>
- * It is run in CI, but only to prevent code breakages - this is in general an expensive test which should be run as a
- * dev tool. If you want to run for dev purposes, please increase REQUESTS_PER_THREAD.
+ * It is run in CI, but only to prevent code breakages - this is in general an expensive test which should be run
+ * as a dev tool. If you want to run for dev purposes, please increase REQUESTS_PER_THREAD.
  */
 public final class FlowControlTest {
     private static final Logger log = LoggerFactory.getLogger(FlowControlTest.class);


### PR DESCRIPTION
On applications making a lot of small requests with rate limiting we have noticed apparent deadlocks where the application was no longer able to make any new requests thus not being able to serve any new incoming requests. This was traced down to okhttp dispatcher pool being full. Apart from the application itself rate limiting it's consumers this change lets us preserve previous limit behaviour and keep the limits.

## Before this PR
Rate limited requests could have occupied all of the okhttp dispatcher pool making it impossible to make any new outbound requests

## After this PR
Rate limited requests are tracked separately and no longer contribute to okhttp dispatcher pool usage.