### PR TITLE
Do not retry streamed requests.

### DIFF
--- a/changelog/@unreleased/pr-1152.v2.yml
+++ b/changelog/@unreleased/pr-1152.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Do not retry ``UnrepeatableRequestBody``.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1152

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -184,7 +184,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
         super.enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException exception) {
-                if (isCanceled() || isStreamingBody(call)) {
+                if (isCanceled()) {
                     callback.onFailure(call, exception);
                     return;
                 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -294,22 +294,6 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 SafeArg.of("retryOnTimeout", retryOnTimeout));
     }
 
-    private static void retryIfAllowed(Callback callback, Call call, Exception exception, Runnable retryScheduler) {
-        if (isStreamingBody(call)) {
-            callback.onFailure(
-                    call,
-                    new SafeIoException(
-                            "Cannot retry streamed HTTP body",
-                            exception));
-        } else {
-            retryScheduler.run();
-        }
-    }
-
-    private static boolean isStreamingBody(Call call) {
-        return call.request().body() instanceof UnrepeatableRequestBody;
-    }
-
     @SuppressWarnings("FutureReturnValueIgnored")
     private void scheduleExecution(Runnable execution, Duration backoff) {
         // TODO(rfink): Investigate whether ignoring the ScheduledFuture is safe, #629.
@@ -428,6 +412,22 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 return null;
             }
         };
+    }
+
+    private static void retryIfAllowed(Callback callback, Call call, Exception exception, Runnable retryScheduler) {
+        if (isStreamingBody(call)) {
+            callback.onFailure(
+                    call,
+                    new SafeIoException(
+                            "Cannot retry streamed HTTP body",
+                            exception));
+        } else {
+            retryScheduler.run();
+        }
+    }
+
+    private static boolean isStreamingBody(Call call) {
+        return call.request().body() instanceof UnrepeatableRequestBody;
     }
 
     private static boolean shouldPropagateQos(ClientConfiguration.ServerQoS serverQoS) {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -211,8 +211,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
                     return;
                 }
 
-                log.info(
-                        "Retrying call after failure",
+                log.info("Retrying call after failure",
                         SafeArg.of("backoffMillis", backoff.get().toMillis()),
                         UnsafeArg.of("requestUrl", call.request().url().toString()),
                         UnsafeArg.of("redirectToUrl", redirectTo.get().toString()),
@@ -276,7 +275,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
                     }
 
                     callback.onFailure(call, new SafeIoException("Failed to handle request, "
-                            + "this is a conjure-java-runtime bug."));
+                            + "this is an conjure-java-runtime bug."));
                 }
             }
 
@@ -300,7 +299,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 // Catch-all: handle all other responses
                 Optional<IOException> ioException = ioExceptionHandler.handle(errorResponseSupplier.get());
                 return ioException.orElseGet(
-                        () -> new SafeIoException("Failed to handle request, this is a conjure-java-runtime bug."));
+                        () -> new SafeIoException("Failed to handle request, this is an conjure-java-runtime bug."));
             }
         });
     }


### PR DESCRIPTION
* This ports logic from RetryAndFollowupInterceptor in OkHttp.

## Before this PR
Streaming requests are retried and clients need to guard against that.

## After this PR
==COMMIT_MSG==
Streaming requests are not retried.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

