### PR TITLE
[improvement] Provide a way to propagate 429s

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ExponentialBackoff.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ExponentialBackoff.java
@@ -25,7 +25,7 @@ import java.util.Random;
  * Implements "exponential backoff with full jitter", suggesting a backoff duration chosen randomly from the interval
  * {@code [0, backoffSlotSize * 2^c)} for the c-th retry for a maximum of {@link #maxNumRetries} retries.
  */
-final class ExponentialBackoff implements BackoffStrategy {
+final class ExponentialBackoff implements RetryStrategy {
 
     private final int maxNumRetries;
     private final Duration backoffSlotSize;
@@ -38,6 +38,11 @@ final class ExponentialBackoff implements BackoffStrategy {
         this.maxNumRetries = maxNumRetries;
         this.backoffSlotSize = backoffSlotSize;
         this.random = random;
+    }
+
+    @Override
+    public boolean shouldRetry() {
+        return maxNumRetries > 0;
     }
 
     @Override

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -273,10 +273,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
         return new QosException.Visitor<Void>() {
             @Override
             public Void visit(QosException.Throttle exception) {
-                if (!retryStrategy.shouldRetry()) {
-                    throw exception;
-                }
-
                 Optional<Duration> nonAdvertizedBackoff = retryStrategy.nextBackoff();
                 if (!nonAdvertizedBackoff.isPresent()) {
                     callback.onFailure(call, new SafeIoException(
@@ -332,10 +328,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
 
             @Override
             public Void visit(QosException.Unavailable exception) {
-                if (!retryStrategy.shouldRetry()) {
-                    throw exception;
-                }
-
                 Optional<Duration> backoff = retryStrategy.nextBackoff();
                 if (!backoff.isPresent()) {
                     callback.onFailure(call, new SafeIoException(

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RetryStrategy.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RetryStrategy.java
@@ -20,12 +20,16 @@ import java.time.Duration;
 import java.util.Optional;
 
 /**
- * Defines a strategy for waiting in between successive retries of an operation that is subject to failure.
+ * Defines a strategy for handling an operation that is subject to failure.
  */
-public interface BackoffStrategy {
+public interface RetryStrategy {
     /**
-     * Returns the next suggested backoff duration, or {@link Optional#empty} if the operation should not be retried
-     * again.
+     * Returns whether a failed operation should be retried.
+     */
+    boolean shouldRetry();
+    /**
+     * Returns the next suggested backoff duration before retrying, or {@link Optional#empty} if the operation should
+     * not be retried again.
      */
     Optional<Duration> nextBackoff();
 }

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ExponentialBackoffTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ExponentialBackoffTest.java
@@ -35,6 +35,7 @@ public final class ExponentialBackoffTest {
         Random random = mock(Random.class);
         ExponentialBackoff backoff = new ExponentialBackoff(0, ONE_SECOND, random);
 
+        assertThat(backoff.shouldRetry()).isFalse();
         assertThat(backoff.nextBackoff()).isEmpty();
     }
 


### PR DESCRIPTION
Repurpose BackoffStrategy to also indicate whether or not an operation should be retried at all. This allows us to propagate 429s instead of always throwing a SafeIoException on failure.

Fixes: #985 

## Before this PR
A 429 always results in either a successful retry or a `SafeIoException`. Sometimes the client does not have enough context to decide how to handle a 429 and wants to propagate the 429 to an upstream client.

## After this PR
When `ClientConfiguration.maxNumRetries` is set to 0, 429s are propagated instead of rethrown as `SafeIoException`s.