### PR TITLE
[improvement] Allow use of a no-op concurrency limiter via code configuration

### DIFF
--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -101,6 +101,13 @@ public interface ClientConfiguration {
      */
     Duration backoffSlotSize();
 
+    /**
+     * Disables the client-side sympathetic QoS. Consumers should almost always set this value to its default of false,
+     * except where there are known issues with the QoS interaction. Please consult project maintainers if flipping
+     * this value to true.
+     */
+    boolean forExpertsOnlyDisableSympatheticClientQoS();
+
     @Value.Check
     default void check() {
         if (meshProxy().isPresent()) {

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -128,9 +128,9 @@ public interface ClientConfiguration {
         ENABLED,
 
         /**
-         * Disables the client-side sympathetic QoS. Consumers should almost always set this value to its default of false,
-         * except where there are known issues with the QoS interaction. Please consult project maintainers if flipping
-         * this value to true.
+         * Disables the client-side sympathetic QoS. Consumers should almost never use this option, reserving it
+         * for where there are known issues with the QoS interaction. Please consult project maintainers if applying
+         * this option.
          */
         DANGEROUS_DISABLE_SYMPATHETIC_CLIENT_QOS
     }

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -101,12 +101,9 @@ public interface ClientConfiguration {
      */
     Duration backoffSlotSize();
 
-    /**
-     * Disables the client-side sympathetic QoS. Consumers should almost always set this value to its default of false,
-     * except where there are known issues with the QoS interaction. Please consult project maintainers if flipping
-     * this value to true.
-     */
-    boolean forExpertsOnlyDisableSympatheticClientQoS();
+
+    /** Indicates whether client-side sympathetic QoS should be enabled. */
+    ClientQoS clientQoS();
 
     @Value.Check
     default void check() {
@@ -125,4 +122,16 @@ public interface ClientConfiguration {
     }
 
     class Builder extends ImmutableClientConfiguration.Builder {}
+
+    enum ClientQoS {
+        /** Default. */
+        ENABLED,
+
+        /**
+         * Disables the client-side sympathetic QoS. Consumers should almost always set this value to its default of false,
+         * except where there are known issues with the QoS interaction. Please consult project maintainers if flipping
+         * this value to true.
+         */
+        DANGEROUS_DISABLE_SYMPATHETIC_CLIENT_QOS
+    }
 }

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -46,6 +46,7 @@ public final class ClientConfigurations {
     private static final boolean DEFAULT_FALLBACK_TO_COMMON_NAME_VERIFICATION = false;
     private static final NodeSelectionStrategy DEFAULT_NODE_SELECTION_STRATEGY = NodeSelectionStrategy.PIN_UNTIL_ERROR;
     private static final int DEFAULT_MAX_NUM_RETRIES = 4;
+    private static final boolean DEFAULT_DISABLE_SYMPATHETIC_QOS = false;
 
     private ClientConfigurations() {}
 
@@ -71,6 +72,7 @@ public final class ClientConfigurations {
                 .nodeSelectionStrategy(DEFAULT_NODE_SELECTION_STRATEGY)
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .backoffSlotSize(config.backoffSlotSize().orElse(DEFAULT_BACKOFF_SLOT_SIZE))
+                .forExpertsOnlyDisableSympatheticClientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
                 .build();
     }
 
@@ -95,6 +97,7 @@ public final class ClientConfigurations {
                 .backoffSlotSize(DEFAULT_BACKOFF_SLOT_SIZE)
                 .nodeSelectionStrategy(DEFAULT_NODE_SELECTION_STRATEGY)
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
+                .forExpertsOnlyDisableSympatheticClientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
                 .build();
     }
 

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -46,7 +46,8 @@ public final class ClientConfigurations {
     private static final boolean DEFAULT_FALLBACK_TO_COMMON_NAME_VERIFICATION = false;
     private static final NodeSelectionStrategy DEFAULT_NODE_SELECTION_STRATEGY = NodeSelectionStrategy.PIN_UNTIL_ERROR;
     private static final int DEFAULT_MAX_NUM_RETRIES = 4;
-    private static final boolean DEFAULT_DISABLE_SYMPATHETIC_QOS = false;
+    private static final ClientConfiguration.ClientQoS DEFAULT_DISABLE_SYMPATHETIC_QOS =
+            ClientConfiguration.ClientQoS.ENABLED;
 
     private ClientConfigurations() {}
 
@@ -72,7 +73,7 @@ public final class ClientConfigurations {
                 .nodeSelectionStrategy(DEFAULT_NODE_SELECTION_STRATEGY)
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .backoffSlotSize(config.backoffSlotSize().orElse(DEFAULT_BACKOFF_SLOT_SIZE))
-                .forExpertsOnlyDisableSympatheticClientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
+                .clientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
                 .build();
     }
 
@@ -97,7 +98,7 @@ public final class ClientConfigurations {
                 .backoffSlotSize(DEFAULT_BACKOFF_SLOT_SIZE)
                 .nodeSelectionStrategy(DEFAULT_NODE_SELECTION_STRATEGY)
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
-                .forExpertsOnlyDisableSympatheticClientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
+                .clientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
                 .build();
     }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -139,8 +139,9 @@ public final class OkHttpClients {
             HostEventsSink hostEventsSink,
             Class<?> serviceClass,
             boolean randomizeUrlOrder) {
+        boolean enableClientQoS = config.clientQoS().equals(ClientConfiguration.ClientQoS.ENABLED);
         ConcurrencyLimiters concurrencyLimiters = new ConcurrencyLimiters(limitReviver, registry, serviceClass,
-                !config.forExpertsOnlyDisableSympatheticClientQoS());
+                enableClientQoS);
         OkHttpClient.Builder client = new OkHttpClient.Builder();
 
         // Routing
@@ -159,7 +160,7 @@ public final class OkHttpClients {
         }
 
         // Intercept calls to augment request meta data
-        if (!config.forExpertsOnlyDisableSympatheticClientQoS()) {
+        if (enableClientQoS) {
             client.addInterceptor(new ConcurrencyLimitingInterceptor());
         }
         client.addInterceptor(InstrumentedInterceptor.create(registry, hostEventsSink, serviceClass));

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -139,7 +139,8 @@ public final class OkHttpClients {
             HostEventsSink hostEventsSink,
             Class<?> serviceClass,
             boolean randomizeUrlOrder) {
-        ConcurrencyLimiters concurrencyLimiters = new ConcurrencyLimiters(limitReviver, registry, serviceClass);
+        ConcurrencyLimiters concurrencyLimiters = new ConcurrencyLimiters(limitReviver, registry, serviceClass,
+                !config.forExpertsOnlyDisableSympatheticClientQoS());
         OkHttpClient.Builder client = new OkHttpClient.Builder();
 
         // Routing
@@ -158,7 +159,9 @@ public final class OkHttpClients {
         }
 
         // Intercept calls to augment request meta data
-        client.addInterceptor(new ConcurrencyLimitingInterceptor());
+        if (!config.forExpertsOnlyDisableSympatheticClientQoS()) {
+            client.addInterceptor(new ConcurrencyLimitingInterceptor());
+        }
         client.addInterceptor(InstrumentedInterceptor.create(registry, hostEventsSink, serviceClass));
         client.addInterceptor(OkhttpTraceInterceptor.INSTANCE);
         client.addInterceptor(UserAgentInterceptor.of(augmentUserAgent(userAgent, serviceClass)));

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/DefaultConcurrencyLimitersTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/DefaultConcurrencyLimitersTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import org.junit.Test;
 
-public final class ConcurrencyLimitersTest {
+public final class DefaultConcurrencyLimitersTest {
     private static final ConcurrencyLimiters.Key KEY = ImmutableKey.builder()
             .hostname("")
             .build();
@@ -38,7 +38,7 @@ public final class ConcurrencyLimitersTest {
                     .build()),
             new DefaultTaggedMetricRegistry(),
             TIMEOUT,
-            ConcurrencyLimitersTest.class);
+            DefaultConcurrencyLimitersTest.class);
 
     @Test
     public void testTimeout() {

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/DefaultConcurrencyLimitersTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/DefaultConcurrencyLimitersTest.java
@@ -38,7 +38,8 @@ public final class DefaultConcurrencyLimitersTest {
                     .build()),
             new DefaultTaggedMetricRegistry(),
             TIMEOUT,
-            DefaultConcurrencyLimitersTest.class);
+            DefaultConcurrencyLimitersTest.class,
+            true);
 
     @Test
     public void testTimeout() {

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/FlowControlTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/FlowControlTest.java
@@ -68,7 +68,8 @@ public final class FlowControlTest {
                     .setNameFormat("listener-reviver")
                     .build()),
             new DefaultTaggedMetricRegistry(),
-            FlowControlTest.class);
+            FlowControlTest.class,
+            true);
 
     @BeforeClass
     public static void beforeClass() {


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
It's not possible to disable sympathetic client-side QoS, even when it interacts poorly with misbehaving servers.

## After this PR
==COMMIT_MSG==
Allow use of a no-op concurrency limiter via code configuration.
==COMMIT_MSG==

## Possible downsides?
Users might abuse this setting to remove a feature we generally want -- this PR attempts to mitigate that by:
1. Requiring that configuration be performed in code
2. Adding the text `forExpertsOnly` to the beginning of the method and clear JavaDoc to indicate the limitations under which this configuration should be applied.