### PR TITLE
[improvement] Instrument time spent in dispatcher queue

### DIFF
--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/TracerTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/TracerTest.java
@@ -70,9 +70,11 @@ public final class TracerTest extends TestBase {
 
         Tracer.unsubscribe(TracerTest.class.getName());
         assertThat(observedSpans, contains(
+                Maps.immutableEntry(SpanType.LOCAL, "OkHttp: acquire-limiter-enqueue"),
+                Maps.immutableEntry(SpanType.LOCAL, "OkHttp: acquire-limiter-run"),
                 Maps.immutableEntry(SpanType.LOCAL, "OkHttp: execute-enqueue"),
-                Maps.immutableEntry(SpanType.LOCAL, "OkHttp: execute-run"),
                 Maps.immutableEntry(SpanType.CLIENT_OUTGOING, "OkHttp: GET /{param}"),
+                Maps.immutableEntry(SpanType.LOCAL, "OkHttp: execute-run"),
                 Maps.immutableEntry(SpanType.LOCAL, "OkHttp: dispatcher")));
 
         RecordedRequest request = server.takeRequest();

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DispatcherTraceTerminatingInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DispatcherTraceTerminatingInterceptor.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import com.palantir.tracing.AsyncTracer;
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+public final class DispatcherTraceTerminatingInterceptor implements Interceptor {
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        AsyncTracer tracerTag = chain.request().tag(AsyncTracer.class);
+        if (tracerTag == null) {
+            return chain.proceed(chain.request());
+        }
+
+        return tracerTag.withTrace(() -> chain.proceed(chain.request()));
+    }
+}

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -157,6 +157,7 @@ public final class OkHttpClients {
         ConcurrencyLimiters concurrencyLimiters = new ConcurrencyLimiters(limitReviver.get(), registry, serviceClass,
                 enableClientQoS);
         OkHttpClient.Builder client = new OkHttpClient.Builder();
+        client.addInterceptor(new DispatcherTraceTerminatingInterceptor());
 
         // Routing
         UrlSelectorImpl urlSelector = UrlSelectorImpl.createWithFailedUrlCooldown(config.uris(), randomizeUrlOrder,

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -151,7 +151,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
 
     @Override
     public void enqueue(Callback callback) {
-        AsyncTracer tracer = new AsyncTracer("OkHttp: execute");
+        AsyncTracer tracer = new AsyncTracer("OkHttp: acquire-limiter");
         ListenableFuture<Limiter.Listener> limiterListener = limiter.acquire();
         request().tag(ConcurrencyLimiterListener.class).setLimiterListener(limiterListener);
         Futures.addCallback(limiterListener, new FutureCallback<Limiter.Listener>() {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
@@ -20,6 +20,7 @@ import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.tracing.AsyncTracer;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -92,6 +93,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
         return request.newBuilder()
                 .url(getNewRequestUrl(request.url()))
                 .tag(ConcurrencyLimiterListener.class, ConcurrencyLimiterListener.create())
+                .tag(AsyncTracer.class, new AsyncTracer("OkHttp: execute"))
                 .build();
     }
 


### PR DESCRIPTION
## Before this PR
Time spent in dispatcher queue is not measured 
## After this PR
==COMMIT_MSG==
Time spent in dispatcher queue as well as time spent acquiring limiter is measure
==COMMIT_MSG==

Apologies for yet another span rename - the previous name was silly if we want to measure the whole thing and the whole thing is execute. Now you get 4 spans `OkHttp: acquire-limiter-enqueue` for time spent in acquireLimiter, `OkHttp: acquire-limiter-run` - time spent enqueing in okhttp (yeah this is auto generated by tracing-java and we don't have good enough hooks for better name), `OkHttp: execute-enqueue` for time spent in dispatcher queue and `OkHttp: execute-run` for total time client side executing the call. 

I think the `Tracers#wrap` around okhttp executore service is no longer necessary and is largely the same as `OkHttp: execute-run`

@markelliot 