### PR TITLE
[improvement] Make http2 configurable

### DIFF
--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -105,6 +105,9 @@ public interface ClientConfiguration {
     /** Indicates whether client-side sympathetic QoS should be enabled. */
     ClientQoS clientQoS();
 
+    /** Indicates whether the client should support the HTTP/2 protocol. */
+    boolean http2();
+
     @Value.Check
     default void check() {
         if (meshProxy().isPresent()) {

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -48,6 +48,7 @@ public final class ClientConfigurations {
     private static final int DEFAULT_MAX_NUM_RETRIES = 4;
     private static final ClientConfiguration.ClientQoS DEFAULT_DISABLE_SYMPATHETIC_QOS =
             ClientConfiguration.ClientQoS.ENABLED;
+    private static final boolean DEFAULT_HTTP_2 = true;
 
     private ClientConfigurations() {}
 
@@ -74,6 +75,7 @@ public final class ClientConfigurations {
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .backoffSlotSize(config.backoffSlotSize().orElse(DEFAULT_BACKOFF_SLOT_SIZE))
                 .clientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
+                .http2(DEFAULT_HTTP_2)
                 .build();
     }
 
@@ -99,6 +101,7 @@ public final class ClientConfigurations {
                 .nodeSelectionStrategy(DEFAULT_NODE_SELECTION_STRATEGY)
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .clientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
+                .http2(DEFAULT_HTTP_2)
                 .build();
     }
 

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -56,6 +56,7 @@ public final class ClientConfigurationsTest {
         assertThat(actual.enableGcmCipherSuites()).isFalse();
         assertThat(actual.fallbackToCommonNameVerification()).isFalse();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);
+        assertThat(actual.http2()).isTrue();
     }
 
     @Test
@@ -73,6 +74,7 @@ public final class ClientConfigurationsTest {
         assertThat(actual.enableGcmCipherSuites()).isFalse();
         assertThat(actual.fallbackToCommonNameVerification()).isFalse();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);
+        assertThat(actual.http2()).isTrue();
     }
 
     @Test

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -34,6 +34,7 @@ import com.palantir.tracing.okhttp3.OkhttpTraceInterceptor;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -47,6 +48,7 @@ import okhttp3.ConnectionSpec;
 import okhttp3.Credentials;
 import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import okhttp3.TlsVersion;
 import okhttp3.internal.Util;
 import org.slf4j.Logger;
@@ -203,6 +205,11 @@ public final class OkHttpClients {
 
         // cipher setup
         client.connectionSpecs(createConnectionSpecs(config.enableGcmCipherSuites()));
+
+        // http2
+        if (!config.http2()) {
+            client.protocols(Arrays.asList(Protocol.HTTP_1_1));
+        }
 
         // increase default connection pool from 5 @ 5 minutes to 100 @ 10 minutes
         client.connectionPool(connectionPool);


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->
Fixes #1058 
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The okhttp library used by conjure-java-runtime allows configuring which protocols the client will support, which is useful in situations where a server doesn't behave correctly when HTTP/2 is enabled. However, conjure-java-runtime's ClientConfiguration does not expose this configuration.
## After this PR
==COMMIT_MSG==
Allow http2 to be disabled via code configuration
==COMMIT_MSG==
HTTP/2 remains enabled by default, but there is now a field in ClientConfiguration to disable it if necessary.
## Possible downsides?
