### PR TITLE
[fix] ConcurrencyLimiter log line includes method and template SafeArgs

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -29,6 +29,7 @@ import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.limit.AIMDLimit;
 import com.netflix.concurrency.limits.limiter.SimpleLimiter;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tracing.okhttp3.OkhttpTraceInterceptor;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -267,7 +268,9 @@ final class ConcurrencyLimiters {
                             + "deadlock. We expect that either this is caused by either service overloading, or not "
                             + "closing response bodies (consider using the try-with-resources pattern).",
                     SafeArg.of("serviceClass", serviceClass),
-                    SafeArg.of("limiterKey", limiterKey),
+                    UnsafeArg.of("hostname", limiterKey.hostname()),
+                    safeArgMethod,
+                    safeArgPathTemplate,
                     SafeArg.of("timeout", timeout));
             leakSuspected.mark();
             limiter = limiterFactory.get();


### PR DESCRIPTION
## Before this PR

An internal service saw the WARN log line: 

> Timed out waiting to get permits for concurrency. In most cases this would indicate some kind of deadlock. We expect that either this is caused by either service overloading, or not closing response bodies (consider using the try-with-resources pattern).

But the limiterKey SafeArg just contained `{}`.

## After this PR
==COMMIT_MSG==
ConcurrencyLimiter log line includes method and template SafeArgs, which should help debugging as it allows operators to identify where a single concurrencylimiter is problematic, or whether all of them are.
==COMMIT_MSG==

## Possible downsides?
- Adding more log args, gotta be careful we don't leak things