### PR TITLE
Conjure should not retry cancelled calls

### DIFF
--- a/changelog/@unreleased/pr-1149.v2.yml
+++ b/changelog/@unreleased/pr-1149.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Do not retry cancelled calls
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1149

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -183,6 +183,10 @@ final class RemotingOkHttpCall extends ForwardingCall {
         super.enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException exception) {
+                if (isCanceled()) {
+                    callback.onFailure(call, exception);
+                }
+
                 urls.markAsFailed(request().url());
 
                 // Fail call if backoffs are exhausted or if no retry URL can be determined.

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -185,6 +185,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
             public void onFailure(Call call, IOException exception) {
                 if (isCanceled()) {
                     callback.onFailure(call, exception);
+                    return;
                 }
 
                 urls.markAsFailed(request().url());

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -105,7 +105,7 @@ public final class OkHttpClientsTest extends TestBase {
         }
     }
 
-    private static class AsyncRequest extends AbstractFuture<Response> implements Callback {
+    private static final class AsyncRequest extends AbstractFuture<Response> implements Callback {
         private final Call call;
 
         private AsyncRequest(Call call) {
@@ -117,8 +117,8 @@ public final class OkHttpClientsTest extends TestBase {
         }
 
         @Override
-        public void onFailure(Call unused, IOException e) {
-            setException(e);
+        public void onFailure(Call unused, IOException exception) {
+            setException(exception);
         }
 
         @Override

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -20,12 +20,16 @@ import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptio
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
 import com.google.common.net.HostAndPort;
 import com.google.common.net.HttpHeaders;
+import com.google.common.util.concurrent.AbstractFuture;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
@@ -85,6 +89,48 @@ public final class OkHttpClientsTest extends TestBase {
         url = "http://localhost:" + server.getPort();
         url2 = "http://localhost:" + server2.getPort();
         url3 = "http://localhost:" + server3.getPort();
+    }
+
+    @Test
+    public void cancelledCallsDoNotRetry() {
+        server.enqueue(new MockResponse().setHeadersDelay(1, TimeUnit.SECONDS).setBody("pong"));
+        OkHttpClient client = createRetryingClient(1);
+        AsyncRequest future = AsyncRequest.of(client.newCall(new Request.Builder().url(url).build()));
+        future.cancelCall();
+        try {
+            Futures.getUnchecked(future);
+            fail("Did not throw an exception");
+        } catch (UncheckedExecutionException e) {
+            assertThat(e.getCause()).hasMessage("Canceled").isInstanceOf(IOException.class);
+        }
+    }
+
+    private static class AsyncRequest extends AbstractFuture<Response> implements Callback {
+        private final Call call;
+
+        private AsyncRequest(Call call) {
+            this.call = call;
+        }
+
+        public void cancelCall() {
+            call.cancel();
+        }
+
+        @Override
+        public void onFailure(Call unused, IOException e) {
+            setException(e);
+        }
+
+        @Override
+        public void onResponse(Call unused, Response response) {
+            set(response);
+        }
+
+        static AsyncRequest of(Call call) {
+            AsyncRequest future = new AsyncRequest(call);
+            call.enqueue(future);
+            return future;
+        }
     }
 
     @Test


### PR DESCRIPTION
Currently if you cancel a call, Conjure will cancel the underlying call,
and then retry it.

This has a number of bad outcomes - it generally means that cancelled
calls run twice. It also means that they leak their concurrency permits.

Sadness for all.