### PR TITLE
Don't potentially leak response bodies when cancelling Retrofit calls

### DIFF
--- a/changelog/@unreleased/pr-1196.v2.yml
+++ b/changelog/@unreleased/pr-1196.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Don't potentially leak response bodies when cancelling Retrofit calls
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1196

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/AsyncSerializableErrorCallAdapterFactory.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/AsyncSerializableErrorCallAdapterFactory.java
@@ -26,6 +26,7 @@
  */
 package com.palantir.conjure.java.client.retrofit2;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.java.okhttp.IoRemoteException;
@@ -34,6 +35,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.concurrent.CompletableFuture;
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.CallAdapter;
 import retrofit2.Callback;
@@ -90,7 +92,13 @@ final class AsyncSerializableErrorCallAdapterFactory extends CallAdapter.Factory
 
         @Override
         public void onResponse(Call<R> call, Response<R> response) {
-            set(response.body());
+            boolean futureWasCancelled = !set(response.body());
+            if (futureWasCancelled) {
+                ResponseBody body = response.raw().body();
+                if (body != null) {
+                    body.close();
+                }
+            }
         }
 
         @Override
@@ -104,7 +112,8 @@ final class AsyncSerializableErrorCallAdapterFactory extends CallAdapter.Factory
         }
     }
 
-    private static final class ListenableFutureBodyCallAdapter<R> implements CallAdapter<R, ListenableFuture<R>> {
+    @VisibleForTesting
+    static final class ListenableFutureBodyCallAdapter<R> implements CallAdapter<R, ListenableFuture<R>> {
         private final Type responseType;
 
         ListenableFutureBodyCallAdapter(Type responseType) {
@@ -124,7 +133,8 @@ final class AsyncSerializableErrorCallAdapterFactory extends CallAdapter.Factory
         }
     }
 
-    private static final class CompletableFutureBodyCallAdapter<R> implements CallAdapter<R, CompletableFuture<R>> {
+    @VisibleForTesting
+    static final class CompletableFutureBodyCallAdapter<R> implements CallAdapter<R, CompletableFuture<R>> {
         private final Type responseType;
 
         CompletableFutureBodyCallAdapter(Type responseType) {
@@ -151,7 +161,13 @@ final class AsyncSerializableErrorCallAdapterFactory extends CallAdapter.Factory
             call.enqueue(new Callback<R>() {
                 @Override
                 public void onResponse(Call<R> call, Response<R> response) {
-                    future.complete(response.body());
+                    boolean futureWasCancelled = !future.complete(response.body());
+                    if (futureWasCancelled) {
+                        ResponseBody body = response.raw().body();
+                        if (body != null) {
+                            body.close();
+                        }
+                    }
                 }
 
                 @Override

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/AsyncSerializableErrorCallAdapterFactory.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/AsyncSerializableErrorCallAdapterFactory.java
@@ -35,7 +35,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.concurrent.CompletableFuture;
-import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.CallAdapter;
 import retrofit2.Callback;
@@ -94,10 +93,7 @@ final class AsyncSerializableErrorCallAdapterFactory extends CallAdapter.Factory
         public void onResponse(Call<R> call, Response<R> response) {
             boolean futureWasCancelled = !set(response.body());
             if (futureWasCancelled) {
-                ResponseBody body = response.raw().body();
-                if (body != null) {
-                    body.close();
-                }
+                close(response);
             }
         }
 
@@ -163,10 +159,7 @@ final class AsyncSerializableErrorCallAdapterFactory extends CallAdapter.Factory
                 public void onResponse(Call<R> call, Response<R> response) {
                     boolean futureWasCancelled = !future.complete(response.body());
                     if (futureWasCancelled) {
-                        ResponseBody body = response.raw().body();
-                        if (body != null) {
-                            body.close();
-                        }
+                        close(response);
                     }
                 }
 
@@ -184,5 +177,12 @@ final class AsyncSerializableErrorCallAdapterFactory extends CallAdapter.Factory
 
             return future;
         }
+    }
+
+    private static void close(Response<?> response) {
+        if (response.raw().body() == null) {
+            return;
+        }
+        response.raw().body().close();
     }
 }

--- a/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/AsyncSerializableErrorCallAdapterFactoryTest.java
+++ b/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/AsyncSerializableErrorCallAdapterFactoryTest.java
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.retrofit2;
+
+import static org.mockito.Mockito.verify;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.conjure.java.client.retrofit2.AsyncSerializableErrorCallAdapterFactory.CompletableFutureBodyCallAdapter;
+import com.palantir.conjure.java.client.retrofit2.AsyncSerializableErrorCallAdapterFactory.ListenableFutureBodyCallAdapter;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AsyncSerializableErrorCallAdapterFactoryTest {
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS) private Response<String> response;
+    @Mock private Call<String> call;
+    @Captor private ArgumentCaptor<Callback<String>> callbackCaptor;
+
+    @Test
+    public void testResponseNotLeakedIfCancelled_completable() {
+        CompletableFutureBodyCallAdapter<String> adapter = new CompletableFutureBodyCallAdapter<>(String.class);
+        CompletableFuture<String> result = adapter.adapt(call);
+        verify(call).enqueue(callbackCaptor.capture());
+        Callback<String> callback = callbackCaptor.getValue();
+        result.cancel(true);
+        callback.onResponse(call, response);
+        verify(response.raw().body()).close();
+    }
+
+    @Test
+    public void testResponseNotLeakedIfCancelled_listenable() {
+        ListenableFutureBodyCallAdapter<String> adapter = new ListenableFutureBodyCallAdapter<>(String.class);
+        ListenableFuture<String> result = adapter.adapt(call);
+        verify(call).enqueue(callbackCaptor.capture());
+        Callback<String> callback = callbackCaptor.getValue();
+        result.cancel(true);
+        callback.onResponse(call, response);
+        verify(response.raw().body()).close();
+    }
+}

--- a/conjure-java-retrofit2-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/conjure-java-retrofit2-client/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This one's a bit of a doozy. When streaming responses with Retrofit, we
will complete the response with the result. If our call is cancelled, we
might leak it.