### PR TITLE
[fix] Rename custom feign Encoders and Decoders to avoid clashing with remoting3

### DIFF
--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -27,21 +27,21 @@ import com.palantir.conjure.java.client.jaxrs.feignimpl.SlashEncodingContract;
 import com.palantir.conjure.java.okhttp.HostEventsSink;
 import com.palantir.conjure.java.okhttp.OkHttpClients;
 import com.palantir.logsafe.Preconditions;
-import feign.CborDelegateDecoder;
-import feign.CborDelegateEncoder;
+import feign.ConjureCborDelegateDecoder;
+import feign.ConjureCborDelegateEncoder;
+import feign.ConjureEmptyContainerDecoder;
+import feign.ConjureGuavaOptionalAwareDecoder;
+import feign.ConjureInputStreamDelegateDecoder;
+import feign.ConjureInputStreamDelegateEncoder;
+import feign.ConjureJava8OptionalAwareDecoder;
+import feign.ConjureNeverReturnNullDecoder;
+import feign.ConjureTextDelegateDecoder;
+import feign.ConjureTextDelegateEncoder;
 import feign.Contract;
-import feign.EmptyContainerDecoder;
 import feign.Feign;
-import feign.GuavaOptionalAwareDecoder;
-import feign.InputStreamDelegateDecoder;
-import feign.InputStreamDelegateEncoder;
-import feign.Java8OptionalAwareDecoder;
 import feign.Logger;
-import feign.NeverReturnNullDecoder;
 import feign.Request;
 import feign.Retryer;
-import feign.TextDelegateDecoder;
-import feign.TextDelegateEncoder;
 import feign.codec.Decoder;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
