### PR TITLE
Set higher cooldown time by default

### DIFF
--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -41,7 +41,7 @@ public final class ClientConfigurations {
     private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration DEFAULT_BACKOFF_SLOT_SIZE = Duration.ofMillis(250);
-    private static final Duration DEFAULT_FAILED_URL_COOLDOWN = Duration.ZERO;
+    private static final Duration DEFAULT_FAILED_URL_COOLDOWN = Duration.ofMinutes(5);
     private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = false;
     private static final boolean DEFAULT_FALLBACK_TO_COMMON_NAME_VERIFICATION = false;
     private static final NodeSelectionStrategy DEFAULT_NODE_SELECTION_STRATEGY = NodeSelectionStrategy.PIN_UNTIL_ERROR;


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
Say we have 3 nodes of service A and service B, and one node of service B is in a state that it is accepting connections but not processing requests, all requests will timeout after [IDLE_TIMEOUT which is 60s](https://github.com/square/okio/blob/master/okio/src/jvmMain/kotlin/okio/AsyncTimeout.kt#L256).
So for the first 60s, serviceA sends 1/3rd requests to all three nodes, then one node is blacklisted for cooldown-interval and again service A starts sending 1/3rd requests to all nodes. One service set the cooldown interval to be 10s and a lot of the others set it to less that a minute, thus a lot of the requests will fail. If the cooldown time is set to a higher value, like 5mins, this would be better.

We need to follow-up with PRs so that products remove the hard-coded default unless they have a good reason to not do so.
## After this PR
Blacklist nodes that caused an error for 5mins to prevent a lot requests from hitting a bad node.