### PR TITLE
[improvement] add bean validation + test that we handle `@NotNull` request bodies appropriately

### DIFF
--- a/conjure-java-jersey-server/build.gradle
+++ b/conjure-java-jersey-server/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     implementation "com.palantir.safe-logging:safe-logging"
     implementation "com.palantir.tracing:tracing-jersey"
 
+    runtimeOnly "org.glassfish.jersey.ext:jersey-bean-validation"
+
     testImplementation project(':conjure-java-jackson-serialization')
     testImplementation "com.fasterxml.jackson.core:jackson-databind"
     testImplementation "com.palantir.tracing:tracing"

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/NullRequestBodyTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/NullRequestBodyTest.java
@@ -1,0 +1,143 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.server.jersey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class NullRequestBodyTest {
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> APP = new DropwizardAppRule<>(
+            TestServer.class,
+            "src/test/resources/test-server.yml");
+
+    private WebTarget target;
+
+    @Before
+    public void before() {
+        String endpointUri = "http://localhost:" + APP.getLocalPort();
+        JerseyClientBuilder builder = new JerseyClientBuilder();
+        Client client = builder.build();
+        target = client.target(endpointUri);
+    }
+
+    @Test
+    public void testEmptyRequestBody() {
+        Entity empty = Entity.entity(null, MediaType.APPLICATION_JSON);
+
+        // this endpoint does not have any annotation
+        Response postResponse = target.path("post")
+                .request()
+                .post(empty);
+        assertThat(postResponse.getStatus()).isEqualTo(204);
+
+        // this endpoint has the @NotNull annotation
+        Response postNotNullResponse = target.path("post-not-null")
+                .request()
+                .post(empty);
+        assertThat(postNotNullResponse.getStatus()).isEqualTo(422);
+    }
+
+    @Test
+    public void testExplicitlyNullRequestBody() {
+        Entity explicitlyNull = Entity.entity("null", MediaType.APPLICATION_JSON);
+
+        // this endpoint does not have any annotation
+        Response postResponse = target.path("post")
+                .request()
+                .post(explicitlyNull);
+        assertThat(postResponse.getStatus()).isEqualTo(204);
+
+        // this endpoint has the @NotNull annotation
+        Response postNotNullResponse = target.path("post-not-null")
+                .request()
+                .post(explicitlyNull);
+        assertThat(postNotNullResponse.getStatus()).isEqualTo(422);
+    }
+
+    @Test
+    public void testNonNullRequestBody() {
+        Entity emptyMap = Entity.entity(ImmutableMap.of(), MediaType.APPLICATION_JSON);
+
+        // this endpoint's handler method does not throw
+        Response postResponse = target.path("post")
+                .request()
+                .post(emptyMap);
+        System.out.println(postResponse);
+        assertThat(postResponse.getStatus()).isEqualTo(204);
+
+        // this endpoint's handler method throws -> 500
+        Response postNotNullResponse = target.path("post-not-null")
+                .request()
+                .post(emptyMap);
+        assertThat(postNotNullResponse.getStatus()).isEqualTo(500);
+    }
+
+    public static class TestServer extends Application<Configuration> {
+        @Override
+        public final void run(Configuration config, final Environment env) throws Exception {
+            env.jersey().register(ConjureJerseyFeature.INSTANCE);
+            env.jersey().register(new TestResource());
+        }
+    }
+
+    public static final class TestResource implements TestService {
+        @Override
+        public void postRequestBody(Map<String, String> data) {
+
+        }
+
+        @Override
+        public void postRequestBodyNotNull(Map<String, String> data) {
+            throw new RuntimeException("oh no");
+        }
+    }
+
+    @Path("/")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public interface TestService {
+
+        @POST
+        @Path("/post")
+        void postRequestBody(Map<String, String> data);
+
+        @POST
+        @Path("/post-not-null")
+        void postRequestBodyNotNull(@NotNull Map<String, String> data);
+    }
+}

