### PR TITLE
Convert empty optional responses in retrofit clients

### DIFF
--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/CoerceNullValuesCallAdapterFactory.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/CoerceNullValuesCallAdapterFactory.java
@@ -13,6 +13,10 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -29,16 +33,16 @@ import retrofit2.Retrofit;
  * type is a collection. Jackson can only do this for fields inside an object, but for top-level fields we have to do
  * this manually.
  * <p>
- * This class is the counterpart of {@link CoerceNullCollectionsConverterFactory} and handles coercion of 204/205
+ * This class is the counterpart of {@link CoerceNullValuesConverterFactory} and handles coercion of 204/205
  * responses to the default values for collections (without this, the {@link Response} body would be null,
  * according to {@link retrofit2.OkHttpCall#parseResponse(okhttp3.Response)}).
  */
 // TODO(dsanduleac): link to spec
-final class CoerceNullCollectionsCallAdapterFactory extends CallAdapter.Factory {
+final class CoerceNullValuesCallAdapterFactory extends CallAdapter.Factory {
 
     private final CallAdapter.Factory delegate;
 
-    CoerceNullCollectionsCallAdapterFactory(Factory delegate) {
+    CoerceNullValuesCallAdapterFactory(Factory delegate) {
         this.delegate = delegate;
     }
 
@@ -63,7 +67,18 @@ final class CoerceNullCollectionsCallAdapterFactory extends CallAdapter.Factory 
             return new DefaultingOnNullAdapter<>(callAdapter, Collections::emptySet);
         } else if (Map.class.isAssignableFrom(rawType)) {
             return new DefaultingOnNullAdapter<>(callAdapter, Collections::emptyMap);
+        } else if (rawType == java.util.Optional.class) {
+            return new DefaultingOnNullAdapter<>(callAdapter, Optional::empty);
+        } else if (rawType == java.util.OptionalInt.class) {
+            return new DefaultingOnNullAdapter<>(callAdapter, OptionalInt::empty);
+        } else if (rawType == java.util.OptionalLong.class) {
+            return new DefaultingOnNullAdapter<>(callAdapter, OptionalLong::empty);
+        } else if (rawType == java.util.OptionalDouble.class) {
+            return new DefaultingOnNullAdapter<>(callAdapter, OptionalDouble::empty);
+        } else if (rawType == com.google.common.base.Optional.class) {
+            return new DefaultingOnNullAdapter<>(callAdapter, com.google.common.base.Optional::absent);
         }
+
         return callAdapter;
     }
 

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/CoerceNullValuesConverterFactory.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/CoerceNullValuesConverterFactory.java
@@ -22,6 +22,10 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import okhttp3.RequestBody;
 import okhttp3.Response;
@@ -41,10 +45,10 @@ import retrofit2.Retrofit;
  * this manually.)
  */
 // TODO(dsanduleac): link to spec
-final class CoerceNullCollectionsConverterFactory extends Converter.Factory {
+final class CoerceNullValuesConverterFactory extends Converter.Factory {
     private final Converter.Factory delegate;
 
-    CoerceNullCollectionsConverterFactory(Converter.Factory delegate) {
+    CoerceNullValuesConverterFactory(Converter.Factory delegate) {
         this.delegate = delegate;
     }
 
@@ -69,6 +73,7 @@ final class CoerceNullCollectionsConverterFactory extends Converter.Factory {
             this.type = type;
         }
 
+        @SuppressWarnings("CyclomaticComplexity")
         @Override
         public Object convert(ResponseBody value) throws IOException {
             Object object = (value.contentLength() == 0) ? null : responseBodyConverter.convert(value);
@@ -84,9 +89,19 @@ final class CoerceNullCollectionsConverterFactory extends Converter.Factory {
                 return Collections.emptySet();
             } else if (Map.class.isAssignableFrom(rawType)) {
                 return Collections.emptyMap();
-            } else {
-                return null;
+            }  else if (rawType == java.util.Optional.class) {
+                return Optional.empty();
+            } else if (rawType == java.util.OptionalInt.class) {
+                return OptionalInt.empty();
+            } else if (rawType == java.util.OptionalLong.class) {
+                return OptionalLong.empty();
+            } else if (rawType == java.util.OptionalDouble.class) {
+                return OptionalDouble.empty();
+            } else if (rawType == com.google.common.base.Optional.class) {
+                return com.google.common.base.Optional.absent();
             }
+
+            return null;
         }
     }
 }

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
@@ -58,12 +58,13 @@ public final class Retrofit2ClientBuilder {
                 .addConverterFactory(
                         new CborConverterFactory(
                                 new NeverReturnNullConverterFactory(
-                                        new CoerceNullCollectionsConverterFactory(
+                                        new CoerceNullValuesConverterFactory(
                                                 JacksonConverterFactory.create(OBJECT_MAPPER))),
                                 CBOR_OBJECT_MAPPER))
                 .addConverterFactory(OptionalObjectToStringConverterFactory.INSTANCE)
-                .addCallAdapterFactory(new CoerceNullCollectionsCallAdapterFactory(
-                        AsyncSerializableErrorCallAdapterFactory.INSTANCE))
+                .addCallAdapterFactory(
+                        new CoerceNullValuesCallAdapterFactory(
+                                AsyncSerializableErrorCallAdapterFactory.INSTANCE))
                 .build();
         return retrofit.create(serviceClass);
     }

--- a/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientApiTest.java
+++ b/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientApiTest.java
@@ -36,6 +36,9 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -75,17 +78,12 @@ public final class Retrofit2ClientApiTest extends TestBase {
     }
 
     @Test
-    public void testOptionalStringHandling() throws IOException, InterruptedException {
+    public void testGuavaOptionalParamStringHandling() throws IOException, InterruptedException {
         server.enqueue(new MockResponse().setBody("\"pong\""));
         assertThat(service.getGuavaOptionalString(guavaOptional("p"), guavaOptional("q")).execute().body())
                 .isEqualTo(guavaOptional("pong"));
         assertThat(server.takeRequest().getPath())
                 .isEqualTo("/getGuavaOptionalString/p/?queryString=q");
-
-        server.enqueue(new MockResponse().setBody("\"pong\""));
-        assertThat(service.getJava8OptionalString(java8Optional("p"), java8Optional("q")).execute().body())
-                .isEqualTo(java8Optional("pong"));
-        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalString/p/?queryString=q");
 
         server.enqueue(new MockResponse().setBody("\"pong\""));
         assertThat(service.getGuavaOptionalString(guavaOptional("p"), guavaEmptyOptional()).execute().body())
@@ -94,10 +92,103 @@ public final class Retrofit2ClientApiTest extends TestBase {
                 .isEqualTo("/getGuavaOptionalString/p/");
 
         server.enqueue(new MockResponse().setBody("\"pong\""));
+        assertThat(service.getGuavaOptionalString(guavaEmptyOptional(), guavaOptional("q")).execute().body())
+                .isEqualTo(guavaOptional("pong"));
+        assertThat(server.takeRequest().getPath())
+                .isEqualTo("/getGuavaOptionalString//?queryString=q");
+
+        server.enqueue(new MockResponse().setBody("\"pong\""));
         assertThat(service.getGuavaOptionalString(guavaEmptyOptional(), guavaEmptyOptional()).execute().body())
                 .isEqualTo(guavaOptional("pong"));
         assertThat(server.takeRequest().getPath())
                 .isEqualTo("/getGuavaOptionalString//");
+    }
+
+    @Test
+    public void testOptionalParamStringHandling() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse().setBody("\"pong\""));
+        assertThat(service.getJava8OptionalString(java8Optional("p"), java8Optional("q")).execute().body())
+                .isEqualTo(java8Optional("pong"));
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalString/p/?queryString=q");
+
+        server.enqueue(new MockResponse().setBody("\"pong\""));
+        assertThat(service.getJava8OptionalString(java8Optional("p"), java8EmptyOptional()).execute().body())
+                .isEqualTo(java8Optional("pong"));
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalString/p/");
+
+        server.enqueue(new MockResponse().setBody("\"pong\""));
+        assertThat(service.getJava8OptionalString(java8EmptyOptional(), java8Optional("q")).execute().body())
+                .isEqualTo(java8Optional("pong"));
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalString//?queryString=q");
+
+        server.enqueue(new MockResponse().setBody("\"pong\""));
+        assertThat(service.getJava8OptionalString(java8EmptyOptional(), java8EmptyOptional()).execute().body())
+                .isEqualTo(java8Optional("pong"));
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalString//");
+    }
+
+    @Test
+    public void testEmptyGuavaOptionalResponseStringHandling() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse().setResponseCode(204));
+        assertThat(service.getGuavaOptionalString(guavaEmptyOptional(), guavaEmptyOptional()).execute().body())
+                .isEqualTo(guavaEmptyOptional());
+        assertThat(server.takeRequest().getPath())
+                .isEqualTo("/getGuavaOptionalString//");
+    }
+
+    @Test
+    public void testEmptyOptionalResponseStringHandling() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse().setResponseCode(204));
+        assertThat(service.getJava8OptionalString(java8EmptyOptional(), java8EmptyOptional()).execute().body())
+                .isEqualTo(java8EmptyOptional());
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalString//");
+
+        server.enqueue(new MockResponse().setResponseCode(204));
+        assertThat(service.getJava8OptionalInt().execute().body())
+                .isEqualTo(OptionalInt.empty());
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalInt");
+
+        server.enqueue(new MockResponse().setResponseCode(204));
+        assertThat(service.getJava8OptionalLong().execute().body())
+                .isEqualTo(OptionalLong.empty());
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalLong");
+
+        server.enqueue(new MockResponse().setResponseCode(204));
+        assertThat(service.getJava8OptionalDouble().execute().body())
+                .isEqualTo(OptionalDouble.empty());
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalDouble");
+    }
+
+    @Test
+    public void testNullGuavaOptionalResponseStringHandling() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse().setBody("null"));
+        assertThat(service.getGuavaOptionalString(guavaEmptyOptional(), guavaEmptyOptional()).execute().body())
+                .isEqualTo(guavaEmptyOptional());
+        assertThat(server.takeRequest().getPath())
+                .isEqualTo("/getGuavaOptionalString//");
+    }
+
+    @Test
+    public void testNullOptionalResponseStringHandling() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse().setBody("null"));
+        assertThat(service.getJava8OptionalString(java8EmptyOptional(), java8EmptyOptional()).execute().body())
+                .isEqualTo(java8EmptyOptional());
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalString//");
+
+        server.enqueue(new MockResponse().setBody("null"));
+        assertThat(service.getJava8OptionalInt().execute().body())
+                .isEqualTo(OptionalInt.empty());
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalInt");
+
+        server.enqueue(new MockResponse().setBody("null"));
+        assertThat(service.getJava8OptionalLong().execute().body())
+                .isEqualTo(OptionalLong.empty());
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalLong");
+
+        server.enqueue(new MockResponse().setBody("null"));
+        assertThat(service.getJava8OptionalDouble().execute().body())
+                .isEqualTo(OptionalDouble.empty());
+        assertThat(server.takeRequest().getPath()).isEqualTo("/getJava8OptionalDouble");
     }
 
     @Test
