### PR TITLE
[improvement] Jackson encoder avoids intermediate String request body

### DIFF
--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -45,7 +45,6 @@ import feign.Retryer;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
 import feign.jackson.JacksonDecoder;
-import feign.jackson.JacksonEncoder;
 import feign.jaxrs.JAXRSContract;
 import feign.okhttp.OkHttpClient;
 
@@ -97,7 +96,7 @@ abstract class AbstractFeignJaxRsClientBuilder {
                                 new TextDelegateEncoder(
                                         new CborDelegateEncoder(
                                                 cborObjectMapper,
-                                                new JacksonEncoder(objectMapper)))))
+                                                new ConjureFeignJacksonEncoder(objectMapper)))))
                 .decoder(createDecoder(objectMapper, cborObjectMapper))
                 .errorDecoder(new QosErrorDecoder(new ErrorDecoder.Default()))
                 .client(new OkHttpClient(okHttpClient))

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/ConjureFeignJacksonEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/ConjureFeignJacksonEncoder.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.RequestTemplate;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Similar to {@link feign.jackson.JacksonEncoder}, but optimized to avoid intermediate
+ * String representation of request body.
+ * See upstream PR https://github.com/OpenFeign/feign/pull/989 .
+ */
+final class ConjureFeignJacksonEncoder implements Encoder {
+
+    private final ObjectMapper mapper;
+
+    ConjureFeignJacksonEncoder(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void encode(Object object, Type bodyType, RequestTemplate template) {
+        try {
+            JavaType javaType = mapper.getTypeFactory().constructType(bodyType);
+            template.body(mapper.writerFor(javaType).writeValueAsBytes(object), StandardCharsets.UTF_8);
+        } catch (JsonProcessingException e) {
+            throw new EncodeException(e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Feign's JacksonEncoder would convert object to String, then to UTF-8 bytes.

## After this PR
==COMMIT_MSG==
Serialize Jackson request object directly to UTF-8 byte array without intermediate String representation.

Introduces local Jackson encoder until https://github.com/OpenFeign/feign/pull/989 is upstreamed.

See https://github.com/FasterXML/jackson-docs/wiki/Presentation:-Jackson-Performance#basics-things-you-should-do-anyway
==COMMIT_MSG==

## Possible downsides?
We maintain this code until fix lands in upstream version we can pick up.