### PR TITLE
[improvement] Allow a non-global tagged metric registry

### DIFF
--- a/client-config/build.gradle
+++ b/client-config/build.gradle
@@ -3,6 +3,7 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
     api 'com.palantir.conjure.java.api:service-config'
+    api 'com.palantir.tritium:tritium-registry'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'com.google.guava:guava'
     implementation project(":keystores")

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -23,6 +23,7 @@ import com.palantir.conjure.java.api.config.service.BasicCredentials;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.net.ProxySelector;
 import java.time.Duration;
 import java.util.List;
@@ -103,12 +104,14 @@ public interface ClientConfiguration {
      */
     Duration backoffSlotSize();
 
-
     /** Indicates whether client-side sympathetic QoS should be enabled. */
     ClientQoS clientQoS();
 
     /** Indicates whether QosExceptions (other than RetryOther) should be propagated. */
     ServerQoS serverQoS();
+
+    /** Both per-request and global metrics are recorded in this registry. */
+    TaggedMetricRegistry taggedMetricRegistry();
 
     @Value.Check
     default void check() {

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -21,6 +21,7 @@ import com.google.common.net.HostAndPort;
 import com.palantir.conjure.java.api.config.service.ProxyConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -77,6 +78,7 @@ public final class ClientConfigurations {
                 .backoffSlotSize(config.backoffSlotSize().orElse(DEFAULT_BACKOFF_SLOT_SIZE))
                 .clientQoS(CLIENT_QOS_DEFAULT)
                 .serverQoS(PROPAGATE_QOS_DEFAULT)
+                .taggedMetricRegistry(DefaultTaggedMetricRegistry.getDefault())
                 .build();
     }
 
@@ -103,6 +105,7 @@ public final class ClientConfigurations {
                 .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .clientQoS(CLIENT_QOS_DEFAULT)
                 .serverQoS(PROPAGATE_QOS_DEFAULT)
+                .taggedMetricRegistry(DefaultTaggedMetricRegistry.getDefault())
                 .build();
     }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DispatcherMetricSet.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DispatcherMetricSet.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricSet;
+import java.util.Map;
+import okhttp3.ConnectionPool;
+import okhttp3.Dispatcher;
+
+class DispatcherMetricSet implements TaggedMetricSet {
+
+    private final ImmutableMap<MetricName, Metric> metrics;
+
+    DispatcherMetricSet(Dispatcher dispatcher, ConnectionPool connectionPool) {
+        ImmutableMap.Builder<MetricName, Metric> map = ImmutableMap.builder();
+
+        map.put(
+                MetricName.builder().safeName("com.palantir.conjure.java.dispatcher.calls.queued").build(),
+                (Gauge) dispatcher::queuedCallsCount);
+        map.put(
+                MetricName.builder().safeName("com.palantir.conjure.java.dispatcher.calls.running").build(),
+                (Gauge) dispatcher::runningCallsCount);
+        map.put(
+                MetricName.builder().safeName("com.palantir.conjure.java.connection-pool.connections.total").build(),
+                (Gauge) connectionPool::connectionCount);
+        map.put(
+                MetricName.builder().safeName("com.palantir.conjure.java.connection-pool.connections.idle").build(),
+                (Gauge) connectionPool::idleConnectionCount);
+
+        this.metrics = map.build();
+    }
+
+    @Override
+    public Map<MetricName, Metric> getMetrics() {
+        return metrics;
+    }
+}


### PR DESCRIPTION
## Before this PR

All metrics (e.g. `client.response`) get written to a single shared TaggedMetricRegistry instance, supplied by tritium's `DefaultTaggedMetricRegistry.getDefault()`.

This has been tolerable so far, but means we are unable to carefully roll out a change to the underlying registry reservoir without affecting _all_ products at once, as just having tritium 0.12.0 on the classpath would impose this change on users.

## After this PR
==COMMIT_MSG==
Users can now supply a TaggedMetricRegistry rather than relying on a global singleton.

No behaviour changes for users relying on `ClientConfigurations.of()`.
==COMMIT_MSG==

e.g.

```groovy
     ClientConfiguration clientConfiguration = ClientConfiguration.builder()
                .from(ClientConfigurations.of(serviceConfig))
                .taggedMetricRegistry(registry)
                .build();
```

This is also nicer from a testing perspective, as we no longer clobber global state in each unit test.

## Possible downsides?

- ClientConfiguration has a new field now, so anyone _manually_ building these field-by-field would experience runtime failures until they also initialize the taggedMetricRegistry
- The four dispatcher-related metrics are now scoped under the tag `from: DispatcherMetricSet`, which is a bit pointless (just tritium's API).  It shouldn't increase our DD spend because this metrics are already uniquely identified by the product version!
- Strange things could happen if users provide a TaggedMetricRegistry with an odd equals/hashcode implementation.