### PR TITLE
[fix] Terminate acquire limiter span before executing

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -157,10 +157,8 @@ final class RemotingOkHttpCall extends ForwardingCall {
         Futures.addCallback(limiterListener, new FutureCallback<Limiter.Listener>() {
             @Override
             public void onSuccess(Limiter.Listener listener) {
-                tracer.withTrace(() -> {
-                    enqueueInternal(callback);
-                    return null;
-                });
+                tracer.withTrace(() -> null);
+                enqueueInternal(callback);
             }
 
             @Override


### PR DESCRIPTION
## Before this PR
acquire-limiter-run span was parent of dispatcher span

## After this PR
==COMMIT_MSG==
Terminate acquire limiter run span no longer is parent of dispatcher span and is fully terminated before enqueuing request 
==COMMIT_MSG==

## Possible downsides?
Span structure changes again