### PR TITLE
Concurrency limiters should respect cancellation

### DIFF
--- a/changelog/@unreleased/pr-1147.v2.yml
+++ b/changelog/@unreleased/pr-1147.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Concurrency limiters respect call cancellation
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1147

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -252,7 +252,11 @@ final class ConcurrencyLimiters {
                 QueuedRequest request = waitingRequests.remove();
 
                 SettableFuture<Limiter.Listener> head = request.future;
-                head.set(wrap(acquired, request.allocationStackTrace));
+                Limiter.Listener wrapped = wrap(acquired, request.allocationStackTrace);
+                boolean wasCancelled = !head.set(wrapped);
+                if (wasCancelled) {
+                    wrapped.onIgnore();
+                }
             }
 
             if (timeoutScheduled()) {


### PR DESCRIPTION
Right now the concurrency limiters don't deal with the case where someone cancelled the future before we could set the result. In this case, the permit is leaked. Instead, let's check if the future was otherwise completed and if so, immediately move on to the next one. See internal ticket PDS-94666 for details.