### PR TITLE
Fix: Convert retrofit optional Header parameters into string representation of wrapped objects

### DIFF
--- a/changelog/@unreleased/pr-1184.v2.yml
+++ b/changelog/@unreleased/pr-1184.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Optional header parameters are serialized as string representation
+    of the wrapped object omitting optional wrapper
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1184

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/OptionalObjectToStringConverterFactory.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/OptionalObjectToStringConverterFactory.java
@@ -24,13 +24,14 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
+import retrofit2.http.Header;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
 /**
- * A retrofit2 {@link Converter} that converts {@code Optional<?>} retrofit {@link Path} and {@link Query} parameters
- * into the string representation of the wrapped object, or null if the optional is empty. Handles both
- * {@link java.util.Optional Java8 Optional} and {@link com.google.common.base.Optional Guava Optional}.
+ * A retrofit2 {@link Converter} that converts {@code Optional<?>} retrofit {@link Path}, {@link Query} and
+ * {@link Header} parameters into the string representation of the wrapped object, or null if the optional is empty.
+ * Handles both {@link java.util.Optional Java8 Optional} and {@link com.google.common.base.Optional Guava Optional}.
  */
 public final class OptionalObjectToStringConverterFactory extends Converter.Factory {
     public static final OptionalObjectToStringConverterFactory INSTANCE = new OptionalObjectToStringConverterFactory();
@@ -41,7 +42,7 @@ public final class OptionalObjectToStringConverterFactory extends Converter.Fact
     public Converter<?, String> stringConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
         Optional<?> pathQueryAnnotation = ImmutableList.copyOf(annotations).stream()
                 .map(Annotation::annotationType)
-                .filter(t -> t == Path.class || t == Query.class)
+                .filter(t -> t == Path.class || t == Query.class || t == Header.class)
                 .findAny();
 
         if (pathQueryAnnotation.isPresent()) {

--- a/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/OptionalObjectToStringConverterFactoryTest.java
+++ b/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/OptionalObjectToStringConverterFactoryTest.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import retrofit2.http.Header;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
@@ -47,12 +48,16 @@ public final class OptionalObjectToStringConverterFactoryTest {
             OptionalObjectToStringConverterFactory.Java8OptionalStringConverter.INSTANCE;
 
     @Test
-    public void testRequiresPathOrQueryAnnotation() throws Exception {
+    public void testRequiresPathHeaderQueryAnnotation() throws Exception {
         // Java8
+        assertThat(factory.stringConverter(java.util.Optional.class, createAnnotations(Header.class), null))
+                .isNotNull();
         assertThat(factory.stringConverter(java.util.Optional.class, createAnnotations(Path.class), null)).isNotNull();
         assertThat(factory.stringConverter(java.util.Optional.class, createAnnotations(Query.class), null)).isNotNull();
         assertThat(factory.stringConverter(java.util.Optional.class, createAnnotations(Nonnull.class), null)).isNull();
 
+        assertThat(factory.stringConverter(java.util.OptionalInt.class, createAnnotations(Header.class), null))
+                .isNotNull();
         assertThat(factory.stringConverter(java.util.OptionalInt.class, createAnnotations(Path.class), null))
                 .isNotNull();
         assertThat(factory.stringConverter(java.util.OptionalInt.class, createAnnotations(Query.class), null))
@@ -60,6 +65,8 @@ public final class OptionalObjectToStringConverterFactoryTest {
         assertThat(factory.stringConverter(java.util.OptionalInt.class, createAnnotations(Nonnull.class), null))
                 .isNull();
 
+        assertThat(factory.stringConverter(java.util.OptionalDouble.class, createAnnotations(Header.class), null))
+                .isNotNull();
         assertThat(factory.stringConverter(java.util.OptionalDouble.class, createAnnotations(Path.class), null))
                 .isNotNull();
         assertThat(factory.stringConverter(java.util.OptionalDouble.class, createAnnotations(Query.class), null))
@@ -67,6 +74,8 @@ public final class OptionalObjectToStringConverterFactoryTest {
         assertThat(factory.stringConverter(java.util.OptionalDouble.class, createAnnotations(Nonnull.class), null))
                 .isNull();
 
+        assertThat(factory.stringConverter(java.util.OptionalLong.class, createAnnotations(Header.class), null))
+                .isNotNull();
         assertThat(factory.stringConverter(java.util.OptionalLong.class, createAnnotations(Path.class), null))
                 .isNotNull();
         assertThat(factory.stringConverter(java.util.OptionalLong.class, createAnnotations(Query.class), null))
@@ -75,6 +84,9 @@ public final class OptionalObjectToStringConverterFactoryTest {
                 .isNull();
 
         // Guava
+        assertThat(
+                factory.stringConverter(com.google.common.base.Optional.class, createAnnotations(Header.class), null))
+                .isNotNull();
         assertThat(factory.stringConverter(com.google.common.base.Optional.class, createAnnotations(Path.class), null))
                 .isNotNull();
         assertThat(factory.stringConverter(com.google.common.base.Optional.class, createAnnotations(Query.class), null))

--- a/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientApiTest.java
+++ b/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientApiTest.java
@@ -71,7 +71,8 @@ public final class Retrofit2ClientApiTest extends TestBase {
     @Before
     public void before() {
         url = server.url("/");
-        service = Retrofit2Client.create(TestService.class,
+        service = Retrofit2Client.create(
+                TestService.class,
                 AGENT,
                 new HostMetricsRegistry(),
                 createTestConfig(url.toString()));
@@ -340,6 +341,7 @@ public final class Retrofit2ClientApiTest extends TestBase {
             assertThat(remoteException.getError()).isEqualTo(ERROR);
         }
     }
+
     @Test
     public void future_should_throw_normal_IoException_for_client_side_errors_completable() {
         future_should_throw_normal_IoException_for_client_side_errors(() -> service.makeCompletableFutureRequest());
@@ -409,6 +411,20 @@ public final class Retrofit2ClientApiTest extends TestBase {
             }
         });
         assertThat(assertionsPassed.await(1, TimeUnit.SECONDS)).as("Callback was executed").isTrue();
+    }
+
+    @Test
+    public void serializes_java_optional_headers() throws InterruptedException {
+        server.enqueue(new MockResponse().setBody("\"body\""));
+        assertThat(Futures.getUnchecked(service.getJavaOptionalHeader(Optional.of("value")))).isEqualTo("body");
+        assertThat(server.takeRequest().getHeader("Optional-Header")).isEqualTo("value");
+    }
+
+    @Test
+    public void serializes_guava_optional_headers() throws InterruptedException {
+        server.enqueue(new MockResponse().setBody("\"body\""));
+        assertThat(Futures.getUnchecked(service.getGuavaOptionalHeader(guavaOptional("value")))).isEqualTo("body");
+        assertThat(server.takeRequest().getHeader("Optional-Header")).isEqualTo("value");
     }
 
     private static <T> com.google.common.base.Optional<T> guavaOptional(T value) {

--- a/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/TestService.java
+++ b/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/TestService.java
@@ -18,10 +18,12 @@ package com.palantir.conjure.java.client.retrofit2;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
+import retrofit2.http.Header;
 import retrofit2.http.Headers;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
@@ -73,4 +75,11 @@ public interface TestService {
 
     @POST("makeListenableFutureRequest")
     ListenableFuture<String> makeListenableFutureRequest();
+
+    @GET("getJavaOptionalHeader")
+    ListenableFuture<String> getJavaOptionalHeader(@Header("Optional-Header") Optional<String> optionalHeader);
+
+    @GET("getJavaOptionalHeader")
+    ListenableFuture<String> getGuavaOptionalHeader(
+            @Header("Optional-Header") com.google.common.base.Optional<String> optionalHeader);
 }


### PR DESCRIPTION
## Before this PR
Optional header parameters get serialized as `Optional[<value>]` (or `Optional.of(<value>)`) when using retrofit clients

## After this PR
==COMMIT_MSG==
Optional header parameters are serialized as string representation of the wrapped object omitting optional wrapper
==COMMIT_MSG==

## Possible downsides?
Someone was relying on that behaviour? Unlikely but...

