### PR TITLE
[fix] Never block threads if a non-IOException is thrown

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/CatchThrowableInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/CatchThrowableInterceptor.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+enum CatchThrowableInterceptor implements Interceptor {
+    INSTANCE;
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        try {
+            return chain.proceed(chain.request());
+        } catch (Throwable t) {
+            if (t instanceof IOException) {
+                throw (IOException) t;
+            }
+            throw new IOException("Caught a non-IOException while executing a call. "
+                    + "This is a serious bug and requires investigation. Rethrowing "
+                    + "as an IOException in order to avoid blocking a thread", t);
+        }
+    }
+}

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/CatchThrowableInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/CatchThrowableInterceptor.java
@@ -16,10 +16,15 @@
 
 package com.palantir.conjure.java.okhttp;
 
+import com.palantir.logsafe.exceptions.SafeIoException;
 import java.io.IOException;
 import okhttp3.Interceptor;
 import okhttp3.Response;
 
+/**
+ * {@link okhttp3.RealCall#execute()} only catches IOExceptions, which means that any non-IOException eventually
+ * mean the {@link okhttp3.Dispatcher} runs out of threads and can't make *any* outgoing requests.
+ */
 enum CatchThrowableInterceptor implements Interceptor {
     INSTANCE;
 
@@ -31,9 +36,9 @@ enum CatchThrowableInterceptor implements Interceptor {
             if (t instanceof IOException) {
                 throw (IOException) t;
             }
-            throw new IOException("Caught a non-IOException while executing a call. "
+            throw new SafeIoException("Caught a non-IOException. "
                     + "This is a serious bug and requires investigation. Rethrowing "
-                    + "as an IOException in order to avoid blocking a thread", t);
+                    + "as an IOException in order to avoid blocking a Dispatcher thread", t);
         }
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/CatchThrowableInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/CatchThrowableInterceptor.java
@@ -24,6 +24,8 @@ import okhttp3.Response;
 /**
  * {@link okhttp3.RealCall#execute()} only catches IOExceptions, which means that any non-IOException eventually
  * mean the {@link okhttp3.Dispatcher} runs out of threads and can't make *any* outgoing requests.
+ *
+ * https://github.com/square/okhttp/issues/5151
  */
 enum CatchThrowableInterceptor implements Interceptor {
     INSTANCE;

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -155,6 +155,7 @@ public final class OkHttpClients {
                 enableClientQoS);
 
         OkHttpClient.Builder client = new OkHttpClient.Builder();
+        client.addInterceptor(CatchThrowableInterceptor.INSTANCE);
         client.addInterceptor(new DispatcherTraceTerminatingInterceptor());
 
         // Routing

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -155,7 +155,7 @@ public final class OkHttpClients {
                 enableClientQoS);
 
         OkHttpClient.Builder client = new OkHttpClient.Builder();
-        // client.addInterceptor(CatchThrowableInterceptor.INSTANCE);
+        client.addInterceptor(CatchThrowableInterceptor.INSTANCE);
         client.addInterceptor(new DispatcherTraceTerminatingInterceptor());
 
         // Routing

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -155,7 +155,7 @@ public final class OkHttpClients {
                 enableClientQoS);
 
         OkHttpClient.Builder client = new OkHttpClient.Builder();
-        client.addInterceptor(CatchThrowableInterceptor.INSTANCE);
+        // client.addInterceptor(CatchThrowableInterceptor.INSTANCE);
         client.addInterceptor(new DispatcherTraceTerminatingInterceptor());
 
         // Routing

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/CatchThrowableInterceptorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/CatchThrowableInterceptorTest.java
@@ -1,0 +1,51 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import okhttp3.Interceptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class CatchThrowableInterceptorTest {
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS) private Interceptor.Chain chain;
+
+    @Test
+    public void rethrowsIoException() throws IOException {
+        IOException exception = new IOException();
+        when(chain.proceed(chain.request())).thenThrow(exception);
+        assertThatExceptionOfType(IOException.class)
+                .isThrownBy(() -> CatchThrowableInterceptor.INSTANCE.intercept(chain))
+                .isEqualTo(exception);
+    }
+
+    @Test
+    public void stackOverflowErrorIsWrapped() throws IOException {
+        StackOverflowError error = new StackOverflowError();
+        when(chain.proceed(chain.request())).thenThrow(error);
+        assertThatExceptionOfType(IOException.class)
+                .isThrownBy(() -> CatchThrowableInterceptor.INSTANCE.intercept(chain))
+                .withCause(error);
+    }
+}

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -776,7 +776,6 @@ public final class OkHttpClientsTest extends TestBase {
         HostEventsSink throwingSink = new HostEventsSink() {
             @Override
             public void record(String serviceName, String hostname, int port, int statusCode, long micros) {
-                //empty
                 throw new IllegalStateException("I am not an IOException");
             }
 

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -769,6 +769,35 @@ public final class OkHttpClientsTest extends TestBase {
         assertThat(server.takeRequest().getHeader(HttpHeaders.HOST)).isEqualTo("foo.com");
     }
 
+    @Test
+    public void non_ioexceptions_dont_break_the_world() throws IOException {
+        server.enqueue(new MockResponse().setBody("foo"));
+
+        HostEventsSink throwingSink = new HostEventsSink() {
+            @Override
+            public void record(String serviceName, String hostname, int port, int statusCode, long micros) {
+                //empty
+                throw new IllegalStateException("I am not an IOException");
+            }
+
+            @Override
+            public void recordIoException(String serviceName, String hostname, int port) {
+                //empty;
+            }
+        };
+        OkHttpClient client = OkHttpClients.create(
+                ClientConfiguration.builder()
+                        .from(createTestConfig(url))
+                        .maxNumRetries(0)
+                        .build(),
+                AGENT,
+                throwingSink,
+                OkHttpClientsTest.class);
+
+        assertThatThrownBy(() -> client.newCall(new Request.Builder().url(url).build()).execute())
+                .hasStackTraceContaining("Caught a non-IOException. This is a serious bug and requires investigation");
+    }
+
     private OkHttpClient createRetryingClient(int maxNumRetries) {
         return createRetryingClient(maxNumRetries, Duration.ofMillis(500));
     }

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -769,7 +769,7 @@ public final class OkHttpClientsTest extends TestBase {
         assertThat(server.takeRequest().getHeader(HttpHeaders.HOST)).isEqualTo("foo.com");
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void non_ioexceptions_dont_break_the_world() throws IOException {
         server.enqueue(new MockResponse().setBody("foo"));
 


### PR DESCRIPTION
Instead, just wrap in an IOException

We should not be catching errors, but they will just get blackholed.

## Before this PR
If a remote call throws an exception, the Conjure call will block forever. 

## After this PR
Now, fail the call with an exception.


## Possible downsides?
People relying on threads getting permanently blocked for control flow purposes will see a break.
