### PR TITLE
[fix] Revert "[fix] Stop producing illegal reflective access warnings on JDK9+ (#965)"

### DIFF
--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -100,7 +100,7 @@ public final class ObjectMappers {
                 .registerModule(new GuavaModule())
                 .registerModule(new ShimJdk7Module())
                 .registerModule(new Jdk8Module().configureAbsentsAsNulls(true))
-                .registerModule(newSafeForNewJdksAfterburnerModule())
+                .registerModule(new AfterburnerModule())
                 .registerModule(new JavaTimeModule())
                 .registerModule(new CollectionValidationModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
@@ -110,13 +110,5 @@ public final class ObjectMappers {
                 .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
                 .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
                 .disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT);
-    }
-
-    private static AfterburnerModule newSafeForNewJdksAfterburnerModule() {
-        AfterburnerModule afterburner = new AfterburnerModule();
-        // stops production of warnings about illegal reflective access on JDK9+
-        // https://github.com/FasterXML/jackson-modules-base/issues/37
-        afterburner.setUseValueClassLoader(false);
-        return afterburner;
     }
 }


### PR DESCRIPTION
This reverts commit 5d945f40a302167524b4a2e5edf4df57704be03e.

This fixes IllegalAccessExceptions while deserializing immutables
generated classes.