### PR TITLE
[break] Exclude empty optionals during serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin/
 .idea/
 out/
 generated_src/
+generated_testSrc/
 
 # Codegen
 .generated

--- a/conjure-java-jackson-serialization/build.gradle
+++ b/conjure-java-jackson-serialization/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: "org.inferred.processors"
 apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
@@ -10,4 +11,7 @@ dependencies {
 
     testCompile "junit:junit"
     testCompile "org.assertj:assertj-core"
+
+    testAnnotationProcessor 'org.immutables:value'
+    testCompileOnly 'org.immutables:value::annotations'
 }

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.serialization;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -99,9 +100,10 @@ public final class ObjectMappers {
         return mapper
                 .registerModule(new GuavaModule())
                 .registerModule(new ShimJdk7Module())
-                .registerModule(new Jdk8Module().configureAbsentsAsNulls(true))
+                .registerModule(new Jdk8Module())
                 .registerModule(new AfterburnerModule())
                 .registerModule(new JavaTimeModule())
+                .setDefaultPropertyInclusion(Include.NON_ABSENT)
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                 .disable(DeserializationFeature.WRAP_EXCEPTIONS)

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -31,6 +33,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+import org.immutables.value.Value;
 import org.junit.Test;
 
 public final class ObjectMappersTest {
@@ -56,8 +59,26 @@ public final class ObjectMappersTest {
     }
 
     @Test
-    public void deserializeJdk8ModuleAbsentOptional() throws IOException {
+    public void deserializeJdk8ModuleNullOptional() throws IOException {
         assertThat(MAPPER.readValue("null", Optional.class)).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void deserializeJdk8ModulePresentOptionalField() throws IOException {
+        assertThat(MAPPER.readValue("{\"value\":\"Test\"}", OptionalField.class))
+                .isEqualTo(ImmutableOptionalField.of(Optional.of("Test")));
+    }
+
+    @Test
+    public void deserializeJdk8ModuleNullOptionalField() throws IOException {
+        assertThat(MAPPER.readValue("{\"value\":null}", OptionalField.class))
+                .isEqualTo(ImmutableOptionalField.of(Optional.empty()));
+    }
+
+    @Test
+    public void deserializeJdk8ModuleAbsentOptionalField() throws IOException {
+        assertThat(MAPPER.readValue("{}", OptionalField.class))
+                .isEqualTo(ImmutableOptionalField.of(Optional.empty()));
     }
 
     @Test
@@ -68,6 +89,18 @@ public final class ObjectMappersTest {
     @Test
     public void serializeJdk8ModuleEmptyOptional() throws JsonProcessingException {
         assertThat(MAPPER.writeValueAsString(Optional.empty())).isEqualTo("null");
+    }
+
+    @Test
+    public void serializeJdk8ModulePresentOptionalField() throws JsonProcessingException {
+        assertThat(MAPPER.writeValueAsString(ImmutableOptionalField.of(Optional.of("Test"))))
+                .isEqualTo("{\"value\":\"Test\"}");
+    }
+
+    @Test
+    public void serializeJdk8ModuleEmptyOptionalField() throws JsonProcessingException {
+        assertThat(MAPPER.writeValueAsString(ImmutableOptionalField.of(Optional.empty())))
+                .isEqualTo("{}");
     }
 
     @Test
@@ -100,5 +133,13 @@ public final class ObjectMappersTest {
 
     private static <T> T serDe(Object object, Class<T> clazz) throws IOException {
         return MAPPER.readValue(ser(object), clazz);
+    }
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableOptionalField.class)
+    @JsonDeserialize(as = ImmutableOptionalField.class)
+    interface OptionalField {
+        @Value.Parameter
+        Optional<String> value();
     }
 }

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/SslConfigurationTest.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/SslConfigurationTest.java
@@ -54,10 +54,9 @@ public final class SslConfigurationTest {
     public void serDe_optional() throws Exception {
         SslConfiguration serialized = SslConfiguration.of(Paths.get("trustStore.jks"));
         String deserializedCamelCase = "{\"trustStorePath\":\"trustStore.jks\",\"trustStoreType\":\"JKS\","
-                + "\"keyStorePath\":null,\"keyStorePassword\":null,\"keyStoreType\":\"JKS\",\"keyStoreKeyAlias\":null}";
+                + "\"keyStoreType\":\"JKS\"}";
         String deserializedKebabCase = "{\"trust-store-path\":\"trustStore.jks\",\"trust-store-type\":\"JKS\","
-                + "\"key-store-path\":null,\"key-store-password\":null,\"key-store-type\":\"JKS\","
-                + "\"key-store-key-alias\":null}";
+                + "\"key-store-type\":\"JKS\"}";
 
         assertThat(ObjectMappers.newClientObjectMapper().writeValueAsString(serialized))
                 .isEqualTo(deserializedCamelCase);

--- a/readme.md
+++ b/readme.md
@@ -286,9 +286,9 @@ The workflow is:
  - If the client is itself a server, does not handle the exception and just re-throws the `RemoteException`, the `RemoteException` will be propagated i.e. re-serialized as its own erroneous response
 
 #### Serialization of Optional and Nullable objects
-`@Nullable` or `Optional<?>` fields in complex types are serialized using the standard Jackson mechanism:
+`@Nullable` or `Optional<?>` fields in complex types are serialized using the following mechanism:
 - a present value is serialized as itself (in particular, without being wrapped in a JSON object representing the `Optional` object)
-- an absent value is serialized as a JSON `null`.
+- an absent value is omitted
 For example, assume a Java type of the form
 ```java
 public final class ComplexType {
@@ -301,13 +301,13 @@ public final class ComplexType {
 ComplexType value = new ComplexType(
         Optional.of(
                 new ComplexType(
-                        Optional.<ComplexType>absent(),
-                        Optional.<String>absent(),
+                        Optional.<ComplexType>empty(),
+                        Optional.<String>empty(),
         Optional.of("baz"));
 ```
 The JSON-serialized representation of this object is:
 ```json
-{"nested":{"nested":null,"string":null},"string":"baz"}
+{"nested":{},"string":"baz"}
 ```
 
 #### Optional return values


### PR DESCRIPTION
## Before this PR
Empty optional fields are serialized as `null`.

## After this PR
Empty optional fields are omitted during serialization

---

Fixes #398

~This change should be safe. The only test that fails without the object mapper changes is `serializeJdk8ModuleEmptyOptionalField`, which is expected. Object mappers created both before and after this change can correctly deserialize all forms (present, null, absent).~

I don't think it is possible to omit empty collections without requiring code changes in objects themselves. Many objects require that collection fields are present and don't provide a default value. This includes the default configuration of all immutables objects, which are used extensively with these object mappers.

We can still make this change for conjure objects by adding the relevant `@JsonInclude` annotation.

---

EDIT: This actually would be a break for clients mapping objects that do not provide a default value for optional objects. Both conjure and immutables objects do, so this would only affect objects with hand-rolled jackson annotations. But that is still a break.

