### PR TITLE
[improvement] Decode null response body with text/plain as empty string

### DIFF
--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureTextDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureTextDelegateDecoder.java
@@ -49,7 +49,11 @@ public final class ConjureTextDelegateDecoder implements Decoder {
         }
         // In the case of multiple content types, or an unknown content type, we'll use the delegate instead.
         if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").startsWith(MediaType.TEXT_PLAIN)) {
-            return stringDecoder.decode(response, type);
+            Object decoded = stringDecoder.decode(response, type);
+            if (decoded == null) {
+                return "";
+            }
+            return decoded;
         }
 
         return delegate.decode(response, type);

--- a/conjure-java-jaxrs-client/src/test/java/feign/ConjureTextDelegateDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/feign/ConjureTextDelegateDecoderTest.java
@@ -115,6 +115,16 @@ public final class ConjureTextDelegateDecoderTest extends TestBase {
     }
 
     @Test
+    public void testReturnsEmptyStringForNullResponseBodyWithTextPlain() throws Exception {
+        headers.put(HttpHeaders.CONTENT_TYPE, ImmutableSet.of(MediaType.TEXT_PLAIN));
+        Response response = Response.create(200, "OK", headers, null, StandardCharsets.UTF_8);
+        Object decodedObject = textDelegateDecoder.decode(response, String.class);
+
+        assertEquals("", decodedObject);
+        verifyZeroInteractions(delegate);
+    }
+
+    @Test
     public void testUsesDelegateWithNoHeader() throws Exception {
         when(delegate.decode(any(), any())).thenReturn(DELEGATE_RESPONSE);
         Response response = Response.create(200, "OK", headers, new byte[0]);


### PR DESCRIPTION
## Before this PR
Conjure JaxRS client throws exception if the response with type text/plain has null body. 

## After this PR
Response with type text/plain with null body is now decoded as empty string.