### PR TITLE
[fix] Move ConjureTextDelegateDecoder first, allowing it to return null

### DIFF
--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -119,17 +119,17 @@ abstract class AbstractFeignJaxRsClientBuilder {
     }
 
     private static Decoder createDecoder(ObjectMapper objectMapper, ObjectMapper cborObjectMapper) {
-        // The ConjureTextDelegateDecoder is allowed to return null
-        // This is to support older endpoints that are not conjure-generated
-        return new ConjureTextDelegateDecoder(
-                new ConjureNeverReturnNullDecoder(
-                new ConjureJava8OptionalAwareDecoder(
-                        new ConjureGuavaOptionalAwareDecoder(
-                                new ConjureEmptyContainerDecoder(
-                                        objectMapper,
-                                        new ConjureInputStreamDelegateDecoder(
-                                                new ConjureCborDelegateDecoder(
-                                                        cborObjectMapper,
-                                                        new JacksonDecoder(objectMapper))))))));
+        return new ConjureJava8OptionalAwareDecoder(
+                new ConjureGuavaOptionalAwareDecoder(
+                        // The ConjureTextDelegateDecoder is allowed to return null
+                        // This is to support older endpoints that are not conjure-generated
+                        new ConjureTextDelegateDecoder(
+                                new ConjureNeverReturnNullDecoder(
+                                        new ConjureEmptyContainerDecoder(
+                                                objectMapper,
+                                                new ConjureInputStreamDelegateDecoder(
+                                                        new ConjureCborDelegateDecoder(
+                                                                cborObjectMapper,
+                                                                new JacksonDecoder(objectMapper))))))));
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -119,15 +119,17 @@ abstract class AbstractFeignJaxRsClientBuilder {
     }
 
     private static Decoder createDecoder(ObjectMapper objectMapper, ObjectMapper cborObjectMapper) {
-        return new ConjureNeverReturnNullDecoder(
+        // The ConjureTextDelegateDecoder is allowed to return null
+        // This is to support older endpoints that are not conjure-generated
+        return new ConjureTextDelegateDecoder(
+                new ConjureNeverReturnNullDecoder(
                 new ConjureJava8OptionalAwareDecoder(
                         new ConjureGuavaOptionalAwareDecoder(
                                 new ConjureEmptyContainerDecoder(
                                         objectMapper,
                                         new ConjureInputStreamDelegateDecoder(
-                                                new ConjureTextDelegateDecoder(
-                                                        new ConjureCborDelegateDecoder(
-                                                                cborObjectMapper,
-                                                                new JacksonDecoder(objectMapper))))))));
+                                                new ConjureCborDelegateDecoder(
+                                                        cborObjectMapper,
+                                                        new JacksonDecoder(objectMapper))))))));
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureTextDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureTextDelegateDecoder.java
@@ -48,7 +48,10 @@ public final class ConjureTextDelegateDecoder implements Decoder {
             contentTypes = ImmutableSet.of();
         }
         // In the case of multiple content types, or an unknown content type, we'll use the delegate instead.
-        if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").startsWith(MediaType.TEXT_PLAIN)) {
+        boolean acceptsString = type instanceof Class && ((Class<?>) type).isAssignableFrom(String.class);
+        if (acceptsString
+                && contentTypes.size() == 1
+                && Iterables.getOnlyElement(contentTypes, "").startsWith(MediaType.TEXT_PLAIN)) {
             return stringDecoder.decode(response, type);
         }
 

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientTextPlainHandlingTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientTextPlainHandlingTest.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import feign.codec.DecodeException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class JaxRsClientTextPlainHandlingTest extends TestBase {
+    @Rule
+    public final MockWebServer server = new MockWebServer();
+
+    private Service proxy;
+
+    @Before
+    public void before() {
+        proxy = JaxRsClient.create(Service.class,
+                AGENT,
+                new HostMetricsRegistry(),
+                createTestConfig("http://localhost:" + server.getPort()));
+    }
+
+    @Path("/")
+    public interface Service {
+        @GET
+        String textString();
+
+        @GET
+        Object textObject();
+
+        @GET
+        Integer textInteger();
+    }
+
+    @Test
+    public void testEmptyTextPlainString() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(Status.NO_CONTENT.getStatusCode())
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN));
+        assertThat(proxy.textString()).isNull();
+    }
+
+    @Test
+    public void testEmptyTextPlainObject() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(Status.NO_CONTENT.getStatusCode())
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN));
+        assertThat(proxy.textObject()).isNull();
+    }
+
+    @Test
+    public void testEmptyTextPlainInteger() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(Status.NO_CONTENT.getStatusCode())
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN));
+        assertThatCode(() -> proxy.textInteger()).isInstanceOf(DecodeException.class)
+                .hasMessageContaining("unable to construct an empty instance for return type");
+    }
+}


### PR DESCRIPTION
## Before this PR

conjure-java-runtime currently has some special handling for endpoints marked with `@Produces(MediaType.TEXT_PLAIN)` that return String.
This is a kind of endpoint that is not generated by conjure, but supported by the feign client for historical reasons.

Such an endpoint might respond with a 204 (NO CONTENT), but that would currently throw because the `ConjureNeverReturnNullDecoder` sits at the top of the decoder stack.

## After this PR

Don't apply the `ConjureNeverReturnNullDecoder` to such endpoints as described above.

These are not endpoints that conjure would generate, so it seems acceptable to relax the null safety on them.

We still want the null safety to apply to endpoints that could be generated by conjure, since we know that conjure servers should not permit unexpected null/empty responses, but not to other kinds of endpoints that the feign client supports for historical reasons.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
