### PR TITLE
Rename to ServerQoS#{AUTOMATIC_RETRY, PROPAGATE_429_and_503_TO_CALLER}

### DIFF
--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -106,7 +106,7 @@ public interface ClientConfiguration {
     ClientQoS clientQoS();
 
     /** Indicates whether QosExceptions (other than RetryOther) should be propagated. */
-    AutomaticRetryOnQoS automaticRetryOnQoS();
+    PropagateQoS propagateQoS();
 
     @Value.Check
     default void check() {
@@ -138,14 +138,14 @@ public interface ClientConfiguration {
         DANGEROUS_DISABLE_SYMPATHETIC_CLIENT_QOS
     }
 
-    enum AutomaticRetryOnQoS {
+    enum PropagateQoS {
         /** Default. */
-        ENABLED,
+        DISABLED,
         /**
-         * Instead of retrying on QosException.Throttle and QosException.Unavailable (429/503), pass them through to the
-         * caller.  Consumers should use this when an upstream service has better context on how to handle the QoS
-         * error. This delegates the responsibility to the upstream service, which should use an appropriate conjure
-         * client to handle the response.
+         * Propagate QosException.Throttle and QosException.Unavailable (429/503) to the caller. Consumers should use
+         * this when an upstream service has better context on how to handle the QoS error. This delegates the
+         * responsibility to the upstream service, which should use an appropriate conjure client to handle the
+         * response.
          *
          * For example, let us imagine a proxy server that serves both interactive and long-running background requests
          * by dispatching requests to some backend. Interactive requests should be retried relatively few times in
@@ -158,6 +158,6 @@ public interface ClientConfiguration {
          * but the backend is not, it makes no sense to redirect the caller to a new backend. The client will still
          * follow redirects.
          */
-        DANGEROUS_DISABLE_AUTOMATIC_RETRY_ON_QOS;
+        ENABLED
     }
 }

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -106,7 +106,7 @@ public interface ClientConfiguration {
     ClientQoS clientQoS();
 
     /** Indicates whether QosExceptions (other than RetryOther) should be propagated. */
-    PropagateQoS propagateQoS();
+    ServerQoS serverQoS();
 
     @Value.Check
     default void check() {
@@ -138,13 +138,14 @@ public interface ClientConfiguration {
         DANGEROUS_DISABLE_SYMPATHETIC_CLIENT_QOS
     }
 
-    enum PropagateQoS {
+    enum ServerQoS {
         /** Default. */
-        DISABLED,
+        AUTOMATIC_RETRY,
+
         /**
-         * Propagate QosException.Throttle and QosException.Unavailable (429/503) to the caller. Consumers should use
-         * this when an upstream service has better context on how to handle the QoS error. This delegates the
-         * responsibility to the upstream service, which should use an appropriate conjure client to handle the
+         * Propagate QosException.Throttle and QosException.Unavailable (429/503) to the caller. Consumers
+         * should use this when an upstream service has better context on how to handle the QoS error. This delegates
+         * the responsibility to the upstream service, which should use an appropriate conjure client to handle the
          * response.
          *
          * For example, let us imagine a proxy server that serves both interactive and long-running background requests
@@ -158,6 +159,6 @@ public interface ClientConfiguration {
          * but the backend is not, it makes no sense to redirect the caller to a new backend. The client will still
          * follow redirects.
          */
-        ENABLED
+        PROPAGATE_429_and_503_TO_CALLER
     }
 }

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -48,8 +48,8 @@ public final class ClientConfigurations {
     private static final int DEFAULT_MAX_NUM_RETRIES = 4;
     private static final ClientConfiguration.ClientQoS DEFAULT_DISABLE_SYMPATHETIC_QOS =
             ClientConfiguration.ClientQoS.ENABLED;
-    private static final ClientConfiguration.AutomaticRetryOnQoS AUTOMATIC_RETRY_ON_QOS_DEFAULT =
-            ClientConfiguration.AutomaticRetryOnQoS.ENABLED;
+    private static final ClientConfiguration.PropagateQoS PROPAGATE_QOS_DEFAULT =
+            ClientConfiguration.PropagateQoS.DISABLED;
 
     private ClientConfigurations() {}
 
@@ -76,7 +76,7 @@ public final class ClientConfigurations {
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .backoffSlotSize(config.backoffSlotSize().orElse(DEFAULT_BACKOFF_SLOT_SIZE))
                 .clientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
-                .automaticRetryOnQoS(AUTOMATIC_RETRY_ON_QOS_DEFAULT)
+                .propagateQoS(PROPAGATE_QOS_DEFAULT)
                 .build();
     }
 
@@ -102,7 +102,7 @@ public final class ClientConfigurations {
                 .nodeSelectionStrategy(DEFAULT_NODE_SELECTION_STRATEGY)
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .clientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
-                .automaticRetryOnQoS(AUTOMATIC_RETRY_ON_QOS_DEFAULT)
+                .propagateQoS(PROPAGATE_QOS_DEFAULT)
                 .build();
     }
 

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -48,8 +48,8 @@ public final class ClientConfigurations {
     private static final int DEFAULT_MAX_NUM_RETRIES = 4;
     private static final ClientConfiguration.ClientQoS DEFAULT_DISABLE_SYMPATHETIC_QOS =
             ClientConfiguration.ClientQoS.ENABLED;
-    private static final ClientConfiguration.PropagateQoS PROPAGATE_QOS_DEFAULT =
-            ClientConfiguration.PropagateQoS.DISABLED;
+    private static final ClientConfiguration.ServerQoS PROPAGATE_QOS_DEFAULT =
+            ClientConfiguration.ServerQoS.AUTOMATIC_RETRY;
 
     private ClientConfigurations() {}
 
@@ -76,7 +76,7 @@ public final class ClientConfigurations {
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .backoffSlotSize(config.backoffSlotSize().orElse(DEFAULT_BACKOFF_SLOT_SIZE))
                 .clientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
-                .propagateQoS(PROPAGATE_QOS_DEFAULT)
+                .serverQoS(PROPAGATE_QOS_DEFAULT)
                 .build();
     }
 
@@ -102,7 +102,7 @@ public final class ClientConfigurations {
                 .nodeSelectionStrategy(DEFAULT_NODE_SELECTION_STRATEGY)
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .clientQoS(DEFAULT_DISABLE_SYMPATHETIC_QOS)
-                .propagateQoS(PROPAGATE_QOS_DEFAULT)
+                .serverQoS(PROPAGATE_QOS_DEFAULT)
                 .build();
     }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -226,7 +226,7 @@ public final class OkHttpClients {
                 schedulingExecutor.get(),
                 executionExecutor,
                 concurrencyLimiters,
-                config.automaticRetryOnQoS());
+                config.propagateQoS());
     }
 
     private static boolean shouldEnableQos(ClientConfiguration.ClientQoS clientQoS) {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -226,7 +226,7 @@ public final class OkHttpClients {
                 schedulingExecutor.get(),
                 executionExecutor,
                 concurrencyLimiters,
-                config.propagateQoS());
+                config.serverQoS());
     }
 
     private static boolean shouldEnableQos(ClientConfiguration.ClientQoS clientQoS) {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -70,7 +70,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
     private final ScheduledExecutorService schedulingExecutor;
     private final ExecutorService executionExecutor;
     private final ConcurrencyLimiters.ConcurrencyLimiter limiter;
-    private final ClientConfiguration.PropagateQoS propagateQoS;
+    private final ClientConfiguration.ServerQoS serverQoS;
 
     private final int maxNumRelocations;
 
@@ -83,7 +83,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
             ExecutorService executionExecutor,
             ConcurrencyLimiters.ConcurrencyLimiter limiter,
             int maxNumRelocations,
-            ClientConfiguration.PropagateQoS propagateQoS) {
+            ClientConfiguration.ServerQoS serverQoS) {
         super(delegate);
         this.backoffStrategy = backoffStrategy;
         this.urls = urls;
@@ -92,7 +92,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
         this.executionExecutor = executionExecutor;
         this.limiter = limiter;
         this.maxNumRelocations = maxNumRelocations;
-        this.propagateQoS = propagateQoS;
+        this.serverQoS = serverQoS;
     }
 
     /**
@@ -275,7 +275,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
         return new QosException.Visitor<Void>() {
             @Override
             public Void visit(QosException.Throttle exception) {
-                if (shouldPropagateQos(propagateQoS)) {
+                if (shouldPropagateQos(serverQoS)) {
                     propagateResponse(callback, call, response);
                     return null;
                 }
@@ -335,7 +335,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
 
             @Override
             public Void visit(QosException.Unavailable exception) {
-                if (shouldPropagateQos(propagateQoS)) {
+                if (shouldPropagateQos(serverQoS)) {
                     propagateResponse(callback, call, response);
                     return null;
                 }
@@ -375,16 +375,16 @@ final class RemotingOkHttpCall extends ForwardingCall {
         };
     }
 
-    private static boolean shouldPropagateQos(ClientConfiguration.PropagateQoS propagateQoS) {
-        switch (propagateQoS) {
-            case ENABLED:
+    private static boolean shouldPropagateQos(ClientConfiguration.ServerQoS serverQoS) {
+        switch (serverQoS) {
+            case PROPAGATE_429_and_503_TO_CALLER:
                 return true;
-            case DISABLED:
+            case AUTOMATIC_RETRY:
                 return false;
         }
 
         throw new SafeIllegalStateException("Encountered unknown propagate QoS configuration",
-                SafeArg.of("propagateQoS", propagateQoS));
+                SafeArg.of("serverQoS", serverQoS));
     }
 
     private static void propagateResponse(Callback callback, Call call, Response response) {
@@ -399,6 +399,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
     @Override
     public RemotingOkHttpCall doClone() {
         return new RemotingOkHttpCall(getDelegate().clone(), backoffStrategy, urls, client, schedulingExecutor,
-                executionExecutor, limiter, maxNumRelocations, propagateQoS);
+                executionExecutor, limiter, maxNumRelocations, serverQoS);
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -70,7 +70,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
     private final ScheduledExecutorService schedulingExecutor;
     private final ExecutorService executionExecutor;
     private final ConcurrencyLimiters.ConcurrencyLimiter limiter;
-    private final ClientConfiguration.AutomaticRetryOnQoS automaticRetryOnQoS;
+    private final ClientConfiguration.PropagateQoS propagateQoS;
 
     private final int maxNumRelocations;
 
@@ -83,7 +83,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
             ExecutorService executionExecutor,
             ConcurrencyLimiters.ConcurrencyLimiter limiter,
             int maxNumRelocations,
-            ClientConfiguration.AutomaticRetryOnQoS automaticRetryOnQoS) {
+            ClientConfiguration.PropagateQoS propagateQoS) {
         super(delegate);
         this.backoffStrategy = backoffStrategy;
         this.urls = urls;
@@ -92,7 +92,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
         this.executionExecutor = executionExecutor;
         this.limiter = limiter;
         this.maxNumRelocations = maxNumRelocations;
-        this.automaticRetryOnQoS = automaticRetryOnQoS;
+        this.propagateQoS = propagateQoS;
     }
 
     /**
@@ -275,7 +275,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
         return new QosException.Visitor<Void>() {
             @Override
             public Void visit(QosException.Throttle exception) {
-                if (shouldPropagateQos(automaticRetryOnQoS)) {
+                if (shouldPropagateQos(propagateQoS)) {
                     propagateResponse(callback, call, response);
                     return null;
                 }
@@ -335,7 +335,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
 
             @Override
             public Void visit(QosException.Unavailable exception) {
-                if (shouldPropagateQos(automaticRetryOnQoS)) {
+                if (shouldPropagateQos(propagateQoS)) {
                     propagateResponse(callback, call, response);
                     return null;
                 }
@@ -375,16 +375,16 @@ final class RemotingOkHttpCall extends ForwardingCall {
         };
     }
 
-    private static boolean shouldPropagateQos(ClientConfiguration.AutomaticRetryOnQoS automaticRetryOnQoS) {
-        switch (automaticRetryOnQoS) {
+    private static boolean shouldPropagateQos(ClientConfiguration.PropagateQoS propagateQoS) {
+        switch (propagateQoS) {
             case ENABLED:
-                return false;
-            case DANGEROUS_DISABLE_AUTOMATIC_RETRY_ON_QOS:
                 return true;
+            case DISABLED:
+                return false;
         }
 
         throw new SafeIllegalStateException("Encountered unknown propagate QoS configuration",
-                SafeArg.of("automaticRetryOnQoS", automaticRetryOnQoS));
+                SafeArg.of("propagateQoS", propagateQoS));
     }
 
     private static void propagateResponse(Callback callback, Call call, Response response) {
@@ -399,6 +399,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
     @Override
     public RemotingOkHttpCall doClone() {
         return new RemotingOkHttpCall(getDelegate().clone(), backoffStrategy, urls, client, schedulingExecutor,
-                executionExecutor, limiter, maxNumRelocations, automaticRetryOnQoS);
+                executionExecutor, limiter, maxNumRelocations, propagateQoS);
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
@@ -47,7 +47,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
     private final ScheduledExecutorService schedulingExecutor;
     private final ExecutorService executionExecutor;
     private final ConcurrencyLimiters concurrencyLimiters;
-    private final ClientConfiguration.AutomaticRetryOnQoS automaticRetryOnQoS;
+    private final ClientConfiguration.PropagateQoS propagateQoS;
 
     RemotingOkHttpClient(
             OkHttpClient delegate,
@@ -57,7 +57,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
             ScheduledExecutorService schedulingExecutor,
             ExecutorService executionExecutor,
             ConcurrencyLimiters concurrencyLimiters,
-            ClientConfiguration.AutomaticRetryOnQoS automaticRetryOnQoS) {
+            ClientConfiguration.PropagateQoS propagateQoS) {
         super(delegate);
         this.backoffStrategyFactory = backoffStrategy;
         this.nodeSelectionStrategy = nodeSelectionStrategy;
@@ -65,7 +65,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
         this.schedulingExecutor = schedulingExecutor;
         this.executionExecutor = executionExecutor;
         this.concurrencyLimiters = concurrencyLimiters;
-        this.automaticRetryOnQoS = automaticRetryOnQoS;
+        this.propagateQoS = propagateQoS;
     }
 
     @Override
@@ -91,7 +91,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
                 executionExecutor,
                 concurrencyLimiters.acquireLimiter(request),
                 maxNumRelocations,
-                automaticRetryOnQoS);
+                propagateQoS);
     }
 
     private Request createNewRequest(Request request) {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
@@ -47,7 +47,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
     private final ScheduledExecutorService schedulingExecutor;
     private final ExecutorService executionExecutor;
     private final ConcurrencyLimiters concurrencyLimiters;
-    private final ClientConfiguration.PropagateQoS propagateQoS;
+    private final ClientConfiguration.ServerQoS serverQoS;
 
     RemotingOkHttpClient(
             OkHttpClient delegate,
@@ -57,7 +57,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
             ScheduledExecutorService schedulingExecutor,
             ExecutorService executionExecutor,
             ConcurrencyLimiters concurrencyLimiters,
-            ClientConfiguration.PropagateQoS propagateQoS) {
+            ClientConfiguration.ServerQoS serverQoS) {
         super(delegate);
         this.backoffStrategyFactory = backoffStrategy;
         this.nodeSelectionStrategy = nodeSelectionStrategy;
@@ -65,7 +65,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
         this.schedulingExecutor = schedulingExecutor;
         this.executionExecutor = executionExecutor;
         this.concurrencyLimiters = concurrencyLimiters;
-        this.propagateQoS = propagateQoS;
+        this.serverQoS = serverQoS;
     }
 
     @Override
@@ -91,7 +91,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
                 executionExecutor,
                 concurrencyLimiters.acquireLimiter(request),
                 maxNumRelocations,
-                propagateQoS);
+                serverQoS);
     }
 
     private Request createNewRequest(Request request) {


### PR DESCRIPTION
I know I suggested the last `AutomaticRetryOnQoS` name, but it seemed kinda gross and too much indirection on further thought.  

I hope the new name will be more obvious

Follow-up to https://github.com/palantir/conjure-java-runtime/pull/1041

cc @jonsyu1 