### PR TITLE
Allow disabling of handling of SocketExceptions

### DIFF
--- a/changelog/@unreleased/pr-1171.v2.yml
+++ b/changelog/@unreleased/pr-1171.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow disabling of handling of SocketExceptions
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1171

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -113,6 +113,9 @@ public interface ClientConfiguration {
     /** Indicates whether timed out requests should be retried. */
     RetryOnTimeout retryOnTimeout();
 
+    /** Indicates whether requests that resulted in a socket exception should be retried. */
+    RetryOnSocketException retryOnSocketException();
+
     /** Both per-request and global metrics are recorded in this registry. */
     TaggedMetricRegistry taggedMetricRegistry();
 
@@ -197,6 +200,18 @@ public interface ClientConfiguration {
          * Note that connect timeouts will always be retried.
          */
         DANGEROUS_ENABLE_AT_RISK_OF_RETRY_STORMS
+    }
+
+    enum RetryOnSocketException {
+        /** Default. */
+        ENABLED,
+        /**
+         * Disables all {@link java.net.SocketException} handling. This is almost always not what you want,
+         * the solitary case where this is desirable being cases where Conjure is used to create single-host clients
+         * with retry on host failure handled outside of the Conjure layer. If you want to use this, please
+         * talk to a relevant party; this is here to enable a very specific workflow.
+         */
+        DANGEROUS_DISABLED
     }
 
 }

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -54,6 +54,8 @@ public final class ClientConfigurations {
             ClientConfiguration.ServerQoS.AUTOMATIC_RETRY;
     private static final ClientConfiguration.RetryOnTimeout RETRY_ON_TIMEOUT_DEFAULT =
             ClientConfiguration.RetryOnTimeout.DISABLED;
+    private static final ClientConfiguration.RetryOnSocketException RETRY_ON_SOCKET_EXCEPTION_DEFAULT =
+            ClientConfiguration.RetryOnSocketException.ENABLED;
 
     private ClientConfigurations() {}
 
@@ -84,6 +86,7 @@ public final class ClientConfigurations {
                 .clientQoS(CLIENT_QOS_DEFAULT)
                 .serverQoS(PROPAGATE_QOS_DEFAULT)
                 .retryOnTimeout(RETRY_ON_TIMEOUT_DEFAULT)
+                .retryOnSocketException(RETRY_ON_SOCKET_EXCEPTION_DEFAULT)
                 .taggedMetricRegistry(DefaultTaggedMetricRegistry.getDefault())
                 .build();
     }
@@ -112,6 +115,7 @@ public final class ClientConfigurations {
                 .clientQoS(CLIENT_QOS_DEFAULT)
                 .serverQoS(PROPAGATE_QOS_DEFAULT)
                 .retryOnTimeout(RETRY_ON_TIMEOUT_DEFAULT)
+                .retryOnSocketException(RETRY_ON_SOCKET_EXCEPTION_DEFAULT)
                 .taggedMetricRegistry(DefaultTaggedMetricRegistry.getDefault())
                 .build();
     }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -225,7 +225,8 @@ public final class OkHttpClients {
                 executionExecutor,
                 concurrencyLimiters,
                 config.serverQoS(),
-                config.retryOnTimeout());
+                config.retryOnTimeout(),
+                config.retryOnSocketException());
     }
 
     private static boolean shouldEnableQos(ClientConfiguration.ClientQoS clientQoS) {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java
@@ -49,6 +49,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
     private final ConcurrencyLimiters concurrencyLimiters;
     private final ClientConfiguration.ServerQoS serverQoS;
     private final ClientConfiguration.RetryOnTimeout retryOnTimeout;
+    private final ClientConfiguration.RetryOnSocketException retryOnSocketException;
 
     RemotingOkHttpClient(
             OkHttpClient delegate,
@@ -59,7 +60,8 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
             ExecutorService executionExecutor,
             ConcurrencyLimiters concurrencyLimiters,
             ClientConfiguration.ServerQoS serverQoS,
-            ClientConfiguration.RetryOnTimeout retryOnTimeout) {
+            ClientConfiguration.RetryOnTimeout retryOnTimeout,
+            ClientConfiguration.RetryOnSocketException retryOnSocketException) {
         super(delegate);
         this.backoffStrategyFactory = backoffStrategy;
         this.nodeSelectionStrategy = nodeSelectionStrategy;
@@ -69,6 +71,7 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
         this.concurrencyLimiters = concurrencyLimiters;
         this.serverQoS = serverQoS;
         this.retryOnTimeout = retryOnTimeout;
+        this.retryOnSocketException = retryOnSocketException;
     }
 
     @Override
@@ -95,7 +98,8 @@ final class RemotingOkHttpClient extends ForwardingOkHttpClient {
                 concurrencyLimiters.acquireLimiter(request),
                 maxNumRelocations,
                 serverQoS,
-                retryOnTimeout);
+                retryOnTimeout,
+                retryOnSocketException);
     }
 
     private Request createNewRequest(Request request) {


### PR DESCRIPTION
We have an internal service which manages its own multiplexing between a
number of Conjure clients (this was decided as the right approach a
number of months ago). We'd like it to use a client per remote server.

Unfortunately, with Conjure, discovering the server is down requires a 4
second backoff loop, which makes using these clients very painful.

This PR enables a mode that only we should use which disables retrying
on that, but retains retrying on 503s and 429s. We have a retry loop at
a higher level.

Alternatives considered:

1. Enabling URL selection pluggability in Conjure. This would require significant refactoring in order to be confident with a pluggable API.
2. Adding a hash based approach to Conjure that could be used - this has been attempted, and would also require significant effort within Conjure in order to refactor how URL selection works - would prefer to do this post-Dialogue.
3. Could just continue with our current 'use-many-clients-each-having-all-the-servers' approach, but this has very poor randomization properties, which combines poorly with rate limiting - you still essentially pin your rate limits to the rate limit of the smallest client.
4. We could blacklist internally, but this gives a lot of unpleasant tuning properties - how long do you blacklist clients for, do you do the 'single request tries to use the server' healthcheck thing, do you need a thread pool for that, etc etc.