### PR TITLE
Fix comments re: jackson coercion of scalars

### DIFF
--- a/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
@@ -3,7 +3,7 @@ client:
 
    receiveBooleanExample:
    - '{"value":0}' # jackson is casting 0 -> false and 1 -> true... 2.9.9 will save us - https://github.com/FasterXML/jackson-modules-base/pull/70
-   - '{"value":"true"}' # jackson is casting 0 -> false and 1 -> true... in 2.9.9 will save us - https://github.com/FasterXML/jackson-modules-base/pull/70
+   - '{"value":"true"}' # jackson is casting 0 -> false and 1 -> true... 2.9.9 will save us - https://github.com/FasterXML/jackson-modules-base/pull/70
 
    receiveStringExample:
    - '{"value":8}' # jackson coerces things to other types

--- a/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
@@ -2,13 +2,13 @@ client:
   autoDeserialize:
 
    receiveBooleanExample:
-   - '{"value":0}' # jackson is casting 0 -> false and 1 -> true... MapperFeature.ALLOW_COERCION_OF_SCALARS);) in 2.9 will save us
-   - '{"value":"true"}' # jackson is casting 0 -> false and 1 -> true... MapperFeature.ALLOW_COERCION_OF_SCALARS);) in 2.9 will save us
+   - '{"value":0}' # jackson is casting 0 -> false and 1 -> true... 2.9.9 will save us - https://github.com/FasterXML/jackson-modules-base/pull/70
+   - '{"value":"true"}' # jackson is casting 0 -> false and 1 -> true... in 2.9.9 will save us - https://github.com/FasterXML/jackson-modules-base/pull/70
 
    receiveStringExample:
    - '{"value":8}' # jackson coerces things to other types
    receiveIntegerExample:
-   - '{"value":"12"}' # jackson coerces things to other types
+   - '{"value":"12"}' # jackson coerces things to other types... 2.9.9 will save us - https://github.com/FasterXML/jackson-modules-base/pull/70
 
    receiveSetStringExample:
    - '{"value":["a","a"]}' # client turns this into a set of ["a"] without error


### PR DESCRIPTION
## Before this PR

Ignore file was mentioning the wrong jackson flag - we already use ALLOW_COERCION_OF_SCALARS, but it doesn't work with afterburner. See https://github.com/FasterXML/jackson-modules-base/pull/70

## After this PR

Fixed comments to more accurately describe the ignores that will be fixed by jackson 2.9.9