### PR TITLE
[improvement] Log remote exception error information

### DIFF
--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
@@ -54,6 +54,8 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
 
         // log at WARN instead of ERROR because although this indicates an issue in a remote server
         log.warn("Encountered a remote exception. Mapping to an internal error before propagating",
+                SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
+                SafeArg.of("errorName", exception.getError().errorName()),
                 SafeArg.of("statusCode", status.getStatusCode()),
                 exception);
 


### PR DESCRIPTION
## Before this PR
The errorName and errorInstanceId are not logged when mapping a `RemoteException`. Because we don't propagate the error, this information is lost.

## After this PR
The errorName and errorInstanceId are logged when mapping a `RemoteException`. This is consistent with the behavior of `ServiceExceptionMapper` and `JsonExceptionMapper`.