### PR TITLE
[deprecation] Move feign encoders and decoders out of the "feign" package

### DIFF
--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -19,23 +19,23 @@ package com.palantir.conjure.java.client.jaxrs;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.CborDelegateDecoder;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.CborDelegateEncoder;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.EmptyContainerDecoder;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.GuavaOptionalAwareContract;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.GuavaOptionalAwareDecoder;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.InputStreamDelegateDecoder;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.InputStreamDelegateEncoder;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.Java8OptionalAwareContract;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.Java8OptionalAwareDecoder;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.NeverReturnNullDecoder;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.PathTemplateHeaderEnrichmentContract;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.SlashEncodingContract;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.TextDelegateDecoder;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.TextDelegateEncoder;
 import com.palantir.conjure.java.okhttp.HostEventsSink;
 import com.palantir.conjure.java.okhttp.OkHttpClients;
 import com.palantir.logsafe.Preconditions;
-import feign.ConjureCborDelegateDecoder;
-import feign.ConjureCborDelegateEncoder;
-import feign.ConjureEmptyContainerDecoder;
-import feign.ConjureGuavaOptionalAwareDecoder;
-import feign.ConjureInputStreamDelegateDecoder;
-import feign.ConjureInputStreamDelegateEncoder;
-import feign.ConjureJava8OptionalAwareDecoder;
-import feign.ConjureNeverReturnNullDecoder;
-import feign.ConjureTextDelegateDecoder;
-import feign.ConjureTextDelegateEncoder;
 import feign.Contract;
 import feign.Feign;
 import feign.Logger;
