### PR TITLE
[improvement] make sure failedUrlCooldown is at least readTimeout

### DIFF
--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -115,8 +115,9 @@ public interface ClientConfiguration {
             checkArgument(uris().size() == 1, "If meshProxy is configured then uris must contain exactly 1 URI");
         }
         if (nodeSelectionStrategy().equals(NodeSelectionStrategy.ROUND_ROBIN)) {
-            checkArgument(!failedUrlCooldown().isNegative() && !failedUrlCooldown().isZero(),
-                    "If nodeSelectionStrategy is ROUND_ROBIN then failedUrlCooldown must be positive");
+            checkArgument(
+                    !failedUrlCooldown().isNegative() && failedUrlCooldown().compareTo(readTimeout()) >= 0,
+                    "If nodeSelectionStrategy is ROUND_ROBIN then failedUrlCooldown must be greater than read timeout");
         }
     }
 


### PR DESCRIPTION

## Before this PR
Say we have 3 nodes of service A and service B, and one node of service B is in a state that it is accepting connections but not processing requests, all requests will timeout after IDLE_TIMEOUT which is 60s.
So for the first 60s, serviceA sends 1/3rd requests to all three nodes, then one node is blacklisted for cooldown-interval and again service A starts sending 1/3rd requests to all nodes. One service set the cooldown interval to be 10s and a lot of the others set it to less that a minute, thus a lot of the requests will fail. If the cooldown time is set to a higher value, like 5mins, this would be better.

## After this PR
Do not send any requests to nodes that caused a connection error for 5mins to prevent a lot requests from hitting a bad node.
