### PR TITLE
[improvement] log.warn if deserialized raw collections contain null

### DIFF
--- a/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
@@ -75,9 +75,6 @@ client:
    receiveMapBinaryAliasExample:
    - '{}'
    - '{"SGVsbG8sIFdvcmxk": true}'
-   receiveMapDoubleAliasExample:
-   - '{"10": true, "10e0": false}'
-   - '{"10": true, "10.0": false}'
 
   singleHeaderService: {}
 

--- a/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
@@ -43,6 +43,7 @@ client:
    - 'null'
    receiveListAnyAliasExample:
    - 'null'
+   - '[null, 0, "content", true, [1,2,3], {"key":3}]' # null is not a valid any value, see conjure-verification#141
    receiveSetBearerTokenAliasExample:
    - 'null'
    receiveSetBinaryAliasExample:
@@ -65,6 +66,7 @@ client:
    - 'null'
    receiveSetAnyAliasExample:
    - 'null'
+   - '[null, 0, "content", true, [1,2,3], {"key":3}]' # null is not a valid any value, see conjure-verification#141
 
    receiveEnumExample:
    - '"!!!"'

--- a/conjure-java-jackson-serialization/build.gradle
+++ b/conjure-java-jackson-serialization/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"
 
+    implementation "org.slf4j:slf4j-api"
+
     testCompile "junit:junit"
     testCompile "org.assertj:assertj-core"
 }

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
@@ -137,14 +137,19 @@ final class CollectionValidationModule extends SimpleModule {
 
     @Nullable
     private static <T> T logIfNull(@Nullable T value) {
-        // Log noisily in production
-        if (value == null
-                // Avoid the performance cost of Throwable.fillInStackTrace if WARN has been disabled
-                && log.isWarnEnabled()) {
+        if (value == null) {
+            onNull();
+        }
+        return value;
+    }
+
+    private static void onNull() {
+        // Avoid the performance cost of Throwable.fillInStackTrace if WARN has been disabled
+        if (log.isWarnEnabled()) {
+            // Log noisily in production
             log.warn("Detected a null value, null values are not allowed by Conjure", new IllegalArgumentException());
         }
         // Tests should fail, but we're not ready to cause breaks in deployed systems yet.
-        assert value != null : "Null values are not allowed by Conjure";
-        return value;
+        assert false : "Null values are not allowed by Conjure";
     }
 }

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
@@ -1,0 +1,128 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.serialization;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Validates that collections are deserialized into data that Conjure allows. This module provides <i>soft</i>
+ * validation, logging instead of breaking functionality. Over time this will transition to strict validation,
+ * throwing exceptions when incorrect data is received.
+ * This implementation allows us to discover code which leverages incorrect behavior and remediate without
+ * breaking functionality.
+ *
+ * What is validated?
+ * <ul>
+ *     <li>Collection values must not be null</li>
+ *     <li>TODO: Values are not mutated (after deserialization)</li>
+ * </ul>
+ */
+final class CollectionValidationModule extends SimpleModule {
+
+    private static final Logger log = LoggerFactory.getLogger(CollectionValidationModule.class);
+
+    CollectionValidationModule() {
+        super("collection-validation");
+        addAbstractTypeMapping(List.class, ValidatingArrayList.class);
+        addAbstractTypeMapping(Set.class, ValidatingHashSet.class);
+        addAbstractTypeMapping(Map.class, ValidatingHashMap.class);
+    }
+
+    /** Logs noisily if null values are received. */
+    static final class ValidatingArrayList<T> extends ArrayList<T> {
+
+        @Override
+        public boolean add(T value) {
+            return super.add(logIfNull(value));
+        }
+
+        @Override
+        public void add(int index, T value) {
+            super.add(index, logIfNull(value));
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends T> collection) {
+            collection.forEach(CollectionValidationModule::logIfNull);
+            return super.addAll(collection);
+        }
+
+        @Override
+        public boolean addAll(int index, Collection<? extends T> collection) {
+            collection.forEach(CollectionValidationModule::logIfNull);
+            return super.addAll(index, collection);
+        }
+
+        @Override
+        public T set(int index, T value) {
+            return super.set(index, logIfNull(value));
+        }
+    }
+
+    /** Logs noisily if null values are received. */
+    static final class ValidatingHashSet<T> extends HashSet<T> {
+
+        @Override
+        public boolean add(T value) {
+            return super.add(logIfNull(value));
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends T> collection) {
+            collection.forEach(CollectionValidationModule::logIfNull);
+            return super.addAll(collection);
+        }
+    }
+
+    /** Logs noisily if null values are received. */
+    static final class ValidatingHashMap<K, V> extends HashMap<K, V> {
+        private static final BiConsumer<Object, Object> validator = (key, value) -> logIfNull(value);
+
+        @Override
+        public V put(K key, V value) {
+            return super.put(key, logIfNull(value));
+        }
+
+        @Override
+        public void putAll(Map<? extends K, ? extends V> map) {
+            map.forEach(validator);
+            super.putAll(map);
+        }
+    }
+
+    @Nullable
+    private static <T> T logIfNull(@Nullable T value) {
+        // Log noisily in production
+        if (value == null) {
+            log.warn("Detected a null value, null values are not allowed by Conjure", new IllegalArgumentException());
+        }
+        // Tests should fail, but we're not ready to cause breaks in deployed systems yet.
+        assert value != null : "Null values are not allowed by Conjure";
+        return value;
+    }
+}

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
@@ -40,7 +40,10 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *     <li>Collection values must not be null</li>
  *     <li>Maps must not contain duplicate keys</li>
- *     <li>TODO: Values are not mutated (after deserialization)</li>
+ * </ul>
+ * What is not validated?
+ * <ul>
+ *     <li>This implementation does not validate that deserialized collections are not modified.</li>
  * </ul>
  */
 final class CollectionValidationModule extends SimpleModule {

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
@@ -111,17 +111,21 @@ final class CollectionValidationModule extends SimpleModule {
         public V put(K key, V value) {
             V previousValue = super.put(key, logIfNull(value));
             if (previousValue != null) {
-                // Avoid the performance cost of Throwable.fillInStackTrace if WARN has been disabled
-                if (log.isWarnEnabled()) {
-                    // TODO(ckozak): Log key and values as unsafe arguments. This would require us to take a
-                    // dependency on safe-logging.
-                    log.warn("Detected duplicate map keys which are not allowed by Conjure",
-                            new IllegalArgumentException());
-                }
-                assert false : "Duplicate values for the same key are not allowed by Conjure. Key '"
-                        + key + "' values ['" + value + "', '" + previousValue + "']";
+                onDuplicateKey(key, previousValue, value);
             }
             return previousValue;
+        }
+
+        void onDuplicateKey(K key, V previousValue, V newValue) {
+            // Avoid the performance cost of Throwable.fillInStackTrace if WARN has been disabled
+            if (log.isWarnEnabled()) {
+                // TODO(ckozak): Log key and values as unsafe arguments. This would require us to take a
+                // dependency on safe-logging.
+                log.warn("Detected duplicate map keys which are not allowed by Conjure",
+                        new IllegalArgumentException());
+            }
+            assert false : "Duplicate values for the same key are not allowed by Conjure. Key '"
+                    + key + "' values ['" + newValue + "', '" + previousValue + "']";
         }
 
         @Override

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
@@ -118,7 +118,9 @@ final class CollectionValidationModule extends SimpleModule {
     @Nullable
     private static <T> T logIfNull(@Nullable T value) {
         // Log noisily in production
-        if (value == null) {
+        if (value == null
+                // Avoid the performance cost of Throwable.fillInStackTrace if WARN has been disabled
+                && log.isWarnEnabled()) {
             log.warn("Detected a null value, null values are not allowed by Conjure", new IllegalArgumentException());
         }
         // Tests should fail, but we're not ready to cause breaks in deployed systems yet.

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
  * What is validated?
  * <ul>
  *     <li>Collection values must not be null</li>
+ *     <li>Maps must not contain duplicate keys</li>
  *     <li>TODO: Values are not mutated (after deserialization)</li>
  * </ul>
  */
@@ -105,7 +106,19 @@ final class CollectionValidationModule extends SimpleModule {
 
         @Override
         public V put(K key, V value) {
-            return super.put(key, logIfNull(value));
+            V previousValue = super.put(key, logIfNull(value));
+            if (previousValue != null) {
+                // Avoid the performance cost of Throwable.fillInStackTrace if WARN has been disabled
+                if (log.isWarnEnabled()) {
+                    // TODO(ckozak): Log key and values as unsafe arguments. This would require us to take a
+                    // dependency on safe-logging.
+                    log.warn("Detected duplicate map keys which are not allowed by Conjure",
+                            new IllegalArgumentException());
+                }
+                assert false : "Duplicate values for the same key are not allowed by Conjure. Key '"
+                        + key + "' values ['" + value + "', '" + previousValue + "']";
+            }
+            return previousValue;
         }
 
         @Override

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -102,6 +102,7 @@ public final class ObjectMappers {
                 .registerModule(new Jdk8Module().configureAbsentsAsNulls(true))
                 .registerModule(newSafeForNewJdksAfterburnerModule())
                 .registerModule(new JavaTimeModule())
+                .registerModule(new CollectionValidationModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                 .disable(DeserializationFeature.WRAP_EXCEPTIONS)

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -127,6 +127,15 @@ public final class ObjectMappersTest {
                 .isInstanceOf(JsonParseException.class);
     }
 
+    @Test
+    public void testMapWithDuplicateKeys() {
+        assertThatThrownBy(() -> MAPPER.readValue("{\"test\":\"foo\",\"test\":\"bar\"}",
+                new TypeReference<Map<String, String>>() {}))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("Duplicate values for the same key are not allowed by Conjure. "
+                        + "Key 'test' values ['bar', 'foo']");
+    }
+
     private static String ser(Object object) throws IOException {
         return MAPPER.writeValueAsString(object);
     }

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -17,8 +17,11 @@
 package com.palantir.conjure.java.serialization;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
@@ -30,7 +33,10 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.Test;
 
 public final class ObjectMappersTest {
@@ -92,6 +98,33 @@ public final class ObjectMappersTest {
         LocalDate localDate = LocalDate.of(2001, 2, 3);
         assertThat(ser(localDate)).isEqualTo("\"2001-02-03\"");
         assertThat(serDe(localDate, LocalDate.class)).isEqualTo(localDate);
+    }
+
+    @Test
+    public void testListWithNullValues() {
+        assertThatThrownBy(() -> MAPPER.readValue("[1,2,null]", new TypeReference<List<Integer>>() {}))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("Null values are not allowed by Conjure");
+    }
+
+    @Test
+    public void testSetWithNullValues() {
+        assertThatThrownBy(() -> MAPPER.readValue("[1,2,null]", new TypeReference<Set<Integer>>() {}))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("Null values are not allowed by Conjure");
+    }
+
+    @Test
+    public void testMapWithNullValues() {
+        assertThatThrownBy(() -> MAPPER.readValue("{\"test\":null}", new TypeReference<Map<String, String>>() {}))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("Null values are not allowed by Conjure");
+    }
+
+    @Test
+    public void testMapWithNullKeys() {
+        assertThatThrownBy(() -> MAPPER.readValue("{null: \"test\"}", new TypeReference<Map<String, String>>() {}))
+                .isInstanceOf(JsonParseException.class);
     }
 
     private static String ser(Object object) throws IOException {

--- a/conjure-java-server-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-server-verifier/src/test/resources/ignored-test-cases.yml
@@ -3,3 +3,7 @@ server:
     getMapBinaryAliasExample:
       - '{}'
       - '{"SGVsbG8sIFdvcmxk": true}'
+    getListAnyAliasExample:
+      - '[null, 0, "content", true, [1,2,3], {"key":3}]' # null is not a valid any value, see conjure-verification#141
+    getSetAnyAliasExample:
+      - '[null, 0, "content", true, [1,2,3], {"key":3}]' # null is not a valid any value, see conjure-verification#141


### PR DESCRIPTION
Tests will fail, however in production where assertions are not
enabled, warnings will be logged and functionality is unmodified.