### PR TITLE
[improvement] Lower read and write timeouts

### DIFF
--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -38,8 +38,8 @@ public final class ClientConfigurations {
 
     // Defaults for parameters that are optional in ServiceConfiguration.
     private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(10);
-    private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(5);
-    private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(2);
+    private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMinutes(2);
     private static final Duration DEFAULT_BACKOFF_SLOT_SIZE = Duration.ofMillis(250);
     private static final Duration DEFAULT_FAILED_URL_COOLDOWN = Duration.ZERO;
     private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = false;

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -51,8 +51,8 @@ public final class ClientConfigurationsTest {
         assertThat(actual.trustManager()).isNotNull();
         assertThat(actual.uris()).isEqualTo(uris);
         assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
-        assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(5));
-        assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(2));
+        assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(2));
         assertThat(actual.enableGcmCipherSuites()).isFalse();
         assertThat(actual.fallbackToCommonNameVerification()).isFalse();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);
@@ -68,8 +68,8 @@ public final class ClientConfigurationsTest {
         assertThat(actual.trustManager()).isEqualTo(trustManager);
         assertThat(actual.uris()).isEqualTo(uris);
         assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
-        assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(5));
-        assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(2));
+        assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(2));
         assertThat(actual.enableGcmCipherSuites()).isFalse();
         assertThat(actual.fallbackToCommonNameVerification()).isFalse();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);


### PR DESCRIPTION
## Before this PR
Single faulty nodes continue to cause consumers to grind to halt as they wait for requests to timeout. 

## After this PR
Lowering this again means we are more quickly able to detect faulty nodes and recover by failing over to healthy nodes.

Previous PR lowering timeouts: https://github.com/palantir/conjure-java-runtime/pull/924