### PR TITLE
[improvement] Improve exceptions and logging when retrying

### DIFF
--- a/okhttp-clients/build.gradle
+++ b/okhttp-clients/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
     testImplementation project(":conjure-java-jersey-server")
     testImplementation project(":keystores")
+    testImplementation 'com.palantir.safe-logging:preconditions-assertj'
     testImplementation "com.squareup.okhttp3:mockwebserver"
     testImplementation "javax.ws.rs:javax.ws.rs-api"
     testImplementation "junit:junit"

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -26,6 +26,8 @@ import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIoException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.time.Duration;
@@ -175,24 +177,31 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 // Fail call if backoffs are exhausted or if no retry URL can be determined.
                 Optional<Duration> backoff = backoffStrategy.nextBackoff();
                 if (!backoff.isPresent()) {
-                    callback.onFailure(call, new IOException("Failed to complete the request due to an "
-                            + "IOException", exception));
-                    return;
-                }
-                Optional<HttpUrl> redirectTo = urls.redirectToNext(request().url());
-                if (!redirectTo.isPresent()) {
-                    callback.onFailure(call, new IOException("Failed to determine valid failover URL for '"
-                            + request().url() + "' and base URLs " + urls.getBaseUrls()));
+                    callback.onFailure(call, new SafeIoException(
+                            "Failed to complete the request due to an IOException",
+                            exception,
+                            UnsafeArg.of("requestUrl", call.request().url().toString())));
                     return;
                 }
 
+                Optional<HttpUrl> redirectTo = urls.redirectToNext(request().url());
+                if (!redirectTo.isPresent()) {
+                    callback.onFailure(call, new SafeIoException(
+                            "Failed to determine valid failover URL",
+                            exception,
+                            UnsafeArg.of("requestUrl", call.request().url().toString()),
+                            UnsafeArg.of("baseUrls", urls.getBaseUrls())));
+                    return;
+                }
+
+                log.info("Retrying call after failure",
+                        SafeArg.of("backoffMillis", backoff.get().toMillis()),
+                        exception);
                 Request redirectedRequest = request().newBuilder()
                         .url(redirectTo.get())
                         .build();
                 RemotingOkHttpCall retryCall =
                         client.newCallWithMutableState(redirectedRequest, backoffStrategy, maxNumRelocations - 1);
-                log.debug("Rescheduling call after backoff", SafeArg.of("backoffMillis", backoff.get().toMillis()),
-                        exception);
                 scheduleExecution(() -> retryCall.enqueue(callback), backoff.get());
             }
 
