### PR TITLE
Increase the default parallel requests for clients

### DIFF
--- a/changelog/@unreleased/pr-1167.v2.yml
+++ b/changelog/@unreleased/pr-1167.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Increased the default limits on number of parallel requests for CJR
+    clients
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1167

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -94,9 +94,9 @@ public final class OkHttpClients {
 
     static {
         dispatcher = new Dispatcher(executionExecutor);
-        dispatcher.setMaxRequests(256);
+        dispatcher.setMaxRequests(1024);
         // Must be less than maxRequests so a single slow host does not block all requests
-        dispatcher.setMaxRequestsPerHost(64);
+        dispatcher.setMaxRequestsPerHost(256);
 
         dispatcherMetricSet = new DispatcherMetricSet(dispatcher, connectionPool);
     }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -94,7 +94,7 @@ public final class OkHttpClients {
 
     static {
         dispatcher = new Dispatcher(executionExecutor);
-        dispatcher.setMaxRequests(1024);
+        dispatcher.setMaxRequests(Integer.MAX_VALUE);
         // Must be less than maxRequests so a single slow host does not block all requests
         dispatcher.setMaxRequestsPerHost(256);
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -94,6 +94,7 @@ public final class OkHttpClients {
 
     static {
         dispatcher = new Dispatcher(executionExecutor);
+        // Restricting concurrency is done elsewhere in ConcurrencyLimiters.
         dispatcher.setMaxRequests(Integer.MAX_VALUE);
         // Must be less than maxRequests so a single slow host does not block all requests
         dispatcher.setMaxRequestsPerHost(256);


### PR DESCRIPTION
## Before this PR
The default limits for the dispatcher are quite constricting for using CJR with AtlasDB.

## After this PR
==COMMIT_MSG==
Increased the default limits on number of parallel requests for CJR clients
==COMMIT_MSG==

## Possible downsides?
This might not be what we want in the general case. Alternatively, we can come up with a way to make it configurable

