### PR TITLE
[fix] enforce timeout precision

### DIFF
--- a/client-config/build.gradle
+++ b/client-config/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     testImplementation 'com.google.guava:guava'
     testImplementation "org.assertj:assertj-core"
     testImplementation "org.mockito:mockito-core"
+    testImplementation 'com.palantir.safe-logging:preconditions-assertj'
 
     annotationProcessor "org.immutables:value"
     compileOnly 'org.immutables:value::annotations'

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -128,7 +128,7 @@ public interface ClientConfiguration {
 
     default void checkTimeoutPrecision(Duration duration, String timeoutName) {
         checkArgument(duration.minusMillis(duration.toMillis()).isZero(),
-                "Timeout should be a multiple of milliseconds",
+                "Timeouts with sub-millisecond precision are not supported",
                 SafeArg.of("timeoutName", timeoutName),
                 SafeArg.of("duration", duration),
                 UnsafeArg.of("uris", uris()));

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -85,7 +85,7 @@ public final class ClientConfigurationsTest {
                 .build();
         Assertions
                 .assertThatLoggableExceptionThrownBy(() -> ClientConfigurations.of(serviceConfig))
-                .hasLogMessage("Timeout should be a multiple of milliseconds");
+                .hasLogMessage("Timeouts with sub-millisecond precision are not supported");
     }
 
     @Test

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -25,6 +25,7 @@ import com.google.common.net.HostAndPort;
 import com.palantir.conjure.java.api.config.service.ProxyConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import com.palantir.logsafe.testing.Assertions;
 import java.net.Proxy;
 import java.net.URI;
 import java.nio.file.Paths;
@@ -73,6 +74,18 @@ public final class ClientConfigurationsTest {
         assertThat(actual.enableGcmCipherSuites()).isFalse();
         assertThat(actual.fallbackToCommonNameVerification()).isFalse();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);
+    }
+
+    @Test
+    public void testTimeoutMustBeMilliseconds() {
+        ServiceConfiguration serviceConfig = ServiceConfiguration.builder()
+                .uris(uris)
+                .security(SslConfiguration.of(Paths.get("src/test/resources/trustStore.jks")))
+                .connectTimeout(Duration.ofNanos(5))
+                .build();
+        Assertions
+                .assertThatLoggableExceptionThrownBy(() -> ClientConfigurations.of(serviceConfig))
+                .hasLogMessage("Timeout should be a multiple of milliseconds");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR

We require connect / read / write timeouts to have [millisecond precision](https://github.com/palantir/conjure-java-runtime/blob/6ce94d16aeb2f11cf7e72fc779d07f8929b31c69/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java#L195-L200), silently truncating them to 0 if they are smaller than 1ms.
Sadly, okhttp / feign treats a timeout of 0 as "no timeout", leading to user confusion.

## After this PR
==COMMIT_MSG==
Throw an error when attempting to create a service with a timeout with sub-millisecond precision. 
==COMMIT_MSG==

## Possible downsides?
Services configured with such a timeout will now fail to start.