### PR TITLE
Do not propagate RemoteException parameters

### DIFF
--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
@@ -62,11 +62,10 @@ final class RemoteExceptionMapper implements ExceptionMapper<RemoteException> {
         ErrorType errorType = ErrorType.INTERNAL;
         Response.ResponseBuilder builder = Response.status(errorType.httpErrorCode());
         try {
-            // Override only the name and code of the error
             SerializableError error = SerializableError.builder()
-                    .from(exception.getError())
                     .errorName(errorType.name())
                     .errorCode(errorType.code().toString())
+                    .errorInstanceId(exception.getError().errorInstanceId())
                     .build();
             builder.type(MediaType.APPLICATION_JSON);
             builder.entity(error);

--- a/readme.md
+++ b/readme.md
@@ -284,7 +284,7 @@ The workflow is:
  - The client sees a `RemoteException`, which contains the `SerializableError` which was sent over the wire
  - The client can inspect the `SerializableError` and choose to act
  - If the client is itself a server and does not handle the `RemoteException`, a `SerializableError` error will be sent
-   as the response with and `errorCode` of ``INTERNAL`, `errorName` of `Default:Internal`, the same `errorInstanceId` as
+   as the response with and `errorCode` of `INTERNAL`, `errorName` of `Default:Internal`, the same `errorInstanceId` as
    the original `RemoteException` and no `parameters`.
 
 #### Serialization of Optional and Nullable objects

--- a/readme.md
+++ b/readme.md
@@ -283,7 +283,9 @@ The workflow is:
    - serializes this into the response body as JSON
  - The client sees a `RemoteException`, which contains the `SerializableError` which was sent over the wire
  - The client can inspect the `SerializableError` and choose to act
- - If the client is itself a server, does not handle the exception and just re-throws the `RemoteException`, the `RemoteException` will be propagated i.e. re-serialized as its own erroneous response
+ - If the client is itself a server and does not handle the `RemoteException`, a `SerializableError` error will be sent
+   as the response with and `errorCode` of ``INTERNAL`, `errorName` of `Default:Internal`, the same `errorInstanceId` as
+   the original `RemoteException` and no `parameters`.
 
 #### Serialization of Optional and Nullable objects
 `@Nullable` or `Optional<?>` fields in complex types are serialized using the standard Jackson mechanism:


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
RemoteExceptionMapper would override the errorName and errorCode of the propagated SerializableError, but keep the original parameters. Docs were also misleading.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
Original parameters are not propagated and docs are fixed