### PR TITLE
Handle null timeout messages

### DIFF
--- a/changelog/@unreleased/pr-1168.v2.yml
+++ b/changelog/@unreleased/pr-1168.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handle ``null`` exception messages for socket timeouts.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1168

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -281,7 +281,8 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 if (exception instanceof SocketTimeoutException) {
                     // non-connect timeouts should not be retried
                     SocketTimeoutException socketTimeout = (SocketTimeoutException) exception;
-                    if (!socketTimeout.getMessage().contains("connect timed out")) {
+                    if (socketTimeout.getMessage() == null
+                            || !socketTimeout.getMessage().contains("connect timed out")) {
                         return false;
                     }
                 }


### PR DESCRIPTION
## Before this PR
Fix #1165 

## After this PR
==COMMIT_MSG==
Handle null socket timeout messages.
==COMMIT_MSG==

## Possible downsides?
This could mask bigger underlying issues.

