### PR TITLE
Initialize RemoteException cause for Retrofit clients

### DIFF
--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/AsyncException.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/AsyncException.java
@@ -1,0 +1,21 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.conjure.java.client.retrofit2;
+
+final class AsyncException extends RuntimeException {
+
+    AsyncException() {}
+}


### PR DESCRIPTION
## Before this PR
A `RemoteException` created when using a Retrofit clients does not have any cause, making it difficult to know the request that caused the exceptions. Here is an example stacktrace using a Retrofit client:
```
com.palantir.conjure.java.api.errors.RemoteException: {throwable0_message}
	at com.palantir.conjure.java.okhttp.RemoteExceptionResponseHandler.handle(RemoteExceptionResponseHandler.java:62)
	at com.palantir.conjure.java.okhttp.RemotingOkHttpCall$3.onResponse(RemotingOkHttpCall.java:250)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:216)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at com.palantir.tracing.DeferredTracer.withTrace(DeferredTracer.java:115)
	at com.palantir.tracing.Tracers$TracingAwareCallable.call(Tracers.java:343)
	at com.palantir.tracing.WrappingExecutorService.lambda$wrapTask$0(WrappingExecutorService.java:67)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.lang.Thread.run(Thread.java:834)

```
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
A `RemoteException` created when using a Retrofit clients will have a cause whose exception is the stacktrace of the call that enqueued the request.
