### PR TITLE
Revert "[fix] log hosts on retry"

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -207,8 +207,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
 
                 log.info("Retrying call after failure",
                         SafeArg.of("backoffMillis", backoff.get().toMillis()),
-                        SafeArg.of("originalHost", request().url().host()),
-                        SafeArg.of("redirectToHost", redirectTo.get().host()),
                         UnsafeArg.of("redirectToUrl", redirectTo.get()),
                         exception);
                 Request redirectedRequest = request().newBuilder()
@@ -347,8 +345,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 }
 
                 log.debug("Retrying call after receiving QosException.RetryOther",
-                        SafeArg.of("originalHost", request().url().host()),
-                        SafeArg.of("redirectToHost", redirectTo.get().host()),
                         UnsafeArg.of("requestUrl", call.request().url()),
                         UnsafeArg.of("redirectToUrl", redirectTo.get()),
                         exception);
@@ -388,8 +384,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
 
                 log.debug("Retrying call after receiving QosException.Unavailable",
                         SafeArg.of("backoffMillis", backoff.get().toMillis()),
-                        SafeArg.of("originalHost", request().url().host()),
-                        SafeArg.of("redirectToHost", redirectTo.get().host()),
                         UnsafeArg.of("redirectToUrl", redirectTo.get()),
                         exception);
                 Request redirectedRequest = request().newBuilder()


### PR DESCRIPTION
Reverts palantir/conjure-java-runtime#1115

@gatesn flagged that we can't actually guarantee that _all_ hosts passed in here are safe to log, and we don't want to get all our log origins blacklisted.