@@ -92,9 +92,9 @@ abstract class AbstractFeignJaxRsClientBuilder {
         return Feign.builder()
                 .contract(createContract())
                 .encoder(
-                        new InputStreamDelegateEncoder(
-                                new TextDelegateEncoder(
-                                        new CborDelegateEncoder(
+                        new ConjureInputStreamDelegateEncoder(
+                                new ConjureTextDelegateEncoder(
+                                        new ConjureCborDelegateEncoder(
                                                 cborObjectMapper,
                                                 new JacksonEncoder(objectMapper)))))
                 .decoder(createDecoder(objectMapper, cborObjectMapper))
@@ -121,14 +121,14 @@ abstract class AbstractFeignJaxRsClientBuilder {
     }
 
     private static Decoder createDecoder(ObjectMapper objectMapper, ObjectMapper cborObjectMapper) {
-        return new NeverReturnNullDecoder(
-                new Java8OptionalAwareDecoder(
-                        new GuavaOptionalAwareDecoder(
-                                new EmptyContainerDecoder(
+        return new ConjureNeverReturnNullDecoder(
+                new ConjureJava8OptionalAwareDecoder(
+                        new ConjureGuavaOptionalAwareDecoder(
+                                new ConjureEmptyContainerDecoder(
                                         objectMapper,
-                                        new InputStreamDelegateDecoder(
-                                                new TextDelegateDecoder(
-                                                        new CborDelegateDecoder(
+                                        new ConjureInputStreamDelegateDecoder(
+                                                new ConjureTextDelegateDecoder(
+                                                        new ConjureCborDelegateDecoder(
                                                                 cborObjectMapper,
                                                                 new JacksonDecoder(objectMapper))))))));
     }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateDecoder.java
@@ -36,12 +36,12 @@ import java.util.Collection;
  * Ideally we'll codegen a client which handles the content-type switching where necessary (multiple possible response
  * Content-Types from the server) and does not do the checking where this is known at compile time.
  */
-public final class CborDelegateDecoder implements Decoder {
+public final class ConjureCborDelegateDecoder implements Decoder {
 
     private final ObjectMapper cborObjectMapper;
     private final Decoder delegate;
 
-    public CborDelegateDecoder(ObjectMapper cborObjectMapper, Decoder delegate) {
+    public ConjureCborDelegateDecoder(ObjectMapper cborObjectMapper, Decoder delegate) {
         this.cborObjectMapper = cborObjectMapper;
         this.delegate = delegate;
     }
@@ -55,7 +55,7 @@ public final class CborDelegateDecoder implements Decoder {
         }
 
         if (contentTypes.size() == 1
-                && Iterables.getOnlyElement(contentTypes, "").startsWith(CborDelegateEncoder.MIME_TYPE)) {
+                && Iterables.getOnlyElement(contentTypes, "").startsWith(ConjureCborDelegateEncoder.MIME_TYPE)) {
 
             // some sillyness to test whether the input stram is empty
             // if it's empty, we want to return null rather than having jackson throw

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateEncoder.java
@@ -39,14 +39,14 @@ import java.util.Collection;
  * In the future we will likely codegen the client and thus remove the need for
  * scanning the headers on every request.
  */
-public final class CborDelegateEncoder implements Encoder {
+public final class ConjureCborDelegateEncoder implements Encoder {
 
     public static final String MIME_TYPE = "application/cbor";
 
     private final ObjectMapper cborObjectMapper;
     private final Encoder delegate;
 
-    public CborDelegateEncoder(ObjectMapper cborObjectMapper, Encoder delegate) {
+    public ConjureCborDelegateEncoder(ObjectMapper cborObjectMapper, Encoder delegate) {
         this.cborObjectMapper = cborObjectMapper;
         this.delegate = delegate;
     }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureEmptyContainerDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureEmptyContainerDecoder.java
@@ -47,12 +47,12 @@ import org.slf4j.LoggerFactory;
  *
  * Empty instances are cached and re-used to avoid reflection and exceptions on a hot codepath.
  */
-public final class EmptyContainerDecoder implements Decoder {
+public final class ConjureEmptyContainerDecoder implements Decoder {
 
     private final LoadingCache<Type, Object> blankInstanceCache;
     private final Decoder delegate;
 
-    public EmptyContainerDecoder(ObjectMapper mapper, Decoder delegate) {
+    public ConjureEmptyContainerDecoder(ObjectMapper mapper, Decoder delegate) {
         this.delegate = delegate;
         this.blankInstanceCache = Caffeine.newBuilder()
                 .maximumSize(1000)

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureGuavaOptionalAwareDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureGuavaOptionalAwareDecoder.java
@@ -27,11 +27,11 @@ import java.lang.reflect.Type;
  * Decorates a Feign {@link Decoder} such that it returns {@link com.google.common.base.Optional#absent}
  * when observing an HTTP 204 error code for a method with {@link Type} {@link com.google.common.base.Optional}.
  */
-public final class GuavaOptionalAwareDecoder implements Decoder {
+public final class ConjureGuavaOptionalAwareDecoder implements Decoder {
 
     private final Decoder delegate;
 
-    public GuavaOptionalAwareDecoder(Decoder delegate) {
+    public ConjureGuavaOptionalAwareDecoder(Decoder delegate) {
         this.delegate = delegate;
     }
 

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureInputStreamDelegateEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureInputStreamDelegateEncoder.java
@@ -16,29 +16,33 @@
 
 package feign;
 
-import feign.codec.Decoder;
-import java.io.ByteArrayInputStream;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 
 /**
- * If the return type is InputStream, return it, otherwise delegate to provided decoder.
+ * If the body type is an InputStream, write it into the body, otherwise pass to delegate.
  */
-public final class InputStreamDelegateDecoder implements Decoder {
-    private final Decoder delegate;
+public final class ConjureInputStreamDelegateEncoder implements Encoder {
+    private final Encoder delegate;
 
-    public InputStreamDelegateDecoder(Decoder delegate) {
+    public ConjureInputStreamDelegateEncoder(Encoder delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public Object decode(Response response, Type type) throws IOException, FeignException {
-        if (type.equals(InputStream.class)) {
-            byte[] body = response.body() != null ? Util.toByteArray(response.body().asInputStream()) : new byte[0];
-            return new ByteArrayInputStream(body);
+    public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
+        if (bodyType.equals(InputStream.class)) {
+            try {
+                template.body(Util.toByteArray((InputStream) object), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         } else {
-            return delegate.decode(response, type);
+            delegate.encode(object, bodyType, template);
         }
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureJava8OptionalAwareDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureJava8OptionalAwareDecoder.java
@@ -28,11 +28,11 @@ import java.util.Optional;
  * Decorates a Feign {@link Decoder} such that it returns {@link Optional#empty} when observing an HTTP 204 error code
  * for a method with {@link Type} {@link Optional}.
  */
-public final class Java8OptionalAwareDecoder implements Decoder {
+public final class ConjureJava8OptionalAwareDecoder implements Decoder {
 
     private final Decoder delegate;
 
-    public Java8OptionalAwareDecoder(Decoder delegate) {
+    public ConjureJava8OptionalAwareDecoder(Decoder delegate) {
         this.delegate = delegate;
     }
 

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureNeverReturnNullDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureNeverReturnNullDecoder.java
@@ -22,10 +22,10 @@ import feign.codec.Decoder;
 import java.io.IOException;
 import java.lang.reflect.Type;
 
-public final class NeverReturnNullDecoder implements Decoder {
+public final class ConjureNeverReturnNullDecoder implements Decoder {
     private final Decoder delegate;
 
-    public NeverReturnNullDecoder(Decoder delegate) {
+    public ConjureNeverReturnNullDecoder(Decoder delegate) {
         this.delegate = delegate;
     }
 

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureTextDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureTextDelegateDecoder.java
@@ -20,38 +20,38 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.net.HttpHeaders;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.HeaderAccessUtils;
-import feign.codec.EncodeException;
-import feign.codec.Encoder;
+import feign.codec.Decoder;
+import feign.codec.StringDecoder;
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import javax.ws.rs.core.MediaType;
 
 /**
- * Delegates to a {@link feign.codec.Encoder.Default} if the response has a Content-Type of text/plain, or falls back
- * to the given delegate otherwise.
+ * Delegates to a {@link StringDecoder} if the response has a Content-Type of text/plain, or falls back to the given
+ * delegate otherwise.
  */
-public final class TextDelegateEncoder implements Encoder {
-    private static final Encoder defaultEncoder = new Encoder.Default();
+public final class ConjureTextDelegateDecoder implements Decoder {
+    private static final Decoder stringDecoder = new StringDecoder();
 
-    private final Encoder delegate;
+    private final Decoder delegate;
 
-    public TextDelegateEncoder(Encoder delegate) {
+    public ConjureTextDelegateDecoder(Decoder delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
+    public Object decode(Response response, Type type) throws IOException, FeignException {
         Collection<String> contentTypes =
-                HeaderAccessUtils.caseInsensitiveGet(template.headers(), HttpHeaders.CONTENT_TYPE);
+                HeaderAccessUtils.caseInsensitiveGet(response.headers(), HttpHeaders.CONTENT_TYPE);
         if (contentTypes == null) {
             contentTypes = ImmutableSet.of();
         }
-
         // In the case of multiple content types, or an unknown content type, we'll use the delegate instead.
-        if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").equals(MediaType.TEXT_PLAIN)) {
-            defaultEncoder.encode(object, bodyType, template);
-        } else {
-            delegate.encode(object,  bodyType, template);
+        if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").startsWith(MediaType.TEXT_PLAIN)) {
+            return stringDecoder.decode(response, type);
         }
+
+        return delegate.decode(response, type);
     }
 }

--- a/conjure-java-jaxrs-client/src/test/java/feign/ConjureEmptyContainerDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/feign/ConjureEmptyContainerDecoderTest.java
@@ -47,12 +47,14 @@ import javax.annotation.Generated;
 import javax.ws.rs.core.MediaType;
 import org.junit.Test;
 
-public class EmptyContainerDecoderTest {
+public class ConjureEmptyContainerDecoderTest {
 
     private static final ObjectMapper mapper = ObjectMappers.newClientObjectMapper();
-    private static final Response HTTP_204 = Response.create(204, "No Content", Collections.emptyMap(), new byte[] {});
+    private static final Response HTTP_204 =
+            Response.create(204, "No Content", Collections.emptyMap(), new byte[] {});
     private final Decoder delegate = mock(Decoder.class);
-    private final EmptyContainerDecoder emptyContainerDecoder = new EmptyContainerDecoder(mapper, delegate);
+    private final ConjureEmptyContainerDecoder emptyContainerDecoder =
+            new ConjureEmptyContainerDecoder(mapper, delegate);
 
     @Test
     public void http_200_uses_delegate_decoder() throws IOException {

--- a/conjure-java-jaxrs-client/src/test/java/feign/ConjureInputStreamDelegateDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/feign/ConjureInputStreamDelegateDecoderTest.java
@@ -38,7 +38,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public final class InputStreamDelegateDecoderTest extends TestBase {
+public final class ConjureInputStreamDelegateDecoderTest extends TestBase {
     @ClassRule
     public static final DropwizardAppRule<Configuration> APP = new DropwizardAppRule<>(GuavaTestServer.class,
             "src/test/resources/test-server.yml");
@@ -50,7 +50,7 @@ public final class InputStreamDelegateDecoderTest extends TestBase {
     @Before
     public void before() {
         delegate = Mockito.mock(Decoder.class);
-        inputStreamDelegateDecoder = new InputStreamDelegateDecoder(delegate);
+        inputStreamDelegateDecoder = new ConjureInputStreamDelegateDecoder(delegate);
 
         String endpointUri = "http://localhost:" + APP.getLocalPort();
         service = JaxRsClient.create(

--- a/conjure-java-jaxrs-client/src/test/java/feign/ConjureInputStreamDelegateEncoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/feign/ConjureInputStreamDelegateEncoderTest.java
@@ -38,7 +38,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public final class InputStreamDelegateEncoderTest extends TestBase {
+public final class ConjureInputStreamDelegateEncoderTest extends TestBase {
     @Mock
     private Encoder delegate;
 
@@ -54,7 +54,7 @@ public final class InputStreamDelegateEncoderTest extends TestBase {
 
     @Before
     public void before() {
-        inputStreamDelegateEncoder = new InputStreamDelegateEncoder(delegate);
+        inputStreamDelegateEncoder = new ConjureInputStreamDelegateEncoder(delegate);
 
         String endpointUri = "http://localhost:" + APP.getLocalPort();
         service = JaxRsClient.create(

--- a/conjure-java-jaxrs-client/src/test/java/feign/ConjureNeverReturnNullDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/feign/ConjureNeverReturnNullDecoderTest.java
@@ -32,10 +32,10 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
-public final class NeverReturnNullDecoderTest extends TestBase {
+public final class ConjureNeverReturnNullDecoderTest extends TestBase {
 
     private final Map<String, Collection<String>> headers = Maps.newHashMap();
-    private final Decoder textDelegateDecoder = new NeverReturnNullDecoder(
+    private final Decoder textDelegateDecoder = new ConjureNeverReturnNullDecoder(
             new JacksonDecoder(ObjectMappers.newClientObjectMapper()));
 
     @Test

--- a/conjure-java-jaxrs-client/src/test/java/feign/ConjureTextDelegateDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/feign/ConjureTextDelegateDecoderTest.java
@@ -47,7 +47,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public final class TextDelegateDecoderTest extends TestBase {
+public final class ConjureTextDelegateDecoderTest extends TestBase {
     private static final String DELEGATE_RESPONSE = "delegate response";
 
     @ClassRule
@@ -66,7 +66,7 @@ public final class TextDelegateDecoderTest extends TestBase {
     public void before() {
         delegate = mock(Decoder.class);
         headers = Maps.newHashMap();
-        textDelegateDecoder = new TextDelegateDecoder(delegate);
+        textDelegateDecoder = new ConjureTextDelegateDecoder(delegate);
 
         String endpointUri = "http://localhost:" + APP.getLocalPort();
         service = JaxRsClient.create(

--- a/conjure-java-jaxrs-client/src/test/java/feign/ConjureTextDelegateEncoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/feign/ConjureTextDelegateEncoderTest.java
@@ -30,7 +30,7 @@ import javax.ws.rs.core.MediaType;
 import org.junit.Before;
 import org.junit.Test;
 
-public final class TextDelegateEncoderTest {
+public final class ConjureTextDelegateEncoderTest {
 
     private RequestTemplate requestTemplate;
     private Map<String, Collection<String>> headers;
@@ -41,7 +41,7 @@ public final class TextDelegateEncoderTest {
     public void before() {
         delegate = mock(Encoder.class);
         headers = Maps.newHashMap();
-        textDelegateEncoder = new TextDelegateEncoder(delegate);
+        textDelegateEncoder = new ConjureTextDelegateEncoder(delegate);
         requestTemplate = new RequestTemplate();
     }
 


### PR DESCRIPTION
Allows both to exist on the same classpath with reproducible
behavior.

fixes #899
fixes https://github.com/palantir/conjure-java-runtime/issues/810