### PR TITLE
[don't merge without broader conversation] Fix scalar coerscion tests by disabling afterburner

### DIFF
--- a/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
@@ -1,14 +1,7 @@
 client:
   autoDeserialize:
-
-   receiveBooleanExample:
-   - '{"value":0}' # jackson is casting 0 -> false and 1 -> true... MapperFeature.ALLOW_COERCION_OF_SCALARS);) in 2.9 will save us
-   - '{"value":"true"}' # jackson is casting 0 -> false and 1 -> true... MapperFeature.ALLOW_COERCION_OF_SCALARS);) in 2.9 will save us
-
    receiveStringExample:
    - '{"value":8}' # jackson coerces things to other types
-   receiveIntegerExample:
-   - '{"value":"12"}' # jackson coerces things to other types
 
    receiveSetStringExample:
    - '{"value":["a","a"]}' # client turns this into a set of ["a"] without error

--- a/conjure-java-jackson-serialization/build.gradle
+++ b/conjure-java-jackson-serialization/build.gradle
@@ -3,7 +3,6 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-guava"
-    compile "com.fasterxml.jackson.module:jackson-module-afterburner"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
 public final class ObjectMappers {
 
@@ -100,7 +99,6 @@ public final class ObjectMappers {
                 .registerModule(new GuavaModule())
                 .registerModule(new ShimJdk7Module())
                 .registerModule(new Jdk8Module().configureAbsentsAsNulls(true))
-                .registerModule(newSafeForNewJdksAfterburnerModule())
                 .registerModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
@@ -109,13 +107,5 @@ public final class ObjectMappers {
                 .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
                 .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
                 .disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT);
-    }
-
-    private static AfterburnerModule newSafeForNewJdksAfterburnerModule() {
-        AfterburnerModule afterburner = new AfterburnerModule();
-        // stops production of warnings about illegal reflective access on JDK9+
-        // https://github.com/FasterXML/jackson-modules-base/issues/37
-        afterburner.setUseValueClassLoader(false);
-        return afterburner;
     }
 }

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -84,7 +84,7 @@ public final class ObjectMappers {
     /**
      * Configures provided ObjectMapper with default modules and settings.
      * <p>
-     * Modules: Guava, JDK7, JDK8, Afterburner, JavaTime
+     * Modules: Guava, JDK7, JDK8, JavaTime
      * <p>
      * Settings:
      * <ul>

--- a/conjure-java-jersey-server/build.gradle
+++ b/conjure-java-jersey-server/build.gradle
@@ -6,7 +6,6 @@ dependencies {
 
     implementation project(':conjure-java-jackson-serialization')
     implementation "com.fasterxml.jackson.jaxrs:jackson-jaxrs-cbor-provider"
-    implementation "com.fasterxml.jackson.module:jackson-module-afterburner"
     implementation "com.jcraft:jzlib"
     implementation "com.palantir.safe-logging:safe-logging"
     implementation "com.palantir.tracing:tracing-jersey"

--- a/versions.lock
+++ b/versions.lock
@@ -9,7 +9,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.7 (3 constraints: 34232
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.7 (1 constraints: b0086a7e)
 com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.9.7 (1 constraints: 3d175124)
 com.fasterxml.jackson.jaxrs:jackson-jaxrs-cbor-provider:2.9.7 (1 constraints: b0086a7e)
-com.fasterxml.jackson.module:jackson-module-afterburner:2.9.7 (2 constraints: 571513c9)
+com.fasterxml.jackson.module:jackson-module-afterburner:2.9.7 (1 constraints: a80c4f09)
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.9.7 (1 constraints: 3d175124)
 com.fasterxml.jackson.module:jackson-module-paranamer:2.9.7 (1 constraints: e0154600)
 com.fasterxml.jackson.module:jackson-module-scala_2.11:2.9.7 (1 constraints: b0086a7e)


### PR DESCRIPTION
MapperFeature.ALLOW_COERCION_OF_SCALARS _will_ save us
...if we disable afterburner. We can fix the afterburner bug,
however I've been unable to produce a benchmark showing clear
wins using the afterburner module.