### PR TITLE
Correctly handle  Query Parameters for optional primitives

### DIFF
--- a/changelog/@unreleased/pr-1183.v2.yml
+++ b/changelog/@unreleased/pr-1183.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Correctly handle query parameters for optional primitives
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1183

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalDoubleParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalDoubleParamConverterProvider.java
@@ -42,7 +42,7 @@ public final class Java8OptionalDoubleParamConverterProvider implements ParamCon
     public static final class OptionalDoubleParamConverter implements ParamConverter<OptionalDouble> {
         @Override
         public OptionalDouble fromString(final String value) {
-            if (value == null || value.equals("null")) {
+            if (value == null) {
                 return OptionalDouble.empty();
             }
 

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalDoubleParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalDoubleParamConverterProvider.java
@@ -42,14 +42,14 @@ public final class Java8OptionalDoubleParamConverterProvider implements ParamCon
     public static final class OptionalDoubleParamConverter implements ParamConverter<OptionalDouble> {
         @Override
         public OptionalDouble fromString(final String value) {
-            if (value == null) {
+            if (value == null || value.equals("null")) {
                 return OptionalDouble.empty();
             }
 
             try {
                 return OptionalDouble.of(Double.parseDouble(value));
             } catch (NumberFormatException e) {
-                throw new IllegalArgumentException(e);
+                throw new IllegalStateException(e);
             }
         }
 

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalIntParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalIntParamConverterProvider.java
@@ -42,7 +42,7 @@ public final class Java8OptionalIntParamConverterProvider implements ParamConver
     public static final class OptionalIntParamConverter implements ParamConverter<OptionalInt> {
         @Override
         public OptionalInt fromString(final String value) {
-            if (value == null || value.equals("null")) {
+            if (value == null) {
                 return OptionalInt.empty();
             }
 

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalIntParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalIntParamConverterProvider.java
@@ -42,14 +42,14 @@ public final class Java8OptionalIntParamConverterProvider implements ParamConver
     public static final class OptionalIntParamConverter implements ParamConverter<OptionalInt> {
         @Override
         public OptionalInt fromString(final String value) {
-            if (value == null) {
+            if (value == null || value.equals("null")) {
                 return OptionalInt.empty();
             }
 
             try {
                 return OptionalInt.of(Integer.parseInt(value));
             } catch (NumberFormatException e) {
-                throw new IllegalArgumentException(e);
+                throw new IllegalStateException(e);
             }
         }
 

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalLongParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalLongParamConverterProvider.java
@@ -42,7 +42,7 @@ public final class Java8OptionalLongParamConverterProvider implements ParamConve
     public static final class OptionalLongParamConverter implements ParamConverter<OptionalLong> {
         @Override
         public OptionalLong fromString(final String value) {
-            if (value == null || value.equals("null")) {
+            if (value == null) {
                 return OptionalLong.empty();
             }
 

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalLongParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalLongParamConverterProvider.java
@@ -42,14 +42,14 @@ public final class Java8OptionalLongParamConverterProvider implements ParamConve
     public static final class OptionalLongParamConverter implements ParamConverter<OptionalLong> {
         @Override
         public OptionalLong fromString(final String value) {
-            if (value == null) {
+            if (value == null || value.equals("null")) {
                 return OptionalLong.empty();
             }
 
             try {
                 return OptionalLong.of(Long.parseLong(value));
             } catch (NumberFormatException e) {
-                throw new IllegalArgumentException(e);
+                throw new IllegalStateException(e);
             }
         }
 

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/Java8OptionalTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/Java8OptionalTest.java
@@ -103,13 +103,6 @@ public final class Java8OptionalTest {
     }
 
     @Test
-    public void testQueryParam_optionalIntNull() {
-        Response response = target.path("optional/int").queryParam("value", "null").request().get();
-        assertThat(response.getStatus(), is(Status.OK.getStatusCode()));
-        assertThat(response.readEntity(String.class), is("0"));
-    }
-
-    @Test
     public void testQueryParam_optionalIntInvalid() {
         Response response = target.path("optional/int").queryParam("value", "foo").request().get();
         assertThat(response.getStatus(), is(Status.BAD_REQUEST.getStatusCode()));
@@ -130,13 +123,6 @@ public final class Java8OptionalTest {
     }
 
     @Test
-    public void testQueryParam_optionalDoubleNull() {
-        Response response = target.path("optional/double").queryParam("value", "null").request().get();
-        assertThat(response.getStatus(), is(Status.OK.getStatusCode()));
-        assertThat(response.readEntity(String.class), is("0.0"));
-    }
-
-    @Test
     public void testQueryParam_optionalDoubleInvalid() {
         Response response = target.path("optional/double").queryParam("value", "foo").request().get();
         assertThat(response.getStatus(), is(Status.BAD_REQUEST.getStatusCode()));
@@ -152,13 +138,6 @@ public final class Java8OptionalTest {
     @Test
     public void testQueryParam_optionalLongEmpty() {
         Response response = target.path("optional/long").request().get();
-        assertThat(response.getStatus(), is(Status.OK.getStatusCode()));
-        assertThat(response.readEntity(String.class), is("0"));
-    }
-
-    @Test
-    public void testQueryParam_optionalLongNull() {
-        Response response = target.path("optional/long").queryParam("value", "null").request().get();
         assertThat(response.getStatus(), is(Status.OK.getStatusCode()));
         assertThat(response.readEntity(String.class), is("0"));
     }

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/Java8OptionalTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/Java8OptionalTest.java
@@ -103,6 +103,19 @@ public final class Java8OptionalTest {
     }
 
     @Test
+    public void testQueryParam_optionalIntNull() {
+        Response response = target.path("optional/int").queryParam("value", "null").request().get();
+        assertThat(response.getStatus(), is(Status.OK.getStatusCode()));
+        assertThat(response.readEntity(String.class), is("0"));
+    }
+
+    @Test
+    public void testQueryParam_optionalIntInvalid() {
+        Response response = target.path("optional/int").queryParam("value", "foo").request().get();
+        assertThat(response.getStatus(), is(Status.BAD_REQUEST.getStatusCode()));
+    }
+
+    @Test
     public void testQueryParam_optionalDoublePresent() throws NoSuchMethodException, SecurityException {
         Response response = target.path("optional/double").queryParam("value", "1.5").request().get();
         assertThat(response.getStatus(), is(Status.OK.getStatusCode()));
@@ -117,6 +130,19 @@ public final class Java8OptionalTest {
     }
 
     @Test
+    public void testQueryParam_optionalDoubleNull() {
+        Response response = target.path("optional/double").queryParam("value", "null").request().get();
+        assertThat(response.getStatus(), is(Status.OK.getStatusCode()));
+        assertThat(response.readEntity(String.class), is("0.0"));
+    }
+
+    @Test
+    public void testQueryParam_optionalDoubleInvalid() {
+        Response response = target.path("optional/double").queryParam("value", "foo").request().get();
+        assertThat(response.getStatus(), is(Status.BAD_REQUEST.getStatusCode()));
+    }
+
+    @Test
     public void testQueryParam_optionalLongPresent() throws NoSuchMethodException, SecurityException {
         Response response = target.path("optional/long").queryParam("value", "100").request().get();
         assertThat(response.getStatus(), is(Status.OK.getStatusCode()));
@@ -128,6 +154,19 @@ public final class Java8OptionalTest {
         Response response = target.path("optional/long").request().get();
         assertThat(response.getStatus(), is(Status.OK.getStatusCode()));
         assertThat(response.readEntity(String.class), is("0"));
+    }
+
+    @Test
+    public void testQueryParam_optionalLongNull() {
+        Response response = target.path("optional/long").queryParam("value", "null").request().get();
+        assertThat(response.getStatus(), is(Status.OK.getStatusCode()));
+        assertThat(response.readEntity(String.class), is("0"));
+    }
+
+    @Test
+    public void testQueryParam_optionalLongInvalid() {
+        Response response = target.path("optional/long").queryParam("value", "foo").request().get();
+        assertThat(response.getStatus(), is(Status.BAD_REQUEST.getStatusCode()));
     }
 
     public static class OptionalTestServer extends Application<Configuration> {


### PR DESCRIPTION
## Before this PR
Jersey's `SingleValueExtractor` would swallow any `IllegalArgument` exceptions thrown by our ParamConverters and instead set the value of the parameter to be converted to `null`.

This cause invalid requests to resulti in NPEs throughout the applications code.

## After this PR
==COMMIT_MSG==
Correctly handle query parameters for optional primitives
==COMMIT_MSG==

## Possible downsides?
N/A

