### PR TITLE
[improvement] better debugging for concurrency leaks

### DIFF
--- a/changelog/@unreleased/pr-1144.v2.yml
+++ b/changelog/@unreleased/pr-1144.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: better debugging for concurrency leaks
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1144

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -33,7 +33,6 @@ import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tracing.okhttp3.OkhttpTraceInterceptor;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.lang.ref.WeakReference;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -338,15 +337,6 @@ final class ConcurrencyLimiters {
                 SettableFuture<Limiter.Listener> future, Optional<RuntimeException> allocationStackTrace) {
             this.future = future;
             this.allocationStackTrace = allocationStackTrace;
-        }
-    }
-
-    private static final class LeakDetectingReference<T> extends WeakReference<T> {
-        private final Optional<RuntimeException> stackTrace;
-
-        LeakDetectingReference(T referent, Optional<RuntimeException> stackTrace) {
-            super(referent);
-            this.stackTrace = stackTrace;
         }
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -33,6 +33,7 @@ import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tracing.okhttp3.OkhttpTraceInterceptor;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.lang.ref.WeakReference;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -204,42 +205,41 @@ final class ConcurrencyLimiters {
     }
 
     final class DefaultConcurrencyLimiter implements ConcurrencyLimiter {
-
         @GuardedBy("this")
-        private final ThreadWorkQueue<SettableFuture<Limiter.Listener>> waitingRequests = new ThreadWorkQueue<>();
+        private final ThreadWorkQueue<QueuedRequest> waitingRequests = new ThreadWorkQueue<>();
         @GuardedBy("this")
         private SimpleLimiter<Void> limiter;
         @GuardedBy("this")
         private ScheduledFuture<?> timeoutCleanup;
         private final Key limiterKey;
         private final Supplier<SimpleLimiter<Void>> limiterFactory;
-
-        private final SafeArg<Optional<String>> safeArgMethod;
-        private final SafeArg<Optional<String>> safeArgPathTemplate;
+        private final LeakDetector<Limiter.Listener> leakDetector = new LeakDetector<>(Limiter.Listener.class);
 
         DefaultConcurrencyLimiter(Key limiterKey, Supplier<SimpleLimiter<Void>> limiterFactory) {
             this.limiterKey = limiterKey;
             this.limiterFactory = limiterFactory;
             this.limiter = limiterFactory.get();
-            this.safeArgMethod = SafeArg.of("method", limiterKey.method());
-            this.safeArgPathTemplate = SafeArg.of("pathTemplate", limiterKey.pathTemplate());
         }
 
         @Override
         public synchronized ListenableFuture<Limiter.Listener> acquire() {
             SettableFuture<Limiter.Listener> future = SettableFuture.create();
             addSlowAcquireMarker(future);
-            waitingRequests.add(future);
+            waitingRequests.add(new QueuedRequest(future, LeakDetector.maybeCreateStackTrace()));
             processQueue();
             return future;
         }
 
         synchronized void processQueue() {
             while (!waitingRequests.isEmpty()) {
-                log.debug("Limit",
-                        SafeArg.of("limit", limiter.getLimit()),
-                        safeArgMethod,
-                        safeArgPathTemplate);
+                if (log.isDebugEnabled()) {
+                    log.debug("Limit",
+                            SafeArg.of("limit", limiter.getLimit()),
+                            SafeArg.of("queueLength", waitingRequests.size()),
+                            SafeArg.of("method", limiterKey.method()),
+                            SafeArg.of("pathTemplate", limiterKey.pathTemplate()),
+                            UnsafeArg.of("hostname", limiterKey.hostname()));
+                }
                 Optional<Limiter.Listener> maybeAcquired = limiter.acquire(NO_CONTEXT);
                 if (!maybeAcquired.isPresent()) {
                     if (!timeoutScheduled()) {
@@ -250,8 +250,10 @@ final class ConcurrencyLimiters {
                 }
                 Limiter.Listener acquired = maybeAcquired.get();
 
-                SettableFuture<Limiter.Listener> head = waitingRequests.remove();
-                head.set(wrap(acquired));
+                QueuedRequest request = waitingRequests.remove();
+
+                SettableFuture<Limiter.Listener> head = request.future;
+                head.set(wrap(acquired, request.allocationStackTrace));
             }
 
             if (timeoutScheduled()) {
@@ -269,8 +271,8 @@ final class ConcurrencyLimiters {
                             + "closing response bodies (consider using the try-with-resources pattern).",
                     SafeArg.of("serviceClass", serviceClass),
                     UnsafeArg.of("hostname", limiterKey.hostname()),
-                    safeArgMethod,
-                    safeArgPathTemplate,
+                    SafeArg.of("method", limiterKey.method()),
+                    SafeArg.of("pathTemplate", limiterKey.pathTemplate()),
                     SafeArg.of("timeout", timeout));
             leakSuspected.mark();
             limiter = limiterFactory.get();
@@ -300,26 +302,51 @@ final class ConcurrencyLimiters {
             }, MoreExecutors.directExecutor());
         }
 
-        private Limiter.Listener wrap(Limiter.Listener listener) {
-            return new Limiter.Listener() {
+        private Limiter.Listener wrap(Limiter.Listener listener, Optional<RuntimeException> allocationStackTrace) {
+            Limiter.Listener result = new Limiter.Listener() {
                 @Override
                 public void onSuccess() {
+                    leakDetector.unregister(this);
                     listener.onSuccess();
                     processQueue();
                 }
 
                 @Override
                 public void onIgnore() {
+                    leakDetector.unregister(this);
                     listener.onIgnore();
                     processQueue();
                 }
 
                 @Override
                 public void onDropped() {
+                    leakDetector.unregister(this);
                     listener.onDropped();
                     processQueue();
                 }
             };
+            leakDetector.register(result, allocationStackTrace);
+            return result;
+        }
+    }
+
+    private static final class QueuedRequest {
+        private final SettableFuture<Limiter.Listener> future;
+        private final Optional<RuntimeException> allocationStackTrace;
+
+        private QueuedRequest(
+                SettableFuture<Limiter.Listener> future, Optional<RuntimeException> allocationStackTrace) {
+            this.future = future;
+            this.allocationStackTrace = allocationStackTrace;
+        }
+    }
+
+    private static final class LeakDetectingReference<T> extends WeakReference<T> {
+        private final Optional<RuntimeException> stackTrace;
+
+        LeakDetectingReference(T referent, Optional<RuntimeException> stackTrace) {
+            super(referent);
+            this.stackTrace = stackTrace;
         }
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/LeakDetector.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/LeakDetector.java
@@ -1,0 +1,107 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.logsafe.SafeArg;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class LeakDetector<T> {
+    private static final Logger log = LoggerFactory.getLogger(LeakDetector.class);
+
+    private final Class<T> resourceType;
+    private final Consumer<Optional<RuntimeException>> subscriber;
+    private final List<LeakDetectingReference<T>> references = new ArrayList<>();
+
+    LeakDetector(Class<T> resourceType) {
+        this(resourceType, unused -> { });
+    }
+
+    @VisibleForTesting
+    LeakDetector(Class<T> resourceType, Consumer<Optional<RuntimeException>> subscriber) {
+        this.resourceType = resourceType;
+        this.subscriber = subscriber;
+    }
+
+    static Optional<RuntimeException> maybeCreateStackTrace() {
+        if (log.isTraceEnabled()) {
+            return Optional.of(new RuntimeException("Runtime exception for stack trace"));
+        }
+        return Optional.empty();
+    }
+
+    synchronized void register(T objectToMonitor, Optional<RuntimeException> stackTrace) {
+        references.add(new LeakDetectingReference<>(objectToMonitor, stackTrace));
+        pruneAndLog();
+    }
+
+    synchronized void unregister(T objectToNoLongerMonitor) {
+        for (int i = 0; i < references.size(); i++) {
+            if (references.get(i) == objectToNoLongerMonitor) {
+                int last = references.size() - 1;
+                Collections.swap(references, i, last);
+                references.remove(last);
+            }
+        }
+    }
+
+    private synchronized void pruneAndLog() {
+        Iterator<LeakDetectingReference<T>> iterator = references.iterator();
+        while (iterator.hasNext()) {
+            LeakDetectingReference<T> reference = iterator.next();
+            if (reference.get() == null) {
+                subscriber.accept(reference.stackTrace);
+                logLeak(reference.stackTrace);
+                iterator.remove();
+            }
+        }
+    }
+
+    private void logLeak(Optional<RuntimeException> stackTrace) {
+        if (stackTrace.isPresent()) {
+            log.warn("Resource leak detected - did you forget to close a resource properly? "
+                            + "This will likely hurt performance. Stack trace is of the call where "
+                            + "the acquire happened.",
+                    SafeArg.of("resourceType", resourceType.getName()),
+                    stackTrace.get());
+        } else {
+            log.warn("Leak detected in Conjure call - did you forget to close a resource properly? "
+                            + "This will likely hurt performance. To get a "
+                            + "stack trace for the call where the acquire happened, set log "
+                            + "level to TRACE.",
+                    SafeArg.of("resourceType", resourceType.getName()),
+                    SafeArg.of("loggerToSetToTrace", log.getName()));
+        }
+    }
+
+    private static final class LeakDetectingReference<T> extends WeakReference<T> {
+        private final Optional<RuntimeException> stackTrace;
+
+        LeakDetectingReference(T referent, Optional<RuntimeException> stackTrace) {
+            super(referent);
+            this.stackTrace = stackTrace;
+        }
+    }
+}

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ThreadWorkQueue.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ThreadWorkQueue.java
@@ -35,6 +35,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 final class ThreadWorkQueue<T> {
     private final Map<Long, Queue<T>> queuedRequests = new LinkedHashMap<>();
+    private int size = 0;
 
     boolean isEmpty() {
         return queuedRequests.isEmpty();
@@ -43,6 +44,7 @@ final class ThreadWorkQueue<T> {
     void add(T element) {
         long threadId = Thread.currentThread().getId();
         queue(threadId).add(element);
+        size++;
     }
 
     T remove() {
@@ -51,7 +53,12 @@ final class ThreadWorkQueue<T> {
         if (!workQueue.getValue().isEmpty()) {
             queuedRequests.put(workQueue.getKey(), workQueue.getValue());
         }
+        size--;
         return result;
+    }
+
+    int size() {
+        return size;
     }
 
     private Map.Entry<Long, Queue<T>> nextTask() {

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/LeakDetectorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/LeakDetectorTest.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Test;
+
+public class LeakDetectorTest {
+    private final List<Optional<RuntimeException>> leaks = new ArrayList<>();
+    private final LeakDetector<String> leakDetector = new LeakDetector<>(String.class, leaks::add);
+
+    @Test
+    public void detectsLeaks() {
+        String toUnregister = "won't be leaked";
+        leakDetector.register(toUnregister, Optional.empty());
+        Optional<RuntimeException> exception = Optional.of(new RuntimeException());
+        leakDetector.register(new String("this will be leaked".toCharArray()), exception);
+        System.gc();
+        leakDetector.register("this will trigger detection", Optional.empty());
+        assertThat(leaks).containsExactly(exception);
+        leakDetector.unregister(toUnregister);
+    }
+}

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/LeakDetectorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/LeakDetectorTest.java
@@ -16,7 +16,7 @@
 
 package com.palantir.conjure.java.okhttp;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
This changes 3 things.

1. The limit log line now also contains the number of waiting requests.
2. The limit log line now also contains the hostname (unsafe, to be
consistent).
3. We keep a 'leak detector' which uses weak references to log and
optionally log the stack traces of places which we can know definitely
leaked.