### PR TITLE
[fix] java long deserialization regression introduced in #917

### DIFF
--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/LenientLongModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/LenientLongModule.java
@@ -56,6 +56,11 @@ final class LenientLongModule extends SimpleModule {
             throw new IOException("Expected a long value");
         }
 
+        @Override
+        public boolean isCachable() {
+            return true;
+        }
+
         private static Long parseLong(JsonParser jsonParser) throws IOException {
             try {
                 return Long.valueOf(jsonParser.getValueAsString());

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/LenientLongModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/LenientLongModule.java
@@ -49,6 +49,8 @@ final class LenientLongModule extends SimpleModule {
                     return jsonParser.getLongValue();
                 case VALUE_STRING:
                     return Long.valueOf(jsonParser.getValueAsString());
+                case VALUE_NULL:
+                    return null;
             }
             throw new IOException("Expected a long value");
         }

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/LenientLongModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/LenientLongModule.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.IOException;
+
+/**
+ * Provides support for the {@link Long} deserialization from JSON string and numeric values regardless of
+ * <pre>MapperFeature.ALLOW_COERCION_OF_SCALARS</pre> configuration.
+ */
+final class LenientLongModule extends SimpleModule {
+
+    LenientLongModule() {
+        super("lenient long");
+        // Register to both Long.TYPE and Long.class
+        this.addDeserializer(long.class, new LongAsStringDeserializer())
+                .addDeserializer(Long.class, new LongAsStringDeserializer());
+    }
+
+    private static final class LongAsStringDeserializer extends StdDeserializer<Long> {
+
+        private LongAsStringDeserializer() {
+            super(Long.TYPE);
+        }
+
+        @Override
+        public Long deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+            switch (jsonParser.currentToken()) {
+                case VALUE_NUMBER_INT:
+                    // Lenient implementation for compatibility with existing clients
+                    return jsonParser.getLongValue();
+                case VALUE_STRING:
+                    return Long.valueOf(jsonParser.getValueAsString());
+            }
+            throw new IOException("Expected a long value");
+        }
+    }
+}

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/LenientLongModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/LenientLongModule.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.serialization;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
@@ -48,11 +49,19 @@ final class LenientLongModule extends SimpleModule {
                     // Lenient implementation for compatibility with existing clients
                     return jsonParser.getLongValue();
                 case VALUE_STRING:
-                    return Long.valueOf(jsonParser.getValueAsString());
+                    return parseLong(jsonParser);
                 case VALUE_NULL:
                     return null;
             }
             throw new IOException("Expected a long value");
