### PR TITLE
[fix] Relax CollectionValidationModule map validation to match generated objects

### DIFF
--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CollectionValidationModule.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,13 +102,13 @@ final class CollectionValidationModule extends SimpleModule {
         }
     }
 
-    /** Logs noisily if null values are received. */
+    /** Logs noisily if duplicate keys are received. */
     static final class ValidatingHashMap<K, V> extends HashMap<K, V> {
-        private static final BiConsumer<Object, Object> validator = (key, value) -> logIfNull(value);
 
         @Override
-        public V put(K key, V value) {
-            V previousValue = super.put(key, logIfNull(value));
+        public V put(K key, @Nullable V value) {
+            // n.b. Generated bean builders do not currently validate map values are non-null.
+            V previousValue = super.put(key, value);
             if (previousValue != null) {
                 onDuplicateKey(key, previousValue, value);
             }
@@ -126,12 +125,6 @@ final class CollectionValidationModule extends SimpleModule {
             }
             assert false : "Duplicate values for the same key are not allowed by Conjure. Key '"
                     + key + "' values ['" + newValue + "', '" + previousValue + "']";
-        }
-
-        @Override
-        public void putAll(Map<? extends K, ? extends V> map) {
-            map.forEach(validator);
-            super.putAll(map);
         }
     }
 

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -33,6 +33,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -115,10 +116,12 @@ public final class ObjectMappersTest {
     }
 
     @Test
-    public void testMapWithNullValues() {
-        assertThatThrownBy(() -> MAPPER.readValue("{\"test\":null}", new TypeReference<Map<String, String>>() {}))
-                .isInstanceOf(AssertionError.class)
-                .hasMessage("Null values are not allowed by Conjure");
+    public void testMapWithNullValues() throws IOException {
+        // This is potentially a bug, see conjure-java#291
+        assertThat(MAPPER.<Map<String, String>>readValue(
+                "{\"test\":null}",
+                new TypeReference<Map<String, String>>() {}))
+                .isEqualTo(Collections.singletonMap("test", null));
     }
 
     @Test


### PR DESCRIPTION
Null map values no longer trigger WARN logging or assertions.
Tracking conjure-java failure to validate null map values here:
https://github.com/palantir/conjure-java/issues/291

## After this PR
==COMMIT_MSG==
Null map values no longer trigger WARN logging or assertions.
==COMMIT_MSG==
