### PR TITLE
[fix] ScheduledExecutors use daemon threads, to avoid blocking shutdowns

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -111,10 +111,10 @@ public final class OkHttpClients {
      * <p>
      * Note: In contrast to the {@link java.util.concurrent.ThreadPoolExecutor} used by OkHttp's {@link
      * #executionExecutor}, {@code corePoolSize} must not be zero for a {@link ScheduledThreadPoolExecutor}, see its
-     * Javadoc.
+     * Javadoc. Since this executor will never hit zero threads, it must use daemon threads.
      */
     private static final ScheduledExecutorService schedulingExecutor = Tracers.wrap(Executors.newScheduledThreadPool(
-            NUM_SCHEDULING_THREADS, Util.threadFactory("conjure-java-runtime/OkHttp Scheduler", false)));
+            NUM_SCHEDULING_THREADS, Util.threadFactory("conjure-java-runtime/OkHttp Scheduler", true)));
 
     private OkHttpClients() {}
 


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
This library leaves non-daemon threads behind so services never shut down

## After this PR
==COMMIT_MSG==
ScheduledExecutors use daemon threads, so the JVM isn't prevented from shutting down
==COMMIT_MSG==

## Possible downsides?
Very minimal downsides for uses who fire and forget requests and shut down their server and expect the library to keep the JVM alive and retry under the covers.