### PR TITLE
[improvement] Don't ACCEPT_FLOAT_AS_INT

### DIFF
--- a/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
@@ -9,7 +9,6 @@ client:
    - '{"value":8}' # jackson coerces things to other types
    receiveIntegerExample:
    - '{"value":"12"}' # jackson coerces things to other types
-   - '{"value":1.23}' # jackson coerces things to other types
 
    receiveSetStringExample:
    - '{"value":["a","a"]}' # client turns this into a set of ["a"] without error

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -107,6 +107,7 @@ public final class ObjectMappers {
                 .disable(DeserializationFeature.WRAP_EXCEPTIONS)
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
                 .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-                .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
+                .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
+                .disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT);
     }
 }


### PR DESCRIPTION
## Before this PR

Integer fields could be deserialized from floating point values e.g. `123.0` -> `123`.

## After this PR

Floating point JSON values are no longer allowed when an integer is expected.