+        }
+
+        private static Long parseLong(JsonParser jsonParser) throws IOException {
+            try {
+                return Long.valueOf(jsonParser.getValueAsString());
+            } catch (NumberFormatException e) {
+                throw new JsonParseException(jsonParser, "not a valid long value", e);
+            }
         }
     }
 }

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/LenientLongModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/LenientLongModule.java
@@ -46,7 +46,6 @@ final class LenientLongModule extends SimpleModule {
         public Long deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
             switch (jsonParser.currentToken()) {
                 case VALUE_NUMBER_INT:
-                    // Lenient implementation for compatibility with existing clients
                     return jsonParser.getLongValue();
                 case VALUE_STRING:
                     return parseLong(jsonParser);

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -103,6 +103,7 @@ public final class ObjectMappers {
                 .registerModule(new AfterburnerModule())
                 .registerModule(new JavaTimeModule())
                 .registerModule(new CollectionValidationModule())
+                .registerModule(new LenientLongModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                 .disable(DeserializationFeature.WRAP_EXCEPTIONS)

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -136,6 +136,26 @@ public final class ObjectMappersTest {
                         + "Key 'test' values ['bar', 'foo']");
     }
 
+    @Test
+    public void testLongDeserializationFromString() throws IOException {
+        assertThat((Long) MAPPER.readValue("\"1\"", new TypeReference<Long>() {})).isEqualTo(1L);
+    }
+
+    @Test
+    public void testLongTypeDeserializationFromString() throws IOException {
+        assertThat(MAPPER.readValue("\"1\"", Long.TYPE)).isEqualTo(1L);
+    }
+
+    @Test
+    public void testLongDeserializationFromJsonNumber() throws IOException {
+        assertThat((Long) MAPPER.readValue("1", new TypeReference<Long>() {})).isEqualTo(1L);
+    }
+
+    @Test
+    public void testLongTypeDeserializationFromJsonNumber() throws IOException {
+        assertThat(MAPPER.readValue("1", Long.TYPE)).isEqualTo(1L);
+    }
+
     private static String ser(Object object) throws IOException {
         return MAPPER.writeValueAsString(object);
     }

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -36,6 +37,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import org.junit.Test;
@@ -175,6 +177,36 @@ public final class ObjectMappersTest {
     @Test
     public void testOptionalLongDeserializationFromJsonNull() throws IOException {
         assertThat(MAPPER.readValue("null", OptionalLong.class)).isEmpty();
+    }
+
+    @Test
+    public void testLongOverflowDeserialization() {
+        BigInteger large = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertThatThrownBy(() -> MAPPER.readValue("" + large, Long.TYPE))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("out of range of long");
+    }
+
+    @Test
+    public void testOptionalLongOverflowDeserialization() {
+        BigInteger large = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertThatThrownBy(() -> MAPPER.readValue("" + large, OptionalLong.class))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("out of range of long");
+    }
+
+    @Test
+    public void testIntegerOverflowDeserialization() {
+        assertThatThrownBy(() -> MAPPER.readValue("" + Long.MAX_VALUE, Integer.TYPE))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("out of range of int");
+    }
+
+    @Test
+    public void testOptionalIntOverflowDeserialization() {
+        assertThatThrownBy(() -> MAPPER.readValue("" + Long.MAX_VALUE, OptionalInt.class))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("out of range of int");
     }
 
     private static String ser(Object object) throws IOException {

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -36,6 +36,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import org.junit.Test;
 
@@ -138,7 +139,7 @@ public final class ObjectMappersTest {
 
     @Test
     public void testLongDeserializationFromString() throws IOException {
-        assertThat((Long) MAPPER.readValue("\"1\"", new TypeReference<Long>() {})).isEqualTo(1L);
+        assertThat(MAPPER.readValue("\"1\"", Long.class)).isEqualTo(1L);
     }
 
     @Test
@@ -147,13 +148,33 @@ public final class ObjectMappersTest {
     }
 
     @Test
+    public void testOptionalLongTypeDeserializationFromString() throws IOException {
+        assertThat(MAPPER.readValue("\"1\"", OptionalLong.class)).hasValue(1L);
+    }
+
+    @Test
     public void testLongDeserializationFromJsonNumber() throws IOException {
-        assertThat((Long) MAPPER.readValue("1", new TypeReference<Long>() {})).isEqualTo(1L);
+        assertThat(MAPPER.readValue("1", Long.class)).isEqualTo(1L);
+    }
+
+    @Test
+    public void testOptionalLongDeserializationFromJsonNumber() throws IOException {
+        assertThat(MAPPER.readValue("1", OptionalLong.class)).hasValue(1L);
     }
 
     @Test
     public void testLongTypeDeserializationFromJsonNumber() throws IOException {
         assertThat(MAPPER.readValue("1", Long.TYPE)).isEqualTo(1L);
+    }
+
+    @Test
+    public void testLongDeserializationFromJsonNull() throws IOException {
+        assertThat(MAPPER.readValue("null", Long.class)).isNull();
+    }
+
+    @Test
+    public void testOptionalLongDeserializationFromJsonNull() throws IOException {
+        assertThat(MAPPER.readValue("null", OptionalLong.class)).isEmpty();
     }
 
     private static String ser(Object object) throws IOException {

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -188,9 +188,24 @@ public final class ObjectMappersTest {
     }
 
     @Test
+    public void testLongAsStringOverflowDeserialization() {
+        BigInteger large = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertThatThrownBy(() -> MAPPER.readValue("\"" + large + "\"", Long.TYPE))
+                .isInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
     public void testOptionalLongOverflowDeserialization() {
         BigInteger large = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
         assertThatThrownBy(() -> MAPPER.readValue("" + large, OptionalLong.class))
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("out of range of long");
+    }
+
+    @Test
+    public void testOptionalLongAsStringOverflowDeserialization() {
+        BigInteger large = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertThatThrownBy(() -> MAPPER.readValue("\"" + large + "\"", OptionalLong.class))
                 .isInstanceOf(JsonParseException.class)
                 .hasMessageContaining("out of range of long");
     }

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -206,8 +207,8 @@ public final class ObjectMappersTest {
     public void testOptionalLongAsStringOverflowDeserialization() {
         BigInteger large = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
         assertThatThrownBy(() -> MAPPER.readValue("\"" + large + "\"", OptionalLong.class))
-                .isInstanceOf(JsonParseException.class)
-                .hasMessageContaining("out of range of long");
+                .isInstanceOf(InvalidFormatException.class)
+                .hasMessageContaining("not a valid long value");
     }
 
     @Test

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -192,7 +192,8 @@ public final class ObjectMappersTest {
     public void testLongAsStringOverflowDeserialization() {
         BigInteger large = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
         assertThatThrownBy(() -> MAPPER.readValue("\"" + large + "\"", Long.TYPE))
-                .isInstanceOf(NumberFormatException.class);
+                .isInstanceOf(JsonParseException.class)
+                .hasMessageContaining("not a valid long value");
     }
 
     @Test


### PR DESCRIPTION
Java clients and servers will once again support deserialization
of long values encoded as JSON strings.

<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
Disabling `MapperFeature.ALLOW_COERCION_OF_SCALARS` in #917 broke existing services which used java long values encoded as strings (base-type: string) for interoperability with javascript clients.

## After this PR
==COMMIT_MSG==
Java clients and servers once again support deserialization of `java.lang.Long` values encoded as JSON strings.
==COMMIT_MSG==

## Possible downsides?
None known