### PR TITLE
[break][improvement] Deserialize List, Map, and Set to guava immutable implementations

### DIFF
--- a/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
@@ -43,6 +43,7 @@ client:
    - 'null'
    receiveListAnyAliasExample:
    - 'null'
+   - '[null, 0, "content", true, [1,2,3], {"key":3}]' # null is not a valid any value, see conjure-verification#141
    receiveSetBearerTokenAliasExample:
    - 'null'
    receiveSetBinaryAliasExample:
@@ -65,13 +66,11 @@ client:
    - 'null'
    receiveSetAnyAliasExample:
    - 'null'
+   - '[null, 0, "content", true, [1,2,3], {"key":3}]' # null is not a valid any value, see conjure-verification#141
 
    receiveMapBinaryAliasExample:
    - '{}'
    - '{"SGVsbG8sIFdvcmxk": true}'
-   receiveMapDoubleAliasExample:
-   - '{"10": true, "10e0": false}'
-   - '{"10": true, "10.0": false}'
 
   singleHeaderService: {}
 

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ImmutableCollectionsModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ImmutableCollectionsModule.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.serialization;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Values deserialized into {@link List}, {@link Set}, and {@link Map}, use Guava implementations of
+ * {@link ImmutableList}, {@link ImmutableSet}, and {@link ImmutableMap} respectively.
+ */
+final class ImmutableCollectionsModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
+
+    ImmutableCollectionsModule() {
+        super(ImmutableCollectionsModule.class.getCanonicalName());
+        addAbstractTypeMapping(List.class, ImmutableList.class);
+        addAbstractTypeMapping(Map.class, ImmutableMap.class);
+        addAbstractTypeMapping(Set.class, ImmutableSet.class);
+    }
+}

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -98,6 +98,7 @@ public final class ObjectMappers {
     public static ObjectMapper withDefaultModules(ObjectMapper mapper) {
         return mapper
                 .registerModule(new GuavaModule())
+                .registerModule(new ImmutableCollectionsModule())
                 .registerModule(new ShimJdk7Module())
                 .registerModule(new Jdk8Module().configureAbsentsAsNulls(true))
                 .registerModule(newSafeForNewJdksAfterburnerModule())

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -93,6 +93,7 @@ public final class ObjectMappers {
      *   <li>Dates remain in received timezone.
      *   <li>Exceptions will not be wrapped with Jackson exceptions.
      *   <li>Deserializing a null for a primitive field will throw an exception.
+     *   <li>List, Map, and Set are deserialized to immutable implementations.
      * </ul>
      */
     public static ObjectMapper withDefaultModules(ObjectMapper mapper) {

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -19,7 +19,11 @@ package com.palantir.conjure.java.serialization;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -30,7 +34,10 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.Test;
 
 public final class ObjectMappersTest {
@@ -92,6 +99,33 @@ public final class ObjectMappersTest {
         LocalDate localDate = LocalDate.of(2001, 2, 3);
         assertThat(ser(localDate)).isEqualTo("\"2001-02-03\"");
         assertThat(serDe(localDate, LocalDate.class)).isEqualTo(localDate);
+    }
+
+    @Test
+    public void testListsAreImmutable() throws IOException {
+        List<String> value = MAPPER.readValue("[1,2,3,4]", new TypeReference<List<Integer>>() {});
+        assertThat(value).isInstanceOf(ImmutableList.class);
+    }
+
+    @Test
+    public void testSetsAreImmutable() throws IOException {
+        Set<String> value = MAPPER.readValue("[1,2,3,4]", new TypeReference<Set<Integer>>() {});
+        assertThat(value).isInstanceOf(ImmutableSet.class);
+    }
+
+    @Test
+    public void testMapsAreImmutable() throws IOException {
+        Map<String, String> value = MAPPER.readValue(
+                "{\"one\":\"two\",\"three\":\"four\"}", new TypeReference<Map<String, String>>() {});
+        assertThat(value).isInstanceOf(ImmutableMap.class);
+    }
+
+    @Test
+    public void testNestedTypesAreImmutable() throws IOException {
+        List<List<String>> value = MAPPER.readValue(
+                "[[1,2,3]]", new TypeReference<List<List<String>>>() {});
+        assertThat(value).isInstanceOf(ImmutableList.class);
+        assertThat(value.get(0)).isInstanceOf(ImmutableList.class);
     }
 
     private static String ser(Object object) throws IOException {

--- a/conjure-java-server-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-server-verifier/src/test/resources/ignored-test-cases.yml
@@ -3,3 +3,7 @@ server:
     getMapBinaryAliasExample:
       - '{}'
       - '{"SGVsbG8sIFdvcmxk": true}'
+    getListAnyAliasExample:
+      - '[null, 0, "content", true, [1,2,3], {"key":3}]' # null is not a valid any value, see conjure-verification#141
+    getSetAnyAliasExample:
+      - '[null, 0, "content", true, [1,2,3], {"key":3}]' # null is not a valid any value, see conjure-verification#141


### PR DESCRIPTION
Guava collections provide many of the same benefits that we encode into our generated beans, which were previously not applied to conjure objects outside of bean values: immutability, and values contained in collections may not be `null`.