### PR TITLE
Allow external usage of trace interceptor

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkhttpTraceInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkhttpTraceInterceptor.java
@@ -31,7 +31,7 @@ public final class OkhttpTraceInterceptor implements Interceptor {
     /** The HTTP header used to communicate API endpoint names internally. Not considered public API. */
     public static final String PATH_TEMPLATE_HEADER = "hr-path-template";
 
-    static final Interceptor INSTANCE = new OkhttpTraceInterceptor();
+    public static final Interceptor INSTANCE = new OkhttpTraceInterceptor();
 
     private static final Interceptor addHeaders = OkhttpTraceInterceptor2.create(OkhttpTraceInterceptor::createSpan);
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
com.palantir.tracing.okhttp3.OkhttpTraceInterceptor was deprecated, and was public to use outside the package

## After this PR
==COMMIT_MSG==
Allow external usage of trace interceptor
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