@@ -91,9 +91,9 @@ abstract class AbstractFeignJaxRsClientBuilder {
         return Feign.builder()
                 .contract(createContract())
                 .encoder(
-                        new ConjureInputStreamDelegateEncoder(
-                                new ConjureTextDelegateEncoder(
-                                        new ConjureCborDelegateEncoder(
+                        new InputStreamDelegateEncoder(
+                                new TextDelegateEncoder(
+                                        new CborDelegateEncoder(
                                                 cborObjectMapper,
                                                 new JacksonEncoder(objectMapper)))))
                 .decoder(createDecoder(objectMapper, cborObjectMapper))
@@ -119,14 +119,14 @@ abstract class AbstractFeignJaxRsClientBuilder {
     }
 
     private static Decoder createDecoder(ObjectMapper objectMapper, ObjectMapper cborObjectMapper) {
-        return new ConjureNeverReturnNullDecoder(
-                new ConjureJava8OptionalAwareDecoder(
-                        new ConjureGuavaOptionalAwareDecoder(
-                                new ConjureEmptyContainerDecoder(
+        return new NeverReturnNullDecoder(
+                new Java8OptionalAwareDecoder(
+                        new GuavaOptionalAwareDecoder(
+                                new EmptyContainerDecoder(
                                         objectMapper,
-                                        new ConjureInputStreamDelegateDecoder(
-                                                new ConjureTextDelegateDecoder(
-                                                        new ConjureCborDelegateDecoder(
+                                        new InputStreamDelegateDecoder(
+                                                new TextDelegateDecoder(
+                                                        new CborDelegateDecoder(
                                                                 cborObjectMapper,
                                                                 new JacksonDecoder(objectMapper))))))));
     }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/CborDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/CborDelegateDecoder.java
@@ -1,0 +1,80 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.net.HttpHeaders;
+import feign.FeignException;
+import feign.Response;
+import feign.codec.Decoder;
+import java.io.IOException;
+import java.io.PushbackInputStream;
+import java.lang.reflect.Type;
+import java.util.Collection;
+
+/**
+ * Currently this checks the Content-Type of the response on every request.
+ * <p>
+ * In the cases where we know the Content-Type of the response at compile time, i.e. when the only Accepts header is
+ * application/cbor, this is unnecessary work.
+ * <p>
+ * Ideally we'll codegen a client which handles the content-type switching where necessary (multiple possible response
+ * Content-Types from the server) and does not do the checking where this is known at compile time.
+ */
+public final class CborDelegateDecoder implements Decoder {
+
+    private final ObjectMapper cborObjectMapper;
+    private final Decoder delegate;
+
+    public CborDelegateDecoder(ObjectMapper cborObjectMapper, Decoder delegate) {
+        this.cborObjectMapper = cborObjectMapper;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object decode(Response response, Type type) throws IOException, FeignException {
+        Collection<String> contentTypes =
+                HeaderAccessUtils.caseInsensitiveGet(response.headers(), HttpHeaders.CONTENT_TYPE);
+        if (contentTypes == null) {
+            contentTypes = ImmutableSet.of();
+        }
+
+        if (contentTypes.size() == 1
+                && Iterables.getOnlyElement(contentTypes, "").startsWith(CborDelegateEncoder.MIME_TYPE)) {
+
+            // some sillyness to test whether the input stram is empty
+            // if it's empty, we want to return null rather than having jackson throw
+            int pushbackBufferSize = 1;
+            PushbackInputStream pushbackInputStream = new PushbackInputStream(
+                    response.body().asInputStream(), pushbackBufferSize);
+            int firstByte = pushbackInputStream.read();
+            if (firstByte == -1) {
+                return null; // we don't have any data in the stream
+            }
+            // put the byte back
+            pushbackInputStream.unread(firstByte);
+
+            return cborObjectMapper.readValue(pushbackInputStream, cborObjectMapper.constructType(type));
+
+        } else {
+            return delegate.decode(response, type);
+        }
+    }
+
+}

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/CborDelegateEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/CborDelegateEncoder.java
@@ -1,0 +1,75 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HttpHeaders;
+import feign.RequestTemplate;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+
+/**
+ * An encoder which checks the Content-Type headers for the presence of
+ * application/cbor. If present, encodes the request body as cbor and otherwise
+ * delegates the encoding.
+ *
+ * It's silly that we must do this check every time, given the request content
+ * type is fixed at compile time.
+ *
+ * In the future we will likely codegen the client and thus remove the need for
+ * scanning the headers on every request.
+ */
+public final class CborDelegateEncoder implements Encoder {
+
+    public static final String MIME_TYPE = "application/cbor";
+
+    private final ObjectMapper cborObjectMapper;
+    private final Encoder delegate;
+
+    public CborDelegateEncoder(ObjectMapper cborObjectMapper, Encoder delegate) {
+        this.cborObjectMapper = cborObjectMapper;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
+        Collection<String> contentTypes =
+                HeaderAccessUtils.caseInsensitiveGet(template.headers(), HttpHeaders.CONTENT_TYPE);
+        if (contentTypes == null) {
+            contentTypes = ImmutableSet.of();
+        }
+
+        if (!contentTypes.contains(MIME_TYPE)) {
+            delegate.encode(object, bodyType, template);
+            return;
+        }
+
+        try {
+            JavaType javaType = cborObjectMapper.getTypeFactory().constructType(bodyType);
+            template.body(cborObjectMapper.writerFor(javaType).writeValueAsBytes(object), StandardCharsets.UTF_8);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/EmptyContainerDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/EmptyContainerDecoder.java
@@ -1,0 +1,176 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import feign.Response;
+import feign.codec.Decoder;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Interprets HTTP 204 as an 'empty' type using Jackson initially, then using reflection
+ * to manually invoke a static factory annotated with {@link JsonCreator}.
+ *
+ * Empty instances are cached and re-used to avoid reflection and exceptions on a hot codepath.
+ */
+public final class EmptyContainerDecoder implements Decoder {
+
+    private final LoadingCache<Type, Object> blankInstanceCache;
+    private final Decoder delegate;
+
+    public EmptyContainerDecoder(ObjectMapper mapper, Decoder delegate) {
+        this.delegate = delegate;
+        this.blankInstanceCache = Caffeine.newBuilder()
+                .maximumSize(1000)
+                .expireAfterAccess(10, TimeUnit.MINUTES)
+                .build(new BlankInstanceLoader(mapper));
+    }
+
+    @Override
+    public Object decode(Response response, Type type) throws IOException {
+        Object delegateResult = delegate.decode(response, type);
+
+        if (response.status() == 204 || (response.status() == 200 && delegateResult == null)) {
+            @Nullable Object object = blankInstanceCache.get(type);
+            return Preconditions.checkNotNull(
+                    object,
+                    "Received HTTP 204 but unable to construct an empty instance for return type",
+                    SafeArg.of("type", type));
+        } else {
+            return delegateResult;
+        }
+    }
+
+    private static class BlankInstanceLoader implements CacheLoader<Type, Object> {
+        private static final Logger log = LoggerFactory.getLogger(BlankInstanceLoader.class);
+        private final ObjectMapper mapper;
+
+        BlankInstanceLoader(ObjectMapper mapper) {
+            this.mapper = mapper;
+        }
+
+        @Nullable
+        @Override
+        public Object load(@Nonnull Type type) {
+            return constructEmptyInstance(RawTypes.get(type), type, 10)
+                    .orElse(null);
+        }
+
+        private Optional<Object> constructEmptyInstance(Class<?> clazz, Type originalType, int maxRecursion) {
+            // handle Map, List, Set
+            Optional<Object> collection = coerceCollections(clazz);
+            if (collection.isPresent()) {
+                return collection;
+            }
+
+            // this is our preferred way to construct instances
+            Optional<Object> jacksonInstance = jacksonDeserializeFromNull(clazz);
+            if (jacksonInstance.isPresent()) {
+                return jacksonInstance;
+            }
+
+            // fallback to manual reflection to handle aliases of optionals (and aliases of aliases of optionals)
+            Optional<Method> jsonCreator = getJsonCreatorStaticMethod(clazz);
+            if (jsonCreator.isPresent()) {
+                Method method = jsonCreator.get();
+                Class<?> parameterType = method.getParameters()[0].getType();
+                Optional<Object> parameter = constructEmptyInstance(
+                        parameterType, originalType, decrement(maxRecursion, originalType));
+
+                if (parameter.isPresent()) {
+                    return invokeStaticFactoryMethod(method, parameter.get());
+                } else {
+                    log.debug("Found a @JsonCreator, but couldn't construct the parameter",
+                            SafeArg.of("type", originalType),
+                            SafeArg.of("parameter", parameter));
+                    return Optional.empty();
+                }
+            }
+
+            log.debug("Jackson couldn't instantiate an empty instance and also couldn't find a usable @JsonCreator",
+                    SafeArg.of("type", originalType));
+            return Optional.empty();
+        }
+
+        private static int decrement(int maxRecursion, Type originalType) {
+            Preconditions.checkState(
+                    maxRecursion > 0,
+                    "Unable to construct an empty instance as @JsonCreator requires too much recursion",
+                    SafeArg.of("type", originalType));
+            return maxRecursion - 1;
+        }
+
+        private static Optional<Object> coerceCollections(Class<?> clazz) {
+            if (List.class.isAssignableFrom(clazz)) {
+                return Optional.of(Collections.emptyList());
+            } else if (Set.class.isAssignableFrom(clazz)) {
+                return Optional.of(Collections.emptySet());
+            } else if (Map.class.isAssignableFrom(clazz)) {
+                return Optional.of(Collections.emptyMap());
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        private Optional<Object> jacksonDeserializeFromNull(Class<?> clazz) {
+            try {
+                return Optional.ofNullable(mapper.readValue("null", clazz));
+            } catch (IOException e) {
+                return Optional.empty();
+            }
+        }
+
+        // doesn't attempt to handle multiple @JsonCreator methods on one class
+        private static Optional<Method> getJsonCreatorStaticMethod(@Nonnull Class<?> clazz) {
+            return Arrays.stream(clazz.getMethods())
+                    .filter(method -> Modifier.isStatic(method.getModifiers())
+                            && method.getParameterCount() == 1
+                            && method.getAnnotation(JsonCreator.class) != null)
+                    .findFirst();
+        }
+
+        private static Optional<Object> invokeStaticFactoryMethod(Method method, Object parameter) {
+            try {
+                return Optional.ofNullable(method.invoke(null, parameter));
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                log.debug("Reflection instantiation failed", e);
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaOptionalAwareDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaOptionalAwareDecoder.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import feign.FeignException;
+import feign.Response;
+import feign.codec.Decoder;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * Decorates a Feign {@link Decoder} such that it returns {@link com.google.common.base.Optional#absent}
+ * when observing an HTTP 204 error code for a method with {@link Type} {@link com.google.common.base.Optional}.
+ */
+public final class GuavaOptionalAwareDecoder implements Decoder {
+
+    private final Decoder delegate;
+
+    public GuavaOptionalAwareDecoder(Decoder delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object decode(Response response, Type type) throws IOException, FeignException {
+        if (RawTypes.get(type).equals(com.google.common.base.Optional.class)) {
+            if (response.status() == 204) {
+                return com.google.common.base.Optional.absent();
+            } else {
+                Object decoded = checkNotNull(delegate.decode(response, getInnerType(type)),
+                        "Unexpected null content for response status %s", response.status());
+                return com.google.common.base.Optional.of(decoded);
+            }
+        } else {
+            return delegate.decode(response, type);
+        }
+    }
+
+    private static Type getInnerType(Type type) {
+        ParameterizedType paramType = (ParameterizedType) type;
+        return paramType.getActualTypeArguments()[0];
+    }
+}

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/InputStreamDelegateEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/InputStreamDelegateEncoder.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import feign.RequestTemplate;
+import feign.Util;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * If the body type is an InputStream, write it into the body, otherwise pass to delegate.
+ */
+public final class InputStreamDelegateEncoder implements Encoder {
+    private final Encoder delegate;
+
+    public InputStreamDelegateEncoder(Encoder delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
+        if (bodyType.equals(InputStream.class)) {
+            try {
+                template.body(Util.toByteArray((InputStream) object), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            delegate.encode(object, bodyType, template);
+        }
+    }
+}

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8OptionalAwareDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8OptionalAwareDecoder.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import feign.FeignException;
+import feign.Response;
+import feign.codec.Decoder;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+/**
+ * Decorates a Feign {@link Decoder} such that it returns {@link Optional#empty} when observing an HTTP 204 error code
+ * for a method with {@link Type} {@link Optional}.
+ */
+public final class Java8OptionalAwareDecoder implements Decoder {
+
+    private final Decoder delegate;
+
+    public Java8OptionalAwareDecoder(Decoder delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object decode(Response response, Type type) throws IOException, FeignException {
+        if (RawTypes.get(type).equals(Optional.class)) {
+            if (response.status() == 204) {
+                return Optional.empty();
+            } else {
+                Object decoded = checkNotNull(delegate.decode(response, getInnerType(type)),
+                        "Unexpected null content for response status %s", response.status());
+                return Optional.of(decoded);
+            }
+        } else {
+            return delegate.decode(response, type);
+        }
+    }
+
+    private static Type getInnerType(Type type) {
+        ParameterizedType paramType = (ParameterizedType) type;
+        return paramType.getActualTypeArguments()[0];
+    }
+}

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/NeverReturnNullDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/NeverReturnNullDecoder.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,27 +14,30 @@
  * limitations under the License.
  */
 
-package feign;
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
 
-import com.palantir.conjure.java.client.jaxrs.feignimpl.NeverReturnNullDecoder;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import feign.FeignException;
+import feign.Response;
 import feign.codec.Decoder;
 import java.io.IOException;
 import java.lang.reflect.Type;
 
-/**
- * Use {@link NeverReturnNullDecoder}.
- * @deprecated Use {@link NeverReturnNullDecoder}.
- */
-@Deprecated
-public final class ConjureNeverReturnNullDecoder implements Decoder {
+public final class NeverReturnNullDecoder implements Decoder {
     private final Decoder delegate;
 
-    public ConjureNeverReturnNullDecoder(Decoder delegate) {
-        this.delegate = new NeverReturnNullDecoder(delegate);
+    public NeverReturnNullDecoder(Decoder delegate) {
+        this.delegate = delegate;
     }
 
     @Override
     public Object decode(Response response, Type type) throws FeignException, IOException {
-        return delegate.decode(response, type);
+        Object object = delegate.decode(response, type);
+        Preconditions.checkNotNull(object,
+                "Unexpected null body",
+                SafeArg.of("status", response.status()));
+
+        return object;
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/RawTypes.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/RawTypes.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import com.google.common.reflect.TypeToken;
+import java.lang.reflect.Type;
+
+/**
+ * Utility functionality to detect raw types.
+ */
+final class RawTypes {
+
+    /** Attempts to extract the raw type class from a {@link Type}. */
+    static Class<?> get(final Type type) {
+        return TypeToken.of(type).getRawType();
+    }
+
+    private RawTypes() { }
+}

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/TextDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/TextDelegateDecoder.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.net.HttpHeaders;
+import feign.FeignException;
+import feign.Response;
+import feign.codec.Decoder;
+import feign.codec.StringDecoder;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Delegates to a {@link StringDecoder} if the response has a Content-Type of text/plain, or falls back to the given
+ * delegate otherwise.
+ */
+public final class TextDelegateDecoder implements Decoder {
+    private static final Decoder stringDecoder = new StringDecoder();
+
+    private final Decoder delegate;
+
+    public TextDelegateDecoder(Decoder delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object decode(Response response, Type type) throws IOException, FeignException {
+        Collection<String> contentTypes =
+                HeaderAccessUtils.caseInsensitiveGet(response.headers(), HttpHeaders.CONTENT_TYPE);
+        if (contentTypes == null) {
+            contentTypes = ImmutableSet.of();
+        }
+        // In the case of multiple content types, or an unknown content type, we'll use the delegate instead.
+        if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").startsWith(MediaType.TEXT_PLAIN)) {
+            Object decoded = stringDecoder.decode(response, type);
+            if (decoded == null) {
+                return "";
+            }
+            return decoded;
+        }
+
+        return delegate.decode(response, type);
+    }
+}

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/TextDelegateEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/TextDelegateEncoder.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.net.HttpHeaders;
+import feign.RequestTemplate;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Delegates to a {@link feign.codec.Encoder.Default} if the response has a Content-Type of text/plain, or falls back
+ * to the given delegate otherwise.
+ */
+public final class TextDelegateEncoder implements Encoder {
+    private static final Encoder defaultEncoder = new Encoder.Default();
+
+    private final Encoder delegate;
+
+    public TextDelegateEncoder(Encoder delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
+        Collection<String> contentTypes =
+                HeaderAccessUtils.caseInsensitiveGet(template.headers(), HttpHeaders.CONTENT_TYPE);
+        if (contentTypes == null) {
+            contentTypes = ImmutableSet.of();
+        }
+
+        // In the case of multiple content types, or an unknown content type, we'll use the delegate instead.
+        if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").equals(MediaType.TEXT_PLAIN)) {
+            defaultEncoder.encode(object, bodyType, template);
+        } else {
+            delegate.encode(object,  bodyType, template);
+        }
+    }
+}

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateDecoder.java
@@ -17,63 +17,26 @@
 package feign;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.net.HttpHeaders;
-import com.palantir.conjure.java.client.jaxrs.feignimpl.HeaderAccessUtils;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.CborDelegateDecoder;
 import feign.codec.Decoder;
 import java.io.IOException;
-import java.io.PushbackInputStream;
 import java.lang.reflect.Type;
-import java.util.Collection;
 
 /**
- * Currently this checks the Content-Type of the response on every request.
- * <p>
- * In the cases where we know the Content-Type of the response at compile time, i.e. when the only Accepts header is
- * application/cbor, this is unnecessary work.
- * <p>
- * Ideally we'll codegen a client which handles the content-type switching where necessary (multiple possible response
- * Content-Types from the server) and does not do the checking where this is known at compile time.
+ * Use {@link CborDelegateDecoder}.
+ * @deprecated Use {@link CborDelegateDecoder}.
  */
+@Deprecated
 public final class ConjureCborDelegateDecoder implements Decoder {
 
-    private final ObjectMapper cborObjectMapper;
-    private final Decoder delegate;
+    private final CborDelegateDecoder delegate;
 
     public ConjureCborDelegateDecoder(ObjectMapper cborObjectMapper, Decoder delegate) {
-        this.cborObjectMapper = cborObjectMapper;
-        this.delegate = delegate;
+        this.delegate = new CborDelegateDecoder(cborObjectMapper, delegate);
     }
 
     @Override
     public Object decode(Response response, Type type) throws IOException, FeignException {
-        Collection<String> contentTypes =
-                HeaderAccessUtils.caseInsensitiveGet(response.headers(), HttpHeaders.CONTENT_TYPE);
-        if (contentTypes == null) {
-            contentTypes = ImmutableSet.of();
-        }
-
-        if (contentTypes.size() == 1
-                && Iterables.getOnlyElement(contentTypes, "").startsWith(ConjureCborDelegateEncoder.MIME_TYPE)) {
-
-            // some sillyness to test whether the input stram is empty
-            // if it's empty, we want to return null rather than having jackson throw
-            int pushbackBufferSize = 1;
-            PushbackInputStream pushbackInputStream = new PushbackInputStream(
-                    response.body().asInputStream(), pushbackBufferSize);
-            int firstByte = pushbackInputStream.read();
-            if (firstByte == -1) {
-                return null; // we don't have any data in the stream
-            }
-            // put the byte back
-            pushbackInputStream.unread(firstByte);
-
-            return cborObjectMapper.readValue(pushbackInputStream, cborObjectMapper.constructType(type));
-
-        } else {
-            return delegate.decode(response, type);
-        }
+        return delegate.decode(response, type);
     }
-
 }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateEncoder.java
@@ -16,60 +16,30 @@
 
 package feign;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.net.HttpHeaders;
-import com.palantir.conjure.java.client.jaxrs.feignimpl.HeaderAccessUtils;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.CborDelegateEncoder;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 
 /**
- * An encoder which checks the Content-Type headers for the presence of
- * application/cbor. If present, encodes the request body as cbor and otherwise
- * delegates the encoding.
- *
- * It's silly that we must do this check every time, given the request content
- * type is fixed at compile time.
- *
- * In the future we will likely codegen the client and thus remove the need for
- * scanning the headers on every request.
+ * Use {@link CborDelegateEncoder}.
+ * @deprecated Use {@link CborDelegateEncoder}.
  */
+@Deprecated
 public final class ConjureCborDelegateEncoder implements Encoder {
 
-    public static final String MIME_TYPE = "application/cbor";
+    @SuppressWarnings("unused") // public API
+    public static final String MIME_TYPE = CborDelegateEncoder.MIME_TYPE;
 
-    private final ObjectMapper cborObjectMapper;
     private final Encoder delegate;
 
     public ConjureCborDelegateEncoder(ObjectMapper cborObjectMapper, Encoder delegate) {
-        this.cborObjectMapper = cborObjectMapper;
-        this.delegate = delegate;
+        this.delegate = new CborDelegateEncoder(cborObjectMapper, delegate);
     }
 
     @Override
     public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
-        Collection<String> contentTypes =
-                HeaderAccessUtils.caseInsensitiveGet(template.headers(), HttpHeaders.CONTENT_TYPE);
-        if (contentTypes == null) {
-            contentTypes = ImmutableSet.of();
-        }
-
-        if (!contentTypes.contains(MIME_TYPE)) {
-            delegate.encode(object, bodyType, template);
-            return;
-        }
-
-        try {
-            JavaType javaType = cborObjectMapper.getTypeFactory().constructType(bodyType);
-            template.body(cborObjectMapper.writerFor(javaType).writeValueAsBytes(object), StandardCharsets.UTF_8);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        delegate.encode(object, bodyType, template);
     }
-
 }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureEmptyContainerDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureEmptyContainerDecoder.java
@@ -16,160 +16,27 @@
 
 package feign;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.benmanes.caffeine.cache.CacheLoader;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.SafeArg;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.EmptyContainerDecoder;
 import feign.codec.Decoder;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Interprets HTTP 204 as an 'empty' type using Jackson initially, then using reflection
- * to manually invoke a static factory annotated with {@link JsonCreator}.
- *
- * Empty instances are cached and re-used to avoid reflection and exceptions on a hot codepath.
+ * Use {@link EmptyContainerDecoder}.
+ * @deprecated Use {@link EmptyContainerDecoder}.
  */
+@Deprecated
 public final class ConjureEmptyContainerDecoder implements Decoder {
 
-    private final LoadingCache<Type, Object> blankInstanceCache;
     private final Decoder delegate;
 
     public ConjureEmptyContainerDecoder(ObjectMapper mapper, Decoder delegate) {
-        this.delegate = delegate;
-        this.blankInstanceCache = Caffeine.newBuilder()
-                .maximumSize(1000)
-                .expireAfterAccess(10, TimeUnit.MINUTES)
-                .build(new BlankInstanceLoader(mapper));
+        this.delegate = new EmptyContainerDecoder(mapper, delegate);
     }
 
     @Override
     public Object decode(Response response, Type type) throws IOException {
-        Object delegateResult = delegate.decode(response, type);
-
-        if (response.status() == 204 || (response.status() == 200 && delegateResult == null)) {
-            @Nullable Object object = blankInstanceCache.get(type);
-            return Preconditions.checkNotNull(
-                    object,
-                    "Received HTTP 204 but unable to construct an empty instance for return type",
-                    SafeArg.of("type", type));
-        } else {
-            return delegateResult;
-        }
-    }
-
-    private static class BlankInstanceLoader implements CacheLoader<Type, Object> {
-        private static final Logger log = LoggerFactory.getLogger(BlankInstanceLoader.class);
-        private final ObjectMapper mapper;
-
-        BlankInstanceLoader(ObjectMapper mapper) {
-            this.mapper = mapper;
-        }
-
-        @Nullable
-        @Override
-        public Object load(@Nonnull Type type) {
-            return constructEmptyInstance(Types.getRawType(type), type, 10)
-                    .orElse(null);
-        }
-
-        private Optional<Object> constructEmptyInstance(Class<?> clazz, Type originalType, int maxRecursion) {
-            // handle Map, List, Set
-            Optional<Object> collection = coerceCollections(clazz);
-            if (collection.isPresent()) {
-                return collection;
-            }
-
-            // this is our preferred way to construct instances
-            Optional<Object> jacksonInstance = jacksonDeserializeFromNull(clazz);
-            if (jacksonInstance.isPresent()) {
-                return jacksonInstance;
-            }
-
-            // fallback to manual reflection to handle aliases of optionals (and aliases of aliases of optionals)
-            Optional<Method> jsonCreator = getJsonCreatorStaticMethod(clazz);
-            if (jsonCreator.isPresent()) {
-                Method method = jsonCreator.get();
-                Class<?> parameterType = method.getParameters()[0].getType();
-                Optional<Object> parameter = constructEmptyInstance(
-                        parameterType, originalType, decrement(maxRecursion, originalType));
-
-                if (parameter.isPresent()) {
-                    return invokeStaticFactoryMethod(method, parameter.get());
-                } else {
-                    log.debug("Found a @JsonCreator, but couldn't construct the parameter",
-                            SafeArg.of("type", originalType),
-                            SafeArg.of("parameter", parameter));
-                    return Optional.empty();
-                }
-            }
-
-            log.debug("Jackson couldn't instantiate an empty instance and also couldn't find a usable @JsonCreator",
-                    SafeArg.of("type", originalType));
-            return Optional.empty();
-        }
-
-        private static int decrement(int maxRecursion, Type originalType) {
-            Preconditions.checkState(
-                    maxRecursion > 0,
-                    "Unable to construct an empty instance as @JsonCreator requires too much recursion",
-                    SafeArg.of("type", originalType));
-            return maxRecursion - 1;
-        }
-
-        private static Optional<Object> coerceCollections(Class<?> clazz) {
-            if (List.class.isAssignableFrom(clazz)) {
-                return Optional.of(Collections.emptyList());
-            } else if (Set.class.isAssignableFrom(clazz)) {
-                return Optional.of(Collections.emptySet());
-            } else if (Map.class.isAssignableFrom(clazz)) {
-                return Optional.of(Collections.emptyMap());
-            } else {
-                return Optional.empty();
-            }
-        }
-
-        private Optional<Object> jacksonDeserializeFromNull(Class<?> clazz) {
-            try {
-                return Optional.ofNullable(mapper.readValue("null", clazz));
-            } catch (IOException e) {
-                return Optional.empty();
-            }
-        }
-
-        // doesn't attempt to handle multiple @JsonCreator methods on one class
-        private static Optional<Method> getJsonCreatorStaticMethod(@Nonnull Class<?> clazz) {
-            return Arrays.stream(clazz.getMethods())
-                    .filter(method -> Modifier.isStatic(method.getModifiers())
-                            && method.getParameterCount() == 1
-                            && method.getAnnotation(JsonCreator.class) != null)
-                    .findFirst();
-        }
-
-        private static Optional<Object> invokeStaticFactoryMethod(Method method, Object parameter) {
-            try {
-                return Optional.ofNullable(method.invoke(null, parameter));
-            } catch (IllegalAccessException | InvocationTargetException e) {
-                log.debug("Reflection instantiation failed", e);
-                return Optional.empty();
-            }
-        }
+        return delegate.decode(response, type);
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureGuavaOptionalAwareDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureGuavaOptionalAwareDecoder.java
@@ -16,42 +16,26 @@
 
 package feign;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
+import com.palantir.conjure.java.client.jaxrs.feignimpl.GuavaOptionalAwareDecoder;
 import feign.codec.Decoder;
 import java.io.IOException;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
 /**
- * Decorates a Feign {@link Decoder} such that it returns {@link com.google.common.base.Optional#absent}
- * when observing an HTTP 204 error code for a method with {@link Type} {@link com.google.common.base.Optional}.
+ * Use {@link GuavaOptionalAwareDecoder}.
+ * @deprecated Use {@link GuavaOptionalAwareDecoder}.
  */
+@Deprecated
 public final class ConjureGuavaOptionalAwareDecoder implements Decoder {
 
     private final Decoder delegate;
 
     public ConjureGuavaOptionalAwareDecoder(Decoder delegate) {
-        this.delegate = delegate;
+        this.delegate = new GuavaOptionalAwareDecoder(delegate);
     }
 
     @Override
     public Object decode(Response response, Type type) throws IOException, FeignException {
-        if (Types.getRawType(type).equals(com.google.common.base.Optional.class)) {
-            if (response.status() == 204) {
-                return com.google.common.base.Optional.absent();
-            } else {
-                Object decoded = checkNotNull(delegate.decode(response, getInnerType(type)),
-                        "Unexpected null content for response status %s", response.status());
-                return com.google.common.base.Optional.of(decoded);
-            }
-        } else {
-            return delegate.decode(response, type);
-        }
-    }
-
-    private static Type getInnerType(Type type) {
-        ParameterizedType paramType = (ParameterizedType) type;
-        return paramType.getActualTypeArguments()[0];
+        return delegate.decode(response, type);
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureInputStreamDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureInputStreamDelegateDecoder.java
@@ -16,29 +16,25 @@
 
 package feign;
 
+import com.palantir.conjure.java.client.jaxrs.feignimpl.InputStreamDelegateDecoder;
 import feign.codec.Decoder;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Type;
 
 /**
- * If the return type is InputStream, return it, otherwise delegate to provided decoder.
+ * Use {@link InputStreamDelegateDecoder}.
+ * @deprecated Use {@link InputStreamDelegateDecoder}.
  */
+@Deprecated
 public final class ConjureInputStreamDelegateDecoder implements Decoder {
     private final Decoder delegate;
 
     public ConjureInputStreamDelegateDecoder(Decoder delegate) {
-        this.delegate = delegate;
+        this.delegate = new InputStreamDelegateDecoder(delegate);
     }
 
     @Override
     public Object decode(Response response, Type type) throws IOException, FeignException {
-        if (type.equals(InputStream.class)) {
-            byte[] body = response.body() != null ? Util.toByteArray(response.body().asInputStream()) : new byte[0];
-            return new ByteArrayInputStream(body);
-        } else {
-            return delegate.decode(response, type);
-        }
+        return delegate.decode(response, type);
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureInputStreamDelegateEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureInputStreamDelegateEncoder.java
@@ -16,33 +16,25 @@
 
 package feign;
 
+import com.palantir.conjure.java.client.jaxrs.feignimpl.InputStreamDelegateEncoder;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
 
 /**
- * If the body type is an InputStream, write it into the body, otherwise pass to delegate.
+ * Use {@link InputStreamDelegateEncoder}.
+ * @deprecated Use {@link InputStreamDelegateEncoder}.
  */
+@Deprecated
 public final class ConjureInputStreamDelegateEncoder implements Encoder {
     private final Encoder delegate;
 
     public ConjureInputStreamDelegateEncoder(Encoder delegate) {
-        this.delegate = delegate;
+        this.delegate = new InputStreamDelegateEncoder(delegate);
     }
 
     @Override
     public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
-        if (bodyType.equals(InputStream.class)) {
-            try {
-                template.body(Util.toByteArray((InputStream) object), StandardCharsets.UTF_8);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        } else {
-            delegate.encode(object, bodyType, template);
-        }
+        delegate.encode(object, bodyType, template);
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureTextDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureTextDelegateDecoder.java
@@ -16,46 +16,26 @@
 
 package feign;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.net.HttpHeaders;
-import com.palantir.conjure.java.client.jaxrs.feignimpl.HeaderAccessUtils;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.TextDelegateDecoder;
 import feign.codec.Decoder;
-import feign.codec.StringDecoder;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.Collection;
-import javax.ws.rs.core.MediaType;
 
 /**
- * Delegates to a {@link StringDecoder} if the response has a Content-Type of text/plain, or falls back to the given
- * delegate otherwise.
+ * Use {@link TextDelegateDecoder}.
+ * @deprecated Use {@link TextDelegateDecoder}.
  */
+@Deprecated
 public final class ConjureTextDelegateDecoder implements Decoder {
-    private static final Decoder stringDecoder = new StringDecoder();
 
     private final Decoder delegate;
 
     public ConjureTextDelegateDecoder(Decoder delegate) {
-        this.delegate = delegate;
+        this.delegate = new TextDelegateDecoder(delegate);
     }
 
     @Override
     public Object decode(Response response, Type type) throws IOException, FeignException {
-        Collection<String> contentTypes =
-                HeaderAccessUtils.caseInsensitiveGet(response.headers(), HttpHeaders.CONTENT_TYPE);
-        if (contentTypes == null) {
-            contentTypes = ImmutableSet.of();
-        }
-        // In the case of multiple content types, or an unknown content type, we'll use the delegate instead.
-        if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").startsWith(MediaType.TEXT_PLAIN)) {
-            Object decoded = stringDecoder.decode(response, type);
-            if (decoded == null) {
-                return "";
-            }
-            return decoded;
-        }
-
         return delegate.decode(response, type);
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureTextDelegateEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureTextDelegateEncoder.java
@@ -16,42 +16,26 @@
 
 package feign;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.net.HttpHeaders;
-import com.palantir.conjure.java.client.jaxrs.feignimpl.HeaderAccessUtils;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.TextDelegateEncoder;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import java.lang.reflect.Type;
-import java.util.Collection;
-import javax.ws.rs.core.MediaType;
 
 /**
- * Delegates to a {@link feign.codec.Encoder.Default} if the response has a Content-Type of text/plain, or falls back
- * to the given delegate otherwise.
+ * Use {@link TextDelegateEncoder}.
+ * @deprecated Use {@link TextDelegateEncoder}.
  */
+@Deprecated
 public final class ConjureTextDelegateEncoder implements Encoder {
-    private static final Encoder defaultEncoder = new Encoder.Default();
 
     private final Encoder delegate;
 
     public ConjureTextDelegateEncoder(Encoder delegate) {
-        this.delegate = delegate;
+        this.delegate = new TextDelegateEncoder(delegate);
     }
 
     @Override
     public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
-        Collection<String> contentTypes =
-                HeaderAccessUtils.caseInsensitiveGet(template.headers(), HttpHeaders.CONTENT_TYPE);
-        if (contentTypes == null) {
-            contentTypes = ImmutableSet.of();
-        }
-
-        // In the case of multiple content types, or an unknown content type, we'll use the delegate instead.
-        if (contentTypes.size() == 1 && Iterables.getOnlyElement(contentTypes, "").equals(MediaType.TEXT_PLAIN)) {
-            defaultEncoder.encode(object, bodyType, template);
-        } else {
-            delegate.encode(object,  bodyType, template);
-        }
+        delegate.encode(object, bodyType, template);
     }
 }

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/EmptyContainerDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/EmptyContainerDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package feign;
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HttpHeaders;
 import com.palantir.conjure.java.serialization.ObjectMappers;
+import feign.Response;
 import feign.codec.Decoder;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -47,14 +48,14 @@ import javax.annotation.Generated;
 import javax.ws.rs.core.MediaType;
 import org.junit.Test;
 
-public class ConjureEmptyContainerDecoderTest {
+public class EmptyContainerDecoderTest {
 
     private static final ObjectMapper mapper = ObjectMappers.newClientObjectMapper();
     private static final Response HTTP_204 =
             Response.create(204, "No Content", Collections.emptyMap(), new byte[] {});
     private final Decoder delegate = mock(Decoder.class);
-    private final ConjureEmptyContainerDecoder emptyContainerDecoder =
-            new ConjureEmptyContainerDecoder(mapper, delegate);
+    private final EmptyContainerDecoder emptyContainerDecoder =
+            new EmptyContainerDecoder(mapper, delegate);
 
     @Test
     public void http_200_uses_delegate_decoder() throws IOException {

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/InputStreamDelegateDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/InputStreamDelegateDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package feign;
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -25,8 +25,9 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.conjure.java.client.jaxrs.JaxRsClient;
 import com.palantir.conjure.java.client.jaxrs.TestBase;
-import com.palantir.conjure.java.client.jaxrs.feignimpl.GuavaTestServer;
 import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import feign.Response;
+import feign.Util;
 import feign.codec.Decoder;
 import io.dropwizard.Configuration;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -38,7 +39,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public final class ConjureInputStreamDelegateDecoderTest extends TestBase {
+public final class InputStreamDelegateDecoderTest extends TestBase {
     @ClassRule
     public static final DropwizardAppRule<Configuration> APP = new DropwizardAppRule<>(GuavaTestServer.class,
             "src/test/resources/test-server.yml");
@@ -50,7 +51,7 @@ public final class ConjureInputStreamDelegateDecoderTest extends TestBase {
     @Before
     public void before() {
         delegate = Mockito.mock(Decoder.class);
-        inputStreamDelegateDecoder = new ConjureInputStreamDelegateDecoder(delegate);
+        inputStreamDelegateDecoder = new InputStreamDelegateDecoder(delegate);
 
         String endpointUri = "http://localhost:" + APP.getLocalPort();
         service = JaxRsClient.create(

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/InputStreamDelegateEncoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/InputStreamDelegateEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package feign;
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -22,8 +22,8 @@ import static org.mockito.Mockito.verify;
 
 import com.palantir.conjure.java.client.jaxrs.JaxRsClient;
 import com.palantir.conjure.java.client.jaxrs.TestBase;
-import com.palantir.conjure.java.client.jaxrs.feignimpl.GuavaTestServer;
 import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import feign.RequestTemplate;
 import feign.codec.Encoder;
 import io.dropwizard.Configuration;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -38,7 +38,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public final class ConjureInputStreamDelegateEncoderTest extends TestBase {
+public final class InputStreamDelegateEncoderTest extends TestBase {
     @Mock
     private Encoder delegate;
 
@@ -54,7 +54,7 @@ public final class ConjureInputStreamDelegateEncoderTest extends TestBase {
 
     @Before
     public void before() {
-        inputStreamDelegateEncoder = new ConjureInputStreamDelegateEncoder(delegate);
+        inputStreamDelegateEncoder = new InputStreamDelegateEncoder(delegate);
 
         String endpointUri = "http://localhost:" + APP.getLocalPort();
         service = JaxRsClient.create(

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/NeverReturnNullDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/NeverReturnNullDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package feign;
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,6 +24,7 @@ import com.palantir.conjure.java.client.jaxrs.TestBase;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.testing.Assertions;
+import feign.Response;
 import feign.codec.Decoder;
 import feign.jackson.JacksonDecoder;
 import java.nio.charset.StandardCharsets;
@@ -32,10 +33,10 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
-public final class ConjureNeverReturnNullDecoderTest extends TestBase {
+public final class NeverReturnNullDecoderTest extends TestBase {
 
     private final Map<String, Collection<String>> headers = Maps.newHashMap();
-    private final Decoder textDelegateDecoder = new ConjureNeverReturnNullDecoder(
+    private final Decoder textDelegateDecoder = new NeverReturnNullDecoder(
             new JacksonDecoder(ObjectMappers.newClientObjectMapper()));
 
     @Test

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/TextDelegateDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/TextDelegateDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package feign;
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -31,8 +31,9 @@ import com.google.common.collect.Maps;
 import com.google.common.net.HttpHeaders;
 import com.palantir.conjure.java.client.jaxrs.JaxRsClient;
 import com.palantir.conjure.java.client.jaxrs.TestBase;
-import com.palantir.conjure.java.client.jaxrs.feignimpl.GuavaTestServer;
 import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import feign.FeignException;
+import feign.Response;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import io.dropwizard.Configuration;
@@ -47,7 +48,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public final class ConjureTextDelegateDecoderTest extends TestBase {
+public final class TextDelegateDecoderTest extends TestBase {
     private static final String DELEGATE_RESPONSE = "delegate response";
 
     @ClassRule
@@ -66,7 +67,7 @@ public final class ConjureTextDelegateDecoderTest extends TestBase {
     public void before() {
         delegate = mock(Decoder.class);
         headers = Maps.newHashMap();
-        textDelegateDecoder = new ConjureTextDelegateDecoder(delegate);
+        textDelegateDecoder = new TextDelegateDecoder(delegate);
 
         String endpointUri = "http://localhost:" + APP.getLocalPort();
         service = JaxRsClient.create(

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/TextDelegateEncoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/TextDelegateEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package feign;
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 import com.google.common.collect.Maps;
 import com.google.common.net.HttpHeaders;
+import feign.RequestTemplate;
 import feign.codec.Encoder;
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,7 +31,7 @@ import javax.ws.rs.core.MediaType;
 import org.junit.Before;
 import org.junit.Test;
 
-public final class ConjureTextDelegateEncoderTest {
+public final class TextDelegateEncoderTest {
 
     private RequestTemplate requestTemplate;
     private Map<String, Collection<String>> headers;
@@ -41,7 +42,7 @@ public final class ConjureTextDelegateEncoderTest {
     public void before() {
         delegate = mock(Encoder.class);
         headers = Maps.newHashMap();
-        textDelegateEncoder = new ConjureTextDelegateEncoder(delegate);
+        textDelegateEncoder = new TextDelegateEncoder(delegate);
         requestTemplate = new RequestTemplate();
     }
 


### PR DESCRIPTION
Our style guide states that our code must not live in other packages:
> The package name of internal as well as open source projects
> starts with `com.palantir.<project name>`
https://github.com/palantir/gradle-baseline/blob/develop/docs/java-style-guide/readme.md#package-statement

Deprecation: Classes which were previously in the `feign` package
have been migrated into `com.palantir.conjure.java.client.jaxrs.feignimpl`.
These are implementation details of the conjure-java-jaxrs-client library,
however they are still accessable to avoid blocking existing consumers.
We have provided deprecated classes in the `feign` package which shim to
the new location for now.

Classes originally existed in the feign package to use the
package-private `Types.getRawType` utility. This change updates
those uses to a new internal utility `RawTypes.get` which is
implemented using guava TypeToken.getRawType.

## Before this PR
We failed to follow our style rules. This resulted in classpath conflicts moving from `remoting3` to `conjure-java-runtime` because only `com.palantir` packages were renamed.

## After this PR
==COMMIT_MSG==
Move feign encoders and decoders out of the "feign" package.
==COMMIT_MSG==

## Possible downsides?
Code which used these classes directly will get deprecation warnings.