### PR TITLE
[fix] correctly set traceids on retries, ConcurrencyLimiter considers host

### DIFF
--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/TracerTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/TracerTest.java
@@ -17,15 +17,22 @@
 package com.palantir.conjure.java.client.jaxrs;
 
 import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.Sets;
 import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
 import com.palantir.tracing.Tracer;
 import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.TraceHttpHeaders;
 import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -44,11 +51,11 @@ public final class TracerTest extends TestBase {
     public void before() {
         String uri = "http://localhost:" + server.getPort();
         service = JaxRsClient.create(TestService.class, AGENT, new HostMetricsRegistry(), createTestConfig(uri));
-        server.enqueue(new MockResponse().setBody("\"server\""));
     }
 
     @Test
     public void testClientIsInstrumentedWithTracer() throws InterruptedException, IOException {
+        server.enqueue(new MockResponse().setBody("\"server\""));
         OpenSpan parentTrace = Tracer.startSpan("");
 
         Tracer.subscribe(TracerTest.class.getName(), span -> {
@@ -63,5 +70,57 @@ public final class TracerTest extends TestBase {
         RecordedRequest request = server.takeRequest();
         assertThat(request.getHeader(TraceHttpHeaders.TRACE_ID), is(traceId));
         assertThat(request.getHeader(TraceHttpHeaders.SPAN_ID), is(not(parentTrace.getSpanId())));
+    }
+
+    @Test
+    public void testLimiterAcquisitionMultiThread() {
+        reduceConcurrencyLimitTo1();
+        Set<String> observedTraceIds = Sets.newConcurrentHashSet();
+        addTraceSubscriber(observedTraceIds);
+        runTwoRequestsInParallel();
+        removeTraceSubscriber();
+        assertThat(observedTraceIds, hasSize(2));
+    }
+
+    private void runTwoRequestsInParallel() {
+        // time based delays are sad, but meh.
+        server.enqueue(new MockResponse().setBody("\"server\"").setHeadersDelay(100, TimeUnit.MILLISECONDS));
+        server.enqueue(new MockResponse().setBody("\"server\""));
+
+        CompletableFuture<?> first = CompletableFuture.runAsync(() -> {
+            Tracer.initTrace(Optional.of(true), "first");
+            Tracer.startSpan("");
+            service.string();
+        });
+        CompletableFuture<?> second = CompletableFuture.runAsync(() -> {
+            Tracer.initTrace(Optional.of(true), "second");
+            Tracer.startSpan("");
+            service.string();
+        });
+        first.join();
+        second.join();
+    }
+
+    private void addTraceSubscriber(Set<String> observedTraceIds) {
+        Tracer.subscribe(TracerTest.class.getName(), span -> {
+            if (span.getOperation().equals("GET /string")) {
+                observedTraceIds.add(span.getTraceId());
+            }
+        });
+    }
+
+    private void removeTraceSubscriber() {
+        Tracer.unsubscribe(TracerTest.class.getName());
+    }
+
+    private void reduceConcurrencyLimitTo1() {
+        int experimentallyThisNeedsToHappen3Times = 3;
+        for (int i = 0; i < experimentallyThisNeedsToHappen3Times; i++) {
+            IntStream.range(0, 3).forEach(x -> {
+                server.enqueue(new MockResponse().setResponseCode(429));
+            });
+            server.enqueue(new MockResponse().setBody("\"server\""));
+            assertThat(service.string(), is("server"));
+        }
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiterListener.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiterListener.java
@@ -16,20 +16,18 @@
 
 package com.palantir.conjure.java.okhttp;
 
-import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.netflix.concurrency.limits.Limiter;
 import com.palantir.conjure.java.client.config.ImmutablesStyle;
 import org.immutables.value.Value;
 
-@Value.Immutable
+@Value.Modifiable
 @ImmutablesStyle
 public interface ConcurrencyLimiterListener {
+    ListenableFuture<Limiter.Listener> limiterListener();
+    ConcurrencyLimiterListener setLimiterListener(ListenableFuture<Limiter.Listener> limiterListener);
 
-    @Value.Parameter
-    SettableFuture<Limiter.Listener> limiterListener();
-
-    static ConcurrencyLimiterListener of(SettableFuture<Limiter.Listener> limiterListener) {
-        return ImmutableConcurrencyLimiterListener.of(limiterListener);
+    static ConcurrencyLimiterListener create() {
+        return ModifiableConcurrencyLimiterListener.create();
     }
-
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -101,12 +101,12 @@ final class ConcurrencyLimiters {
         return new ConcurrencyLimiter(limiterKey, limiter);
     }
 
-    private static String limiterKey(Request request) {
+    private String limiterKey(Request request) {
         String pathTemplate = request.header(OkhttpTraceInterceptor.PATH_TEMPLATE_HEADER);
         if (pathTemplate == null) {
             return FALLBACK;
         } else {
-            return request.method() + " " + pathTemplate;
+            return request.url().host() + " " + request.method() + " " + pathTemplate;
         }
     }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -28,6 +28,7 @@ import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIoException;
+import com.palantir.tracing.DeferredTracer;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.time.Duration;
@@ -150,12 +151,16 @@ final class RemotingOkHttpCall extends ForwardingCall {
 
     @Override
     public void enqueue(Callback callback) {
+        DeferredTracer tracer = new DeferredTracer();
         ListenableFuture<Limiter.Listener> limiterListener = limiter.acquire();
-        request().tag(ConcurrencyLimiterListener.class).limiterListener().setFuture(limiterListener);
+        request().tag(ConcurrencyLimiterListener.class).setLimiterListener(limiterListener);
         Futures.addCallback(limiterListener, new FutureCallback<Limiter.Listener>() {
             @Override
             public void onSuccess(Limiter.Listener listener) {
-                enqueueInternal(callback);
+                tracer.withTrace(() -> {
+                    enqueueInternal(callback);
+                    return null;
+                });
             }
 
             @Override

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.okhttp;
 
-import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
@@ -92,7 +91,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
     private Request createNewRequest(Request request) {
         return request.newBuilder()
                 .url(getNewRequestUrl(request.url()))
-                .tag(ConcurrencyLimiterListener.class, ConcurrencyLimiterListener.of(SettableFuture.create()))
+                .tag(ConcurrencyLimiterListener.class, ConcurrencyLimiterListener.create())
                 .build();
     }
 

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitersTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitersTest.java
@@ -28,7 +28,9 @@ import java.util.concurrent.Executors;
 import org.junit.Test;
 
 public final class ConcurrencyLimitersTest {
-    private static final String KEY = "";
+    private static final ConcurrencyLimiters.Key KEY = ImmutableKey.builder()
+            .hostname("")
+            .build();
     private static final Duration TIMEOUT = Duration.ofSeconds(1);
     private final ConcurrencyLimiters limiters = new ConcurrencyLimiters(
             Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder()

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitingInterceptorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitingInterceptorTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.Futures;
 import com.netflix.concurrency.limits.Limiter;
 import java.io.IOException;
 import okhttp3.Interceptor;
@@ -51,11 +51,10 @@ public final class ConcurrencyLimitingInterceptorTest {
 
     @Before
     public void before() {
-        SettableFuture<Limiter.Listener> listenerFuture = SettableFuture.create();
-        listenerFuture.set(listener);
         request = new Request.Builder()
                 .url("https://localhost:1234/call")
-                .tag(ConcurrencyLimiterListener.class, ConcurrencyLimiterListener.of(listenerFuture))
+                .tag(ConcurrencyLimiterListener.class,
+                        ConcurrencyLimiterListener.create().setLimiterListener(Futures.immediateFuture(listener)))
                 .get()
                 .build();
         response = new Response.Builder()

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/FlowControlTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/FlowControlTest.java
@@ -56,6 +56,9 @@ import org.slf4j.LoggerFactory;
  */
 public final class FlowControlTest {
     private static final Logger log = LoggerFactory.getLogger(FlowControlTest.class);
+    private static final ConcurrencyLimiters.Key KEY = ImmutableKey.builder()
+            .hostname("")
+            .build();
     private static final Duration GRACE = Duration.ofMinutes(2);
     private static final int REQUESTS_PER_THREAD = 50;
     private static ListeningExecutorService executorService;
@@ -141,7 +144,7 @@ public final class FlowControlTest {
         @Override
         public void run() {
             for (int i = 0; i < REQUESTS_PER_THREAD; ) {
-                Limiter.Listener listener = Futures.getUnchecked(limiters.acquireLimiterInternal("").acquire());
+                Limiter.Listener listener = Futures.getUnchecked(limiters.acquireLimiterInternal(KEY).acquire());
                 boolean gotRateLimited = !rateLimiter.tryAcquire(100, TimeUnit.MILLISECONDS);
                 if (!gotRateLimited) {
                     meter.mark();


### PR DESCRIPTION
I was in the area, and stopped by to fix a few bugs.

The first is that the tracing is not set correctly on retries. This
means that RPCs are associated with incorrect traces. We've seen
symptoms of this internally. Use the DeferredTracer to fix this.

The second is that we use a SettableFuture and setFuture on it within
the limiter listener request tag. If the future is already done (e.g.
this is a retry) then this will already be done, and we will not react
properly; we will attempt to close out the old listener and not the new one.

Interestingly this actually has no effect because the Netflix library
does not validate that you didn't call it twice and behaves as though
it was a different listener. But this could change at any time, and
then we'd be in a tough spot.

Lastly, factor the host you're talking to into the concurrency limiter
key. This means that if you're round robining one bad host can't hurt
your collective performance.

I don't think anyone is negatively affected by this internally - it can only really affect you if you rate limit globally and I don't know we do that internally.