### PR TITLE
Prevent npes if you don't get remotingokhttpclient

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitingInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitingInterceptor.java
@@ -61,8 +61,12 @@ final class ConcurrencyLimitingInterceptor implements Interceptor {
 
     @Override
     public Response intercept(Chain chain) throws IOException {
-        ListenableFuture<Limiter.Listener> limiterFuture = chain.request().tag(ConcurrencyLimiterListener.class)
-                .limiterListener();
+        ConcurrencyLimiterListener limiterListenerTag = chain.request().tag(ConcurrencyLimiterListener.class);
+        if (limiterListenerTag == null) {
+            return chain.proceed(chain.request());
+        }
+
+        ListenableFuture<Limiter.Listener> limiterFuture = limiterListenerTag.limiterListener();
         Preconditions.checkState(limiterFuture.isDone(), "Limit listener future should have been fulfilled.");
         Limiter.Listener listener = Futures.getUnchecked(limiterFuture);
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.okhttp;
 
 import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
@@ -63,7 +64,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
     @Override
     public Builder newBuilder() {
         log.warn("Attempting to copy RemotingOkHttpClient. Some of the functionality like rate limiting and qos will "
-                + "not be available to the new client");
+                + "not be available to the new client", new SafeRuntimeException("stacktrace"));
         return super.newBuilder();
     }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
@@ -22,12 +22,15 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An {@link OkHttpClient} that executes {@link okhttp3.Call}s as {@link RemotingOkHttpCall}s in order to retry a class
  * of retryable error states.
  */
 final class RemotingOkHttpClient extends ForwardingOkHttpClient {
+    private static final Logger log = LoggerFactory.getLogger(RemotingOkHttpClient.class);
 
     private static final int MAX_NUM_RELOCATIONS = 20;
 
@@ -55,6 +58,13 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
     @Override
     public RemotingOkHttpCall newCall(Request request) {
         return newCallWithMutableState(addRateLimitIdTag(request), backoffStrategyFactory.get(), MAX_NUM_RELOCATIONS);
+    }
+
+    @Override
+    public Builder newBuilder() {
+        log.warn("Attempting to copy RemotingOkHttpClient. Some of the functionality like rate limiting and qos will "
+                + "not be available to the new client");
+        return super.newBuilder();
     }
 
     RemotingOkHttpCall newCallWithMutableState(


### PR DESCRIPTION
The error happens if you call newBuilder on RemotingOkhttpClient since then that will lose our override of newCall