### PR TITLE
Clean up URL selector logic

### DIFF
--- a/changelog/@unreleased/pr-1142.v2.yml
+++ b/changelog/@unreleased/pr-1142.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Clean up UrlSelector logic so it's easier to follow.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1142

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
@@ -153,9 +153,10 @@ final class UrlSelectorImpl implements UrlSelector {
 
     @Override
     public Optional<HttpUrl> redirectToNext(HttpUrl existingUrl) {
-        // if possible, determine the index of the passed in url (so we can be sure to return a url which is different)
         List<HttpUrl> httpUrls = baseUrls.get();
-        int currentIndex = getCurrentIndex(existingUrl, httpUrls);
+        // if possible, determine the index of the passed in url (so we can be sure to return a url which is different)
+        Optional<Integer> existingUrlIndex = indexFor(existingUrl, httpUrls);
+        int currentIndex = existingUrlIndex.orElseGet(() -> getCurrentIndex(httpUrls));
 
         Optional<HttpUrl> nextUrl = getNext(currentIndex, httpUrls);
         if (nextUrl.isPresent()) {
@@ -192,21 +193,6 @@ final class UrlSelectorImpl implements UrlSelector {
                     failedUrls.put(baseUrls.get().get(index), UrlAvailability.FAILED)
             );
         }
-    }
-
-    /**
-     * Best-effort to find the index of the last used base URL, by going through the following cases in order.
-     * <ul>
-     *     <li>The index of a baseUrl from {@code httpUrls} that is a path-prefix of {@code justAttemptedUrl}</li>
-     *     <li>The index of {@link #currentBaseUrl}, which is expected to exist in {@code httpUrls}</li>
-     * </ul>
-     *
-     * @param justAttemptedUrl  URL that was just attempted
-     * @param httpUrls          the current list of base URLs
-     */
-    private int getCurrentIndex(HttpUrl justAttemptedUrl, List<HttpUrl> httpUrls) {
-        Optional<Integer> existingUrlIndex = indexFor(justAttemptedUrl, httpUrls);
-        return existingUrlIndex.orElseGet(() -> getCurrentIndex(httpUrls));
     }
 
     /**

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
@@ -119,7 +119,7 @@ final class UrlSelectorImpl implements UrlSelector {
     }
 
     private Optional<HttpUrl> redirectTo(HttpUrl current, HttpUrl redirectBaseUrl) {
-        Optional<Integer> baseUrlIndex = indexFor(redirectBaseUrl);
+        Optional<Integer> baseUrlIndex = indexFor(redirectBaseUrl, baseUrls.get());
         baseUrlIndex.ifPresent(currentUrl::set);
 
         return baseUrlIndex
@@ -145,7 +145,7 @@ final class UrlSelectorImpl implements UrlSelector {
     @Override
     public Optional<HttpUrl> redirectToNext(HttpUrl existingUrl) {
         // if possible, determine the index of the passed in url (so we can be sure to return a url which is different)
-        Optional<Integer> existingUrlIndex = indexFor(existingUrl);
+        Optional<Integer> existingUrlIndex = indexFor(existingUrl, baseUrls.get());
 
         int potentialNextIndex = existingUrlIndex.orElse(currentUrl.get());
 
@@ -179,7 +179,7 @@ final class UrlSelectorImpl implements UrlSelector {
     @Override
     public void markAsFailed(HttpUrl failedUrl) {
         if (useFailedUrlCache) {
-            Optional<Integer> indexForFailedUrl = indexFor(failedUrl);
+            Optional<Integer> indexForFailedUrl = indexFor(failedUrl, baseUrls.get());
             indexForFailedUrl.ifPresent(index ->
                     failedUrls.put(baseUrls.get().get(index), UrlAvailability.FAILED)
             );
@@ -205,11 +205,10 @@ final class UrlSelectorImpl implements UrlSelector {
         return Optional.empty();
     }
 
-    private Optional<Integer> indexFor(HttpUrl url) {
+    private static Optional<Integer> indexFor(HttpUrl url, List<HttpUrl> currentUrls) {
         HttpUrl canonicalUrl = canonicalize(url);
-        List<HttpUrl> httpUrls = baseUrls.get();
-        for (int i = 0; i < httpUrls.size(); ++i) {
-            if (isBaseUrlFor(httpUrls.get(i), canonicalUrl)) {
+        for (int i = 0; i < currentUrls.size(); ++i) {
+            if (isBaseUrlFor(currentUrls.get(i), canonicalUrl)) {
                 return Optional.of(i);
             }
         }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
@@ -45,6 +45,9 @@ final class UrlSelectorImpl implements UrlSelector {
     private final boolean useFailedUrlCache;
 
     private UrlSelectorImpl(ImmutableList<HttpUrl> baseUrls, boolean reshuffle, Duration failedUrlCooldown) {
+        Preconditions.checkArgument(!baseUrls.isEmpty(), "Must specify at least one URL");
+        Preconditions.checkArgument(!failedUrlCooldown.isNegative(), "Cache expiration must be non-negative");
+
         if (reshuffle) {
             // Add jitter to avoid mass node reassignment when multiple nodes of a client are restarted
             Duration jitter = Duration.ofSeconds(ThreadLocalRandom.current().nextLong(-30, 30));
@@ -65,9 +68,6 @@ final class UrlSelectorImpl implements UrlSelector {
                 .expireAfterWrite(coolDownMillis, TimeUnit.MILLISECONDS)
                 .build();
         this.useFailedUrlCache = !failedUrlCooldown.isNegative() && !failedUrlCooldown.isZero();
-
-        Preconditions.checkArgument(!baseUrls.isEmpty(), "Must specify at least one URL");
-        Preconditions.checkArgument(!failedUrlCooldown.isNegative(), "Cache expiration must be non-negative");
     }
 
     /**

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
@@ -149,7 +149,7 @@ final class UrlSelectorImpl implements UrlSelector {
 
         int potentialNextIndex = existingUrlIndex.orElse(currentUrl.get());
 
-        Optional<HttpUrl> nextUrl = getNext(potentialNextIndex);
+        Optional<HttpUrl> nextUrl = getNext(potentialNextIndex, httpUrls);
         if (nextUrl.isPresent()) {
             return redirectTo(existingUrl, nextUrl.get());
         }
@@ -167,7 +167,7 @@ final class UrlSelectorImpl implements UrlSelector {
 
     @Override
     public Optional<HttpUrl> redirectToNextRoundRobin(HttpUrl current) {
-        Optional<HttpUrl> nextUrl = getNext(currentUrl.get());
+        Optional<HttpUrl> nextUrl = getNext(currentUrl.get(), baseUrls.get());
         if (nextUrl.isPresent()) {
             return redirectTo(current, nextUrl.get());
         }
@@ -187,10 +187,9 @@ final class UrlSelectorImpl implements UrlSelector {
     }
 
     /** Get the next URL in {@code baseUrls}, after the supplied index, that has not been marked as failed. */
-    private Optional<HttpUrl> getNext(int startIndex) {
+    private Optional<HttpUrl> getNext(int startIndex, List<HttpUrl> httpUrls) {
         int numAttempts = 0;
         int index = startIndex;
-        List<HttpUrl> httpUrls = baseUrls.get();
 
         // Find the next URL that is not marked as failed
         while (numAttempts < httpUrls.size()) {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
@@ -139,16 +139,15 @@ final class UrlSelectorImpl implements UrlSelector {
             // The requested redirectBaseUrl has a path that is not compatible with
             // the path of the current URL
             return Optional.empty();
-        } else {
-            return Optional.of(current.newBuilder()
-                    .scheme(redirectBaseUrl.scheme())
-                    .host(redirectBaseUrl.host())
-                    .port(redirectBaseUrl.port())
-                    .encodedPath(
-                            redirectBaseUrl.encodedPath()  // matching prefix
-                                    + current.encodedPath().substring(redirectBaseUrl.encodedPath().length()))
-                    .build());
         }
+        return Optional.of(current.newBuilder()
+                .scheme(redirectBaseUrl.scheme())
+                .host(redirectBaseUrl.host())
+                .port(redirectBaseUrl.port())
+                .encodedPath(
+                        redirectBaseUrl.encodedPath()  // matching prefix
+                                + current.encodedPath().substring(redirectBaseUrl.encodedPath().length()))
+                .build());
     }
 
     @Override

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
@@ -151,19 +151,19 @@ final class UrlSelectorImpl implements UrlSelector {
     }
 
     @Override
-    public Optional<HttpUrl> redirectToNext(HttpUrl existingUrl) {
+    public Optional<HttpUrl> redirectToNext(HttpUrl currentUrl) {
         List<HttpUrl> httpUrls = baseUrls.get();
         // if possible, determine the index of the passed in url (so we can be sure to return a url which is different)
-        Optional<Integer> existingUrlIndex = indexFor(existingUrl, httpUrls);
-        int thisIndex = existingUrlIndex.orElseGet(() -> getLastIndex(httpUrls));
+        Optional<Integer> currentUrlIndex = indexFor(currentUrl, httpUrls);
+        int startIndex = currentUrlIndex.orElseGet(() -> getLastIndex(httpUrls));
 
-        Optional<HttpUrl> nextUrl = getNext(thisIndex, httpUrls);
+        Optional<HttpUrl> nextUrl = getNext(startIndex, httpUrls);
         if (nextUrl.isPresent()) {
-            return redirectTo(existingUrl, nextUrl.get());
+            return redirectTo(currentUrl, nextUrl.get());
         }
 
         // No healthy URLs remain; re-balance across any specified nodes
-        return redirectTo(existingUrl, httpUrls.get((thisIndex + 1) % httpUrls.size()));
+        return redirectTo(currentUrl, httpUrls.get((startIndex + 1) % httpUrls.size()));
     }
 
     @Override

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UrlSelectorImpl.java
@@ -155,7 +155,7 @@ final class UrlSelectorImpl implements UrlSelector {
         List<HttpUrl> httpUrls = baseUrls.get();
         // if possible, determine the index of the passed in url (so we can be sure to return a url which is different)
         Optional<Integer> currentUrlIndex = indexFor(currentUrl, httpUrls);
-        int startIndex = currentUrlIndex.orElseGet(() -> getLastIndex(httpUrls));
+        int startIndex = currentUrlIndex.orElseGet(() -> getIndexOfLastBaseUrl(httpUrls));
 
         Optional<HttpUrl> nextUrl = getNext(startIndex, httpUrls);
         if (nextUrl.isPresent()) {
@@ -175,7 +175,7 @@ final class UrlSelectorImpl implements UrlSelector {
     public Optional<HttpUrl> redirectToNextRoundRobin(HttpUrl current) {
         List<HttpUrl> httpUrls = baseUrls.get();
         // Ignore whatever base URL 'current' might match to, get the last base URL that was used
-        int lastIndex = getLastIndex(httpUrls);
+        int lastIndex = getIndexOfLastBaseUrl(httpUrls);
         Optional<HttpUrl> nextUrl = getNext(lastIndex, httpUrls);
         if (nextUrl.isPresent()) {
             return redirectTo(current, nextUrl.get());
@@ -197,7 +197,7 @@ final class UrlSelectorImpl implements UrlSelector {
     /**
      * Returns the index of {@link #lastBaseUrl}, which is expected to exist in {@code httpUrls}.
      */
-    private int getLastIndex(List<HttpUrl> httpUrls) {
+    private int getIndexOfLastBaseUrl(List<HttpUrl> httpUrls) {
         int index = httpUrls.indexOf(lastBaseUrl.get());
         Preconditions.checkState(index != -1,
                 "Expected httpUrls to contain currentBaseUrl",


### PR DESCRIPTION
## Before this PR

A lot of the UrlSelectorImpl methods manipulate multiple mutable fields, making it hard to follow what's going on. For instance, both the set of URIs (which can change non-deterministically due to the periodic re-shuffling) and the current URI index are accessed multiple times through multiple nested methods.

Additionally, it's not clear when you're dealing with base urls vs urls that are supposed to start with base URLs. As a result, a few places deal with attempting to find a baseUrl of a value that in most cases is already a baseUrl, leading to confusion as to what values might be passed in.

Finally, the current index can become stale after a reshuffling.

## After this PR
==COMMIT_MSG==
Clean up UrlSelector logic so it's easier to follow.

* `currentUrl` is not an integer anymore but a HttpUrl, and now named `lastBaseUrl` to clarify that it's meant to be a base url, and to disambiguate from URL parameters named `current` in a bunch of methods. Its purpose is to track last the base url used by the last redirect
* `redirectTo(HttpUrl, HttpUrl)` now makes more assumptions about its inputs - namely that the directBaseUrl is actually a baseUrl, so it's not necessary to call baseUrlFor on it anymore
* `baseUrls.get()` is only called on public methods and then passed in to nested methods, making it easier to reason that it doesn't change throughout a given call stack, independently of the reshuffling cache
* `indexFor` and `getNext` are now static
==COMMIT_MSG==

## Possible downsides?