@@ -330,5 +421,9 @@ public final class Retrofit2ClientApiTest extends TestBase {
 
     private static <T> java.util.Optional<T> java8Optional(T value) {
         return java.util.Optional.of(value);
+    }
+
+    private static <T> java.util.Optional<T> java8EmptyOptional() {
+        return java.util.Optional.empty();
     }
 }

--- a/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/TestService.java
+++ b/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/TestService.java
@@ -41,6 +41,15 @@ public interface TestService {
             @Path("pathString") java.util.Optional<String> pathString,
             @Query("queryString") java.util.Optional<String> queryString);
 
+    @GET("getJava8OptionalInt")
+    Call<java.util.OptionalInt> getJava8OptionalInt();
+
+    @GET("getJava8OptionalLong")
+    Call<java.util.OptionalLong> getJava8OptionalLong();
+
+    @GET("getJava8OptionalDouble")
+    Call<java.util.OptionalDouble> getJava8OptionalDouble();
+
     @POST("getComplexGuavaType")
     Call<com.google.common.base.Optional<LocalDate>> getComplexGuavaType(
             @Body com.google.common.base.Optional<LocalDate> date);


### PR DESCRIPTION
Fixes #668

## Before this PR
Retrofit clients convert 204s, empty response bodies, and `null` response bodies to `null` rather than an empty optional for endpoints that return optional values.

## After this PR
Retrofit clients now convert 204s, empty response bodies, and `null` response bodies to an empty optional for endpoints that return optional values.

## Possible downsides?
This may behave incorrectly for nested optional values, but these have been disallowed since https://github.com/palantir/conjure/pull/44 because of this ambiguity.