--- a/conjure-java-jersey-server/versions.lock
+++ b/conjure-java-jersey-server/versions.lock
@@ -363,6 +363,12 @@
                 "com.fasterxml.jackson.jaxrs:jackson-jaxrs-cbor-provider"
             ]
         },
+        "com.fasterxml:classmate": {
+            "locked": "1.0.0",
+            "transitive": [
+                "org.hibernate:hibernate-validator"
+            ]
+        },
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.2",
             "transitive": [
@@ -435,6 +441,13 @@
                 "org.glassfish.jersey.core:jersey-server"
             ]
         },
+        "javax.el:javax.el-api": {
+            "locked": "2.2.4",
+            "transitive": [
+                "org.glassfish.jersey.ext:jersey-bean-validation",
+                "org.glassfish.web:javax.el"
+            ]
+        },
         "javax.inject:javax.inject": {
             "locked": "1",
             "transitive": [
@@ -445,7 +458,9 @@
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
+                "org.glassfish.jersey.core:jersey-server",
+                "org.glassfish.jersey.ext:jersey-bean-validation",
+                "org.hibernate:hibernate-validator"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -453,7 +468,8 @@
             "transitive": [
                 "org.glassfish.jersey.core:jersey-client",
                 "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "org.glassfish.jersey.core:jersey-server",
+                "org.glassfish.jersey.ext:jersey-bean-validation"
             ]
         },
         "org.checkerframework:checker-compat-qual": {
@@ -482,6 +498,7 @@
                 "org.glassfish.jersey.core:jersey-client",
                 "org.glassfish.jersey.core:jersey-common",
                 "org.glassfish.jersey.core:jersey-server",
+                "org.glassfish.jersey.ext:jersey-bean-validation",
                 "org.glassfish.jersey.media:jersey-media-jaxb"
             ]
         },
@@ -535,14 +552,19 @@
             "transitive": [
                 "org.glassfish.jersey.core:jersey-client",
                 "org.glassfish.jersey.core:jersey-server",
+                "org.glassfish.jersey.ext:jersey-bean-validation",
                 "org.glassfish.jersey.media:jersey-media-jaxb"
             ]
         },
         "org.glassfish.jersey.core:jersey-server": {
             "locked": "2.25.1",
             "transitive": [
-                "com.palantir.tracing:tracing-jersey"
+                "com.palantir.tracing:tracing-jersey",
+                "org.glassfish.jersey.ext:jersey-bean-validation"
             ]
+        },
+        "org.glassfish.jersey.ext:jersey-bean-validation": {
+            "locked": "2.25.1"
         },
         "org.glassfish.jersey.media:jersey-media-jaxb": {
             "locked": "2.25.1",
@@ -550,10 +572,28 @@
                 "org.glassfish.jersey.core:jersey-server"
             ]
         },
+        "org.glassfish.web:javax.el": {
+            "locked": "2.2.4",
+            "transitive": [
+                "org.glassfish.jersey.ext:jersey-bean-validation"
+            ]
+        },
+        "org.hibernate:hibernate-validator": {
+            "locked": "5.1.3.Final",
+            "transitive": [
+                "org.glassfish.jersey.ext:jersey-bean-validation"
+            ]
+        },
         "org.javassist:javassist": {
             "locked": "3.20.0-GA",
             "transitive": [
                 "org.glassfish.hk2:hk2-locator"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.1.3.GA",
+            "transitive": [
+                "org.hibernate:hibernate-validator"
             ]
         },
         "org.slf4j:slf4j-api": {


### PR DESCRIPTION
## Before this PR
In some places where we take a dependency on conjure-java-jersey-server we layer resource classes. Some of these layers make assumptions that the request body parameters are not null (and fail if this is not the case).

## After this PR
By adding jersey-bean-validation we ensure that request handler methods annotating their parameters as `@NotNull` do not get called with null parameters. Instead the request is rejected at the jersey layer.