### PR TITLE
[Discussion] [DNM] Produce conjure-acquire-limiter metrics

### DIFF
--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -153,6 +153,9 @@ public interface ClientConfiguration {
         /** Default. */
         ENABLED,
 
+        /** Enable, and produce additional metrics. */
+        ENABLED_WITH_ADDITIONAL_METRICS,
+
         /**
          * Disables the client-side sympathetic QoS. Consumers should almost never use this option, reserving it
          * for where there are known issues with the QoS interaction. Please consult project maintainers if applying

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiters.java
@@ -239,12 +239,12 @@ final class ConcurrencyLimiters {
             this.limiter = limiterFactory.get();
 
             if (dumpFullMetrics) {
-                taggedMetricRegistry.gauge(metricName(INFLIGHT, limiterKey), limiter::getInflight);
-                taggedMetricRegistry.gauge(metricName(TOTAL, limiterKey), limiter::getLimit);
+                taggedMetricRegistry.gauge(metricName(INFLIGHT), limiter::getInflight);
+                taggedMetricRegistry.gauge(metricName(TOTAL), limiter::getLimit);
             }
         }
 
-        private static MetricName metricName(MetricName base, Key limiterKey) {
+        private MetricName metricName(MetricName base) {
             MetricName.Builder builder = MetricName.builder()
                     .from(base)
                     .putSafeTags("hostName", limiterKey.hostname());

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/DefaultConcurrencyLimitersTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/DefaultConcurrencyLimitersTest.java
@@ -47,7 +47,8 @@ public final class DefaultConcurrencyLimitersTest {
             new DefaultTaggedMetricRegistry(),
             TIMEOUT,
             DefaultConcurrencyLimitersTest.class,
-            true);
+            true,
+            false);
 
     @Test
     public void testTimeout() {

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/FlowControlTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/FlowControlTest.java
@@ -69,6 +69,7 @@ public final class FlowControlTest {
                     .build()),
             new DefaultTaggedMetricRegistry(),
             FlowControlTest.class,
+            true,
             true);
 
     @BeforeClass


### PR DESCRIPTION
## Before this PR
Debugging/diagnosing of the concurrency limiters' actions is extremely hard/a guessing game.

## After this PR
==COMMIT_MSG==
Optionally produce metrics to enable debugging of conjure acquire limiter's internal state.
==COMMIT_MSG==

## Possible downsides?
 - One metric per host/method/path tuple => a lot of metrics (disabled by default)
 - Dodgy way of enabling the metrics.

Pretty convinced this is not the best way to do it. Thoughts on the PR's goal (making CAS more interpretable)? Any better ideas on how to achieve it?
