### PR TITLE
Revert "[improvement] Bump initial concurrency limits form 10 -> 64 to match OkHttp dispatcher limits"

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -107,7 +107,7 @@ final class ConcurrencyLimiters {
     Limit newLimit() {
         return new ConjureWindowedLimit(AIMDLimit.newBuilder()
                 .timeout(Long.MAX_VALUE, TimeUnit.NANOSECONDS)
-                .initialLimit(OkHttpClients.MAX_REQUESTS_PER_HOST)
+                .initialLimit(10)
                 .backoffRatio(0.9)
                 .minLimit(1)
                 .maxLimit(Integer.MAX_VALUE)

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -106,10 +106,30 @@ final class ConcurrencyLimiters {
     @VisibleForTesting
     Limit newLimit() {
         return new ConjureWindowedLimit(AIMDLimit.newBuilder()
+                /**
+                 * Requests slower than this timeout are treated as failures, which reduce concurrency. Since we have
+                 * plenty of long streaming requests, we set this timeout to 292.27726 years to effectively turn it off.
+                 */
                 .timeout(Long.MAX_VALUE, TimeUnit.NANOSECONDS)
+                /**
+                 * Our initial limit is pretty conservative - only 10 concurrent requests in flight at the same time.
+                 * If a client is consistently maxing out its concurrency permits, this increases additively once per
+                 * second (see {@link ConjureWindowedLimit#MIN_WINDOW_TIME}.
+                 */
                 .initialLimit(10)
+                /**
+                 * We reduce concurrency _immediately_ as soon as a request fails, which can result in drastic limit
+                 * reductions, e.g. starting with 30 concurrent permits, 100 failures in a row results in:
+                 * 30 * 0.9^100 = 0.0007 (rounded up to the minLimit of 1).
+                 */
                 .backoffRatio(0.9)
+                /**
+                 * However many failures we get, we always need at least 1 permit so we can keep trying.
+                 */
                 .minLimit(1)
+                /**
+                 * Note that the Dispatcher in {@link OkHttpClients} has a max concurrent requests too.
+                 */
                 .maxLimit(Integer.MAX_VALUE)
                 .build());
     }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -58,9 +58,6 @@ public final class OkHttpClients {
     @VisibleForTesting
     static final int NUM_SCHEDULING_THREADS = 5;
 
-    static final int MAX_REQUESTS = 256;
-    static final int MAX_REQUESTS_PER_HOST = 64;
-
     private static final ThreadFactory executionThreads = new ThreadFactoryBuilder()
             .setUncaughtExceptionHandler((thread, uncaughtException) ->
                     log.error("An exception was uncaught in an execution thread. "
@@ -97,9 +94,9 @@ public final class OkHttpClients {
 
     static {
         dispatcher = new Dispatcher(executionExecutor);
-        dispatcher.setMaxRequests(MAX_REQUESTS);
+        dispatcher.setMaxRequests(256);
         // Must be less than maxRequests so a single slow host does not block all requests
-        dispatcher.setMaxRequestsPerHost(MAX_REQUESTS_PER_HOST);
+        dispatcher.setMaxRequestsPerHost(64);
 
         dispatcherMetricSet = new DispatcherMetricSet(dispatcher, connectionPool);
     }


### PR DESCRIPTION
Reverts palantir/conjure-java-runtime#1111

Haven't released this yet - think it might be worth collecting a bit of information by looking at the debug log lines before we make significant changes to this.