### PR TITLE
Log original requestUrl when retrying, and fix logging for redirectToUrl

### DIFF
--- a/changelog/@unreleased/pr-1141.v2.yml
+++ b/changelog/@unreleased/pr-1141.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix `Retrying call after failure` log parameters, and additionally
+    log the original `requestUrl` that failed.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1141

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -207,7 +207,8 @@ final class RemotingOkHttpCall extends ForwardingCall {
 
                 log.info("Retrying call after failure",
                         SafeArg.of("backoffMillis", backoff.get().toMillis()),
-                        UnsafeArg.of("redirectToUrl", redirectTo.get()),
+                        UnsafeArg.of("requestUrl", call.request().url().toString()),
+                        UnsafeArg.of("redirectToUrl", redirectTo.get().toString()),
                         exception);
                 Request redirectedRequest = request().newBuilder()
                         .url(redirectTo.get())


### PR DESCRIPTION
## Before this PR

Not logging `redirectToUrl` correctly in the `Retrying call after failure` log message.
It currently gets logged as `{"https":true}` which is not helpful.

## After this PR
==COMMIT_MSG==
Fix `Retrying call after failure` log parameters, and additionally log the original `requestUrl` that failed.
==COMMIT_MSG==

## Possible downsides?
