### PR TITLE
[improvement] Lower read/write timeouts to 5 minutes

### DIFF
--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -38,8 +38,8 @@ public final class ClientConfigurations {
 
     // Defaults for parameters that are optional in ServiceConfiguration.
     private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(10);
-    private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(10);
-    private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMinutes(10);
+    private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration DEFAULT_BACKOFF_SLOT_SIZE = Duration.ofMillis(250);
     private static final Duration DEFAULT_FAILED_URL_COOLDOWN = Duration.ZERO;
     private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = false;

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -51,8 +51,8 @@ public final class ClientConfigurationsTest {
         assertThat(actual.trustManager()).isNotNull();
         assertThat(actual.uris()).isEqualTo(uris);
         assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
-        assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(10));
-        assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(10));
+        assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(5));
         assertThat(actual.enableGcmCipherSuites()).isFalse();
         assertThat(actual.fallbackToCommonNameVerification()).isFalse();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);
@@ -68,8 +68,8 @@ public final class ClientConfigurationsTest {
         assertThat(actual.trustManager()).isEqualTo(trustManager);
         assertThat(actual.uris()).isEqualTo(uris);
         assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
-        assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(10));
-        assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(10));
+        assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(5));
         assertThat(actual.enableGcmCipherSuites()).isFalse();
         assertThat(actual.fallbackToCommonNameVerification()).isFalse();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);


### PR DESCRIPTION
## Before this PR
Generally requests that take >5 minutes are highly likely to be taking so long due to talking to a bad server rather than actually requiring that much time.

## After this PR
We timeout in half the time which means we now expect to get a successful response in half the time.