@@ -258,13 +267,16 @@ final class RemotingOkHttpCall extends ForwardingCall {
             public Void visit(QosException.Throttle exception) {
                 Optional<Duration> nonAdvertizedBackoff = backoffStrategy.nextBackoff();
                 if (!nonAdvertizedBackoff.isPresent()) {
-                    callback.onFailure(call, new IOException("Failed to reschedule call since "
-                            + "the number of configured backoffs are exhausted", exception));
+                    callback.onFailure(call, new SafeIoException(
+                            "Failed to complete the request due to QoS throttle",
+                            exception,
+                            UnsafeArg.of("requestUrl", call.request().url().toString())));
                     return null;
                 }
 
                 Duration backoff = exception.getRetryAfter().orElse(nonAdvertizedBackoff.get());
-                log.debug("Rescheduling call after backoff", SafeArg.of("backoffMillis", backoff.toMillis()),
+                log.debug("Rescheduling call after receiving QoS throttle",
+                        SafeArg.of("backoffMillis", backoff.toMillis()),
                         exception);
                 scheduleExecution(() -> doClone().enqueue(callback), backoff);
                 return null;
@@ -273,23 +285,33 @@ final class RemotingOkHttpCall extends ForwardingCall {
             @Override
             public Void visit(QosException.RetryOther exception) {
                 if (maxNumRelocations <= 0) {
-                    callback.onFailure(call, new IOException("Exceeded the maximum number of allowed redirects for "
-                            + "initial URL: " + call.request().url()));
-                } else {
-                    // Redirect to the URL specified by the exception.
-                    Optional<HttpUrl> redirectTo = urls.redirectTo(request().url(),
-                            exception.getRedirectTo().toString());
-                    if (!redirectTo.isPresent()) {
-                        callback.onFailure(call, new IOException("Failed to determine valid redirect URL for '"
-                                + exception.getRedirectTo() + "' and base URLs " + urls.getBaseUrls()));
-                    } else {
-                        Request redirectedRequest = request().newBuilder()
-                                .url(redirectTo.get())
-                                .build();
-                        client.newCallWithMutableState(redirectedRequest, backoffStrategy, maxNumRelocations - 1)
-                                .enqueue(callback);
-                    }
+                    callback.onFailure(call, new SafeIoException(
+                            "Exceeded the maximum number of allowed redirects",
+                            exception,
+                            UnsafeArg.of("requestUrl", call.request().url().toString())));
+                    return null;
                 }
+
+                // Redirect to the URL specified by the exception.
+                Optional<HttpUrl> redirectTo = urls.redirectTo(request().url(), exception.getRedirectTo().toString());
+                if (!redirectTo.isPresent()) {
+                    callback.onFailure(call, new SafeIoException(
+                            "Failed to determine valid redirect URL after receiving QoS retry other",
+                            exception,
+                            UnsafeArg.of("requestUrl", call.request().url().toString()),
+                            UnsafeArg.of("redirectToUrl", exception.getRedirectTo().toString()),
+                            UnsafeArg.of("baseUrls", urls.getBaseUrls())));
+                    return null;
+                }
+
+                log.debug("Retrying call after receiving retry other",
+                        UnsafeArg.of("requestUrl", call.request().url()),
+                        exception);
+                Request redirectedRequest = request().newBuilder()
+                        .url(redirectTo.get())
+                        .build();
+                client.newCallWithMutableState(redirectedRequest, backoffStrategy, maxNumRelocations - 1)
+                        .enqueue(callback);
                 return null;
             }
 
@@ -297,26 +319,31 @@ final class RemotingOkHttpCall extends ForwardingCall {
             public Void visit(QosException.Unavailable exception) {
                 Optional<Duration> backoff = backoffStrategy.nextBackoff();
                 if (!backoff.isPresent()) {
-                    log.debug("Max number of retries exceeded, failing call");
-                    callback.onFailure(call,
-                            new IOException("Failed to complete the request due to a "
-                                    + "server-side QoS condition: 503", exception));
-                } else {
-                    log.debug("Rescheduling call after backoff",
-                            SafeArg.of("backoffMillis", backoff.get().toMillis()), exception);
-                    // Redirect to the "next" URL, whichever that may be, after backing off.
-                    Optional<HttpUrl> redirectTo = urls.redirectToNext(request().url());
-                    if (!redirectTo.isPresent()) {
-                        callback.onFailure(call, new IOException("Failed to determine valid redirect URL for base "
-                                + "URLs " + urls.getBaseUrls()));
-                    } else {
-                        Request redirectedRequest = request().newBuilder()
-                                .url(redirectTo.get())
-                                .build();
-                        scheduleExecution(() -> client.newCallWithMutableState(redirectedRequest, backoffStrategy,
-                                maxNumRelocations).enqueue(callback), backoff.get());
-                    }
+                    callback.onFailure(call, new SafeIoException(
+                            "Failed to complete the request due to QoS unavailable",
+                            exception,
+                            UnsafeArg.of("requestUrl", call.request().url().toString())));
+                    return null;
                 }
+
+                // Redirect to the "next" URL, whichever that may be, after backing off.
+                Optional<HttpUrl> redirectTo = urls.redirectToNext(request().url());
+                if (!redirectTo.isPresent()) {
+                    callback.onFailure(call, new SafeIoException(
+                            "Failed to determine valid redirect URL after receiving QoS unavailable",
+                            UnsafeArg.of("requestUrl", call.request().url().toString()),
+                            UnsafeArg.of("baseUrls", urls.getBaseUrls())));
+                    return null;
+                }
+
+                log.debug("Retrying call after receiving QoS unavailable",
+                        SafeArg.of("backoffMillis", backoff.get().toMillis()),
+                        exception);
+                Request redirectedRequest = request().newBuilder()
+                        .url(redirectTo.get())
+                        .build();
+                scheduleExecution(() -> client.newCallWithMutableState(redirectedRequest, backoffStrategy,
+                        maxNumRelocations).enqueue(callback), backoff.get());
                 return null;
             }
         };

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -268,14 +268,14 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 Optional<Duration> nonAdvertizedBackoff = backoffStrategy.nextBackoff();
                 if (!nonAdvertizedBackoff.isPresent()) {
                     callback.onFailure(call, new SafeIoException(
-                            "Failed to complete the request due to QoS throttle",
+                            "Failed to complete the request due to QosException.Throttle",
                             exception,
                             UnsafeArg.of("requestUrl", call.request().url().toString())));
                     return null;
                 }
 
                 Duration backoff = exception.getRetryAfter().orElse(nonAdvertizedBackoff.get());
-                log.debug("Rescheduling call after receiving QoS throttle",
+                log.debug("Rescheduling call after receiving QosException.Throttle",
                         SafeArg.of("backoffMillis", backoff.toMillis()),
                         exception);
                 scheduleExecution(() -> doClone().enqueue(callback), backoff);
@@ -296,7 +296,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 Optional<HttpUrl> redirectTo = urls.redirectTo(request().url(), exception.getRedirectTo().toString());
                 if (!redirectTo.isPresent()) {
                     callback.onFailure(call, new SafeIoException(
-                            "Failed to determine valid redirect URL after receiving QoS retry other",
+                            "Failed to determine valid redirect URL after receiving QosException.RetryOther",
                             exception,
                             UnsafeArg.of("requestUrl", call.request().url().toString()),
                             UnsafeArg.of("redirectToUrl", exception.getRedirectTo().toString()),
@@ -304,7 +304,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
                     return null;
                 }
 
-                log.debug("Retrying call after receiving retry other",
+                log.debug("Retrying call after receiving QosException.RetryOther",
                         UnsafeArg.of("requestUrl", call.request().url()),
                         exception);
                 Request redirectedRequest = request().newBuilder()
@@ -320,7 +320,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 Optional<Duration> backoff = backoffStrategy.nextBackoff();
                 if (!backoff.isPresent()) {
                     callback.onFailure(call, new SafeIoException(
-                            "Failed to complete the request due to QoS unavailable",
+                            "Failed to complete the request due to QosException.Unavailable",
                             exception,
                             UnsafeArg.of("requestUrl", call.request().url().toString())));
                     return null;
@@ -330,13 +330,13 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 Optional<HttpUrl> redirectTo = urls.redirectToNext(request().url());
                 if (!redirectTo.isPresent()) {
                     callback.onFailure(call, new SafeIoException(
-                            "Failed to determine valid redirect URL after receiving QoS unavailable",
+                            "Failed to determine valid redirect URL after receiving QosException.Unavailable",
                             UnsafeArg.of("requestUrl", call.request().url().toString()),
                             UnsafeArg.of("baseUrls", urls.getBaseUrls())));
                     return null;
                 }
 
-                log.debug("Retrying call after receiving QoS unavailable",
+                log.debug("Retrying call after receiving QosException.Unavailable",
                         SafeArg.of("backoffMillis", backoff.get().toMillis()),
                         exception);
                 Request redirectedRequest = request().newBuilder()

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -232,7 +232,7 @@ public final class OkHttpClientsTest extends TestBase {
         call = createRetryingClient(0).newCall(new Request.Builder().url(url).build());
         assertThatLoggableExceptionThrownBy(call::execute)
                 .isInstanceOf(SafeIoException.class)
-                .hasLogMessage("Failed to complete the request due to QoS unavailable")
+                .hasLogMessage("Failed to complete the request due to QosException.Unavailable")
                 .hasArgs(UnsafeArg.of("requestUrl", url + "/"));
 
         server.enqueue(new MockResponse().setResponseCode(503));
@@ -241,7 +241,7 @@ public final class OkHttpClientsTest extends TestBase {
         call = createRetryingClient(2).newCall(new Request.Builder().url(url).build());
         assertThatLoggableExceptionThrownBy(call::execute)
                 .isInstanceOf(SafeIoException.class)
-                .hasLogMessage("Failed to complete the request due to QoS unavailable")
+                .hasLogMessage("Failed to complete the request due to QosException.Unavailable")
                 .hasArgs(UnsafeArg.of("requestUrl", url + "/"));
 
         assertThat(server.getRequestCount()).isEqualTo(4 /* original plus two retries */);
@@ -266,7 +266,7 @@ public final class OkHttpClientsTest extends TestBase {
         call = createRetryingClient(0).newCall(new Request.Builder().url(url).build());
         assertThatLoggableExceptionThrownBy(call::execute)
                 .isInstanceOf(SafeIoException.class)
-                .hasLogMessage("Failed to complete the request due to QoS throttle")
+                .hasLogMessage("Failed to complete the request due to QosException.Throttle")
                 .hasArgs(UnsafeArg.of("requestUrl", url + "/"));
 
         server.enqueue(new MockResponse().setResponseCode(429));
@@ -275,7 +275,7 @@ public final class OkHttpClientsTest extends TestBase {
         call = createRetryingClient(2).newCall(new Request.Builder().url(url).build());
         assertThatLoggableExceptionThrownBy(call::execute)
                 .isInstanceOf(SafeIoException.class)
-                .hasLogMessage("Failed to complete the request due to QoS throttle")
+                .hasLogMessage("Failed to complete the request due to QosException.Throttle")
                 .hasArgs(UnsafeArg.of("requestUrl", url + "/"));
 
         assertThat(server.getRequestCount()).isEqualTo(4 /* original plus two retries */);
@@ -289,7 +289,7 @@ public final class OkHttpClientsTest extends TestBase {
         Call call = createRetryingClient(2).newCall(new Request.Builder().url(url).build());
         assertThatLoggableExceptionThrownBy(call::execute)
                 .isInstanceOf(SafeIoException.class)
-                .hasLogMessage("Failed to complete the request due to QoS throttle")
+                .hasLogMessage("Failed to complete the request due to QosException.Throttle")
                 .hasArgs(UnsafeArg.of("requestUrl", url + "/"));
         assertThat(server.getRequestCount()).isEqualTo(3 /* original plus two retries */);
     }
@@ -326,7 +326,7 @@ public final class OkHttpClientsTest extends TestBase {
         call = createRetryingClient(0).newCall(new Request.Builder().url(url).build());
         assertThatLoggableExceptionThrownBy(call::execute)
                 .isInstanceOf(SafeIoException.class)
-                .hasLogMessage("Failed to complete the request due to QoS throttle")
+                .hasLogMessage("Failed to complete the request due to QosException.Throttle")
                 .hasArgs(UnsafeArg.of("requestUrl", url + "/"));
     }
 


### PR DESCRIPTION
## Before this PR
- Request failures were logged at the `debug` level
- Nothing was logged when handling a `RetryOther` QoS response
- The message "Rescheduling call after backoff" was logged when retrying requests for different reasons
- `IOException` was used to indicate failures

## After this PR
- Request failures are logged at the `info` level
- Log when handling any QoS response
- Use unique, descriptive messages when retrying requests
- Use `SafeIoException` to indicate failures

Logging request failures at the info level is the primary motivation of this PR. Without this there is no indication when requests fail.

cc @pnepywoda