### PR TITLE
[improvement] ConcurrencyLimiter acquire queue histogram

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ThreadWorkQueue.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ThreadWorkQueue.java
@@ -40,6 +40,10 @@ final class ThreadWorkQueue<T> {
         return queuedRequests.isEmpty();
     }
 
+    int size() {
+        return queuedRequests.size();
+    }
+
     void add(T element) {
         long threadId = Thread.currentThread().getId();
         queue(threadId).add(element);


### PR DESCRIPTION
## Before this PR
It's hard to tell when we're going up against our concurrency limits. All we know is that there's a "slow" acquire.

## After this PR
Histogram of queue sizes across all requests.

## Possible downsides?
Without per-endpoint metrics it will still be quite hard to see what's happening. But the histogram should give us an indication.
