### PR TITLE
[improvement] enqueue for concurrency limits in round robin fifo not fifo

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -32,9 +32,7 @@ import com.palantir.tracing.okhttp3.OkhttpTraceInterceptor;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.time.Duration;
-import java.util.ArrayDeque;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -124,7 +122,7 @@ final class ConcurrencyLimiters {
      */
     final class ConcurrencyLimiter {
         @GuardedBy("this")
-        private final Queue<SettableFuture<Limiter.Listener>> waitingRequests = new ArrayDeque<>();
+        private final ThreadWorkQueue<SettableFuture<Limiter.Listener>> waitingRequests = new ThreadWorkQueue<>();
         @GuardedBy("this")
         private Limiter<Void> limiter;
         @GuardedBy("this")

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ThreadWorkQueue.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ThreadWorkQueue.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A 'fair' queue which prioritizes by submitting thread. Requests are executed either synchronously
+ * or asynchronously, more frequently synchronously. In the former case, one will block on the response;
+ * in the latter case, one might submit many requests from a single thread, which if consumed in a fifo
+ * fashion will potentially starve the shared resource.
+ * <p>
+ * Here, we hand out permits in a per-thread fifo, globally round robin fashion, so a thread which makes
+ * many requests will see its requests fairly prioritized behind other threads.
+ */
+@NotThreadSafe
+final class ThreadWorkQueue<T> {
+    private final Set<Long> activeQueuedThreads = new LinkedHashSet<>();
+    private final Map<Long, Queue<T>> queuedRequests = new HashMap<>();
+
+    boolean isEmpty() {
+        return activeQueuedThreads.isEmpty();
+    }
+
+    void add(T element) {
+        long threadId = Thread.currentThread().getId();
+        if (!activeQueuedThreads.contains(threadId)) {
+            activeQueuedThreads.add(threadId);
+        }
+        queue(threadId).add(element);
+    }
+
+    T remove() {
+        long id = nextThread();
+        Queue<T> workQueue = queuedRequests.get(id);
+        T result = workQueue.remove();
+        if (workQueue.isEmpty()) {
+            queuedRequests.remove(id);
+        } else {
+            activeQueuedThreads.add(id);
+        }
+        return result;
+    }
+
+    private long nextThread() {
+        Iterator<Long> iterator = activeQueuedThreads.iterator();
+        long result = iterator.next();
+        iterator.remove();
+        return result;
+    }
+
+    private Queue<T> queue(long id) {
+        return queuedRequests.computeIfAbsent(id, key -> new ArrayDeque<>(2));
+    }
+}

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ThreadWorkQueueTests.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ThreadWorkQueueTests.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.junit.Test;
+
+public final class ThreadWorkQueueTests {
+    private final ThreadWorkQueue<Integer> queue = new ThreadWorkQueue<>();
+
+    @Test
+    public void testPrioritizesPerThread() throws InterruptedException {
+        queue.add(1);
+        enqueueWithNewThread(2, 3, 4);
+        enqueueWithNewThread(5, 6, 7);
+        queue.add(8);
+        assertThat(dequeue()).containsExactly(1, 2, 5, 8, 3, 6, 4, 7);
+    }
+
+    @Test
+    public void testThrowsIfEmpty() {
+        assertThatExceptionOfType(NoSuchElementException.class)
+                .isThrownBy(queue::remove);
+    }
+
+    private List<Integer> dequeue() {
+        List<Integer> result = new ArrayList<>();
+        while (!queue.isEmpty()) {
+            result.add(queue.remove());
+        }
+        return result;
+    }
+
+    private void enqueueWithNewThread(int... numbers) throws InterruptedException {
+        Thread thread = new Thread(() -> Arrays.stream(numbers).forEach(queue::add));
+        thread.start();
+        thread.join();
+    }
+}

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ThreadWorkQueueTests.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ThreadWorkQueueTests.java
@@ -43,6 +43,17 @@ public final class ThreadWorkQueueTests {
                 .isThrownBy(queue::remove);
     }
 
+    @Test
+    public void testFifoEvenWhileTotallyDequeued() throws InterruptedException {
+        queue.add(1);
+        enqueueWithNewThread(2, 3);
+        assertThat(queue.remove()).isEqualTo(1);
+        assertThat(queue.remove()).isEqualTo(2);
+        queue.add(4);
+        assertThat(queue.remove()).isEqualTo(3);
+        assertThat(queue.remove()).isEqualTo(4);
+    }
+
     private List<Integer> dequeue() {
         List<Integer> result = new ArrayList<>();
         while (!queue.isEmpty()) {


### PR DESCRIPTION
Fifo allows for serious starvation issues; i.e. if a single thread
enqueues 50k requests, it'll be scheduled as the next 50k requests to be
sent; a thread which enqueues in the meantime will have to wait.

This PR means that we will round robin between threads, serving the
requests in fifo order.

For feign clients this will change absolutely nothing, since they are
synchronous. For retrofit clients (of which we have maybe 2) this will
dramatically improve _fairness_; a background task spamming requests
will not be able to totally starve the limiters.