### PR TITLE
[improvement] Remove unnencessary complexity passing trace operations to okhttp

### DIFF
--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -22,7 +22,6 @@ import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.GuavaOptionalAwareContract;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.Java8OptionalAwareContract;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.PathTemplateHeaderEnrichmentContract;
-import com.palantir.conjure.java.client.jaxrs.feignimpl.PathTemplateHeaderRewriter;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.SlashEncodingContract;
 import com.palantir.conjure.java.okhttp.HostEventsSink;
 import com.palantir.conjure.java.okhttp.OkHttpClients;
@@ -98,7 +97,6 @@ abstract class AbstractFeignJaxRsClientBuilder {
                                                 cborObjectMapper,
                                                 new JacksonEncoder(objectMapper)))))
                 .decoder(createDecoder(objectMapper, cborObjectMapper))
-                .requestInterceptor(PathTemplateHeaderRewriter.INSTANCE)
                 .client(new OkHttpClient(okHttpClient))
                 .options(createRequestOptions())
                 .logLevel(Logger.Level.NONE)  // we use OkHttp interceptors for logging. (note that NONE is the default)

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/PathTemplateHeaderEnrichmentContract.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/PathTemplateHeaderEnrichmentContract.java
@@ -10,7 +10,9 @@ import feign.MethodMetadata;
 import java.lang.reflect.Method;
 
 public final class PathTemplateHeaderEnrichmentContract extends AbstractDelegatingContract {
+    @Deprecated
     public static final char OPEN_BRACE_REPLACEMENT = '\0';
+    @Deprecated
     public static final char CLOSE_BRACE_REPLACEMENT = '\1';
 
     public PathTemplateHeaderEnrichmentContract(Contract delegate) {
@@ -19,10 +21,11 @@ public final class PathTemplateHeaderEnrichmentContract extends AbstractDelegati
 
     @Override
     protected void processMetadata(Class<?> targetType, Method method, MethodMetadata metadata) {
+
         metadata.template().header(OkhttpTraceInterceptor.PATH_TEMPLATE_HEADER,
-                metadata.template().method() + " "
-                        + metadata.template().url()
-                            .replace('{', OPEN_BRACE_REPLACEMENT)
-                            .replace('}', CLOSE_BRACE_REPLACEMENT));
+                metadata.template().method() + " " + metadata.template().url()
+                        // escape from feign string interpolation
+                        // See RequestTemplate.expand
+                        .replace("{", "{{"));
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/PathTemplateHeaderEnrichmentContract.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/PathTemplateHeaderEnrichmentContract.java
@@ -10,8 +10,16 @@ import feign.MethodMetadata;
 import java.lang.reflect.Method;
 
 public final class PathTemplateHeaderEnrichmentContract extends AbstractDelegatingContract {
+    /**
+     * No longer used.
+     * @deprecated no longer used
+     */
     @Deprecated
     public static final char OPEN_BRACE_REPLACEMENT = '\0';
+    /**
+     * No longer used.
+     * @deprecated no longer used
+     */
     @Deprecated
     public static final char CLOSE_BRACE_REPLACEMENT = '\1';
 

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/PathTemplateHeaderRewriter.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/PathTemplateHeaderRewriter.java
@@ -16,29 +16,15 @@
 
 package com.palantir.conjure.java.client.jaxrs.feignimpl;
 
-import com.palantir.tracing.okhttp3.OkhttpTraceInterceptor;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
 
+@Deprecated
 public enum PathTemplateHeaderRewriter implements RequestInterceptor {
     INSTANCE;
 
     @Override
     public void apply(RequestTemplate template) {
-        if (template.headers().containsKey(OkhttpTraceInterceptor.PATH_TEMPLATE_HEADER)) {
-            Collection<String> rewrittenHeaders = template.headers().get(OkhttpTraceInterceptor.PATH_TEMPLATE_HEADER)
-                    .stream()
-                    .map(headerValue ->
-                            headerValue.replace(PathTemplateHeaderEnrichmentContract.OPEN_BRACE_REPLACEMENT, '{')
-                                    .replace(PathTemplateHeaderEnrichmentContract.CLOSE_BRACE_REPLACEMENT, '}'))
-                    .collect(Collectors.toList());
-            Map<String, Collection<String>> headers = new HashMap<>(template.headers());
-            headers.put(OkhttpTraceInterceptor.PATH_TEMPLATE_HEADER, rewrittenHeaders);
-            template.headers(headers);
-        }
+        // nop
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/PathTemplateHeaderRewriter.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/PathTemplateHeaderRewriter.java
@@ -19,6 +19,10 @@ package com.palantir.conjure.java.client.jaxrs.feignimpl;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
 
+/**
+ * No longer used.
+ * @deprecated no longer used
+ */
 @Deprecated
 public enum PathTemplateHeaderRewriter implements RequestInterceptor {
     INSTANCE;


### PR DESCRIPTION
Unnecessary for us to un-escape trace operation names for every client request