### PR TITLE
[improvement] Correctly nest spans when tracing okhttp requests

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/AsyncTracerTag.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/AsyncTracerTag.java
@@ -16,18 +16,17 @@
 
 package com.palantir.conjure.java.okhttp;
 
-import java.io.IOException;
-import okhttp3.Interceptor;
-import okhttp3.Response;
+import com.palantir.conjure.java.client.config.ImmutablesStyle;
+import com.palantir.tracing.AsyncTracer;
+import org.immutables.value.Value;
 
-public final class DispatcherTraceTerminatingInterceptor implements Interceptor {
-    @Override
-    public Response intercept(Chain chain) throws IOException {
-        AsyncTracerTag tracerTag = chain.request().tag(AsyncTracerTag.class);
-        if (tracerTag == null && tracerTag.asyncTracer() == null) {
-            return chain.proceed(chain.request());
-        }
+@Value.Modifiable
+@ImmutablesStyle
+public interface AsyncTracerTag {
+    AsyncTracer asyncTracer();
+    AsyncTracerTag setAsyncTracer(AsyncTracer asyncTracer);
 
-        return tracerTag.asyncTracer().withTrace(() -> chain.proceed(chain.request()));
+    static AsyncTracerTag create() {
+        return ModifiableAsyncTracerTag.create();
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DispatcherTraceTerminatingInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DispatcherTraceTerminatingInterceptor.java
@@ -24,7 +24,7 @@ public final class DispatcherTraceTerminatingInterceptor implements Interceptor 
     @Override
     public Response intercept(Chain chain) throws IOException {
         AsyncTracerTag tracerTag = chain.request().tag(AsyncTracerTag.class);
-        if (tracerTag == null && tracerTag.asyncTracer() == null) {
+        if (tracerTag == null || tracerTag.asyncTracer() == null) {
             return chain.proceed(chain.request());
         }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -81,8 +81,7 @@ public final class OkHttpClients {
      *     </li>
      * </ol>
      */
-    private static final ExecutorService executionExecutor =
-            Tracers.wrap("OkHttp: dispatcher", Executors.newCachedThreadPool(executionThreads));
+    private static final ExecutorService executionExecutor = Executors.newCachedThreadPool(executionThreads);
 
     /** Shared dispatcher with static executor service. */
     private static final Dispatcher dispatcher;

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
@@ -21,7 +21,6 @@ import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
-import com.palantir.tracing.AsyncTracer;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
@@ -102,7 +102,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
         return request.newBuilder()
                 .url(getNewRequestUrl(request.url()))
                 .tag(ConcurrencyLimiterListener.class, ConcurrencyLimiterListener.create())
-                .tag(AsyncTracer.class, new AsyncTracer("OkHttp: execute"))
+                .tag(AsyncTracerTag.class, AsyncTracerTag.create())
                 .build();
     }
 


### PR DESCRIPTION
## Before this PR
OkHttp: execute-enqueue would measure time in dispatcher pool and acquire-limiter

## After this PR
==COMMIT_MSG==
OkHttp tracing spans get correctly nested where acquire-limiter and okhttp: execute don't overlap and okhttp: execute-enqueue measures just the queuing time. 
==COMMIT_MSG==

## Possible downsides?
Current spans are not easy to understand - this attempts to at least make sure they measure the right thing.