### PR TITLE
Fix: Prevent NPEs for clients created from newBuilder()

### DIFF
--- a/changelog/@unreleased/pr-1254.v2.yml
+++ b/changelog/@unreleased/pr-1254.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: |
+    Prevent NPEs for clients created from newBuilder()
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1254

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkhttpTraceInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkhttpTraceInterceptor.java
@@ -46,7 +46,7 @@ public final class OkhttpTraceInterceptor implements Interceptor {
         } finally {
             // when we reach this point, we've got a 'Response' object (so the headers have come back), but the server
             // hasn't necessarily filled in the request body.
-            DetachedSpan waitForBody = chain.request().tag(Tags.AttemptSpan.class)
+            DetachedSpan waitForBody = attemptSpanTag
                     .attemptSpan()
                     .childDetachedSpan("OkHttp: wait-for-body", SpanType.CLIENT_OUTGOING);
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkhttpTraceInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkhttpTraceInterceptor.java
@@ -37,6 +37,10 @@ public final class OkhttpTraceInterceptor implements Interceptor {
 
     @Override
     public Response intercept(Chain chain) throws IOException {
+        Tags.AttemptSpan attemptSpanTag = chain.request().tag(Tags.AttemptSpan.class);
+        if (attemptSpanTag == null) {
+            return chain.proceed(chain.request());
+        }
         try {
             return addHeaders.intercept(chain);
         } finally {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/SpanTerminatingInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/SpanTerminatingInterceptor.java
@@ -33,11 +33,7 @@ final class SpanTerminatingInterceptor implements Interceptor {
     public Response intercept(Chain chain) throws IOException {
         Tags.AttemptSpan attemptSpanTag = chain.request().tag(Tags.AttemptSpan.class);
         if (attemptSpanTag == null) {
-            try {
-                return chain.proceed(chain.request());
-            } catch (NullPointerException e) {
-                throw e;
-            }
+            return chain.proceed(chain.request());
         }
         DetachedSpan attemptSpan = attemptSpanTag.attemptSpan();
         DetachedSpan dispatcherSpan = chain.request().tag(Tags.SettableDispatcherSpan.class).dispatcherSpan();

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/SpanTerminatingInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/SpanTerminatingInterceptor.java
@@ -31,7 +31,15 @@ final class SpanTerminatingInterceptor implements Interceptor {
 
     @Override
     public Response intercept(Chain chain) throws IOException {
-        DetachedSpan attemptSpan = chain.request().tag(Tags.AttemptSpan.class).attemptSpan();
+        Tags.AttemptSpan attemptSpanTag = chain.request().tag(Tags.AttemptSpan.class);
+        if (attemptSpanTag == null) {
+            try {
+                return chain.proceed(chain.request());
+            } catch (NullPointerException e) {
+                throw e;
+            }
+        }
+        DetachedSpan attemptSpan = attemptSpanTag.attemptSpan();
         DetachedSpan dispatcherSpan = chain.request().tag(Tags.SettableDispatcherSpan.class).dispatcherSpan();
 
         if (attemptSpan == null || dispatcherSpan == null) {

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -919,6 +919,18 @@ public final class OkHttpClientsTest extends TestBase {
                 .hasStackTraceContaining("Caught a non-IOException. This is a serious bug and requires investigation");
     }
 
+    @Test
+    public void clientMadeFromNewBuilderShouldntThrowOnExecute() throws IOException {
+        ClientConfiguration clientConfiguration = createTestConfig(url);
+        OkHttpClient client = OkHttpClients.create(clientConfiguration, AGENT, hostEventsSink, OkHttpClientsTest.class);
+        client = client.newBuilder().build();
+        try {
+            client.newCall(new Request.Builder().url(url).build()).execute();
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
     private OkHttpClient createRetryingClient(int maxNumRetries) {
         return createRetryingClient(maxNumRetries, Duration.ofMillis(500));
     }

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -921,6 +921,7 @@ public final class OkHttpClientsTest extends TestBase {
 
     @Test
     public void clientMadeFromNewBuilderShouldntThrowOnExecute() throws IOException {
+        server.enqueue(new MockResponse().setBody("foo"));
         ClientConfiguration clientConfiguration = createTestConfig(url);
         OkHttpClient client = OkHttpClients.create(clientConfiguration, AGENT, hostEventsSink, OkHttpClientsTest.class);
         client = client.newBuilder().build();

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -925,11 +925,7 @@ public final class OkHttpClientsTest extends TestBase {
         ClientConfiguration clientConfiguration = createTestConfig(url);
         OkHttpClient client = OkHttpClients.create(clientConfiguration, AGENT, hostEventsSink, OkHttpClientsTest.class);
         client = client.newBuilder().build();
-        try {
-            client.newCall(new Request.Builder().url(url).build()).execute();
-        } catch (IOException e) {
-            throw e;
-        }
+        client.newCall(new Request.Builder().url(url).build()).execute();
     }
 
     private OkHttpClient createRetryingClient(int maxNumRetries) {


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/conjure-java-runtime/pull/1205 introduced an NPE for clients that were created via `newBuilder()`:

```java
OkHttpClient client = OkHttpClients.create(...
client = client.newBuilder().build();
client.newCall(new Request.Builder().url(url).build()).execute(); // NPE
```

In practice, this occurs [here](https://github.com/OpenFeign/feign/blob/882eb96f06712dc19f2daa47381029b5dc533d7f/okhttp/src/main/java/feign/okhttp/OkHttpClient.java#L151) in feign's `execute()`.

#### Detailed explanation of how an NPE is triggered in practice

1.  A `RemoteOkHttpClient` is created via `OkHttpClients.create()`. The `SpanTerminatingInterceptor` is added [here](https://github.com/palantir/conjure-java-runtime/blob/d6abe8aecfc6ecfefec0cf6843a6f392ef453583/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java#L160) to the client on creation.
1. An HTTP request is initiated by a user. This kicks off feign's [`executeAndDecode()`](https://github.com/OpenFeign/feign/blob/882eb96f06712dc19f2daa47381029b5dc533d7f/core/src/main/java/feign/SynchronousMethodHandler.java#L88), which [calls](https://github.com/OpenFeign/feign/blob/882eb96f06712dc19f2daa47381029b5dc533d7f/core/src/main/java/feign/SynchronousMethodHandler.java#L89) [`targetRequest`](https://github.com/OpenFeign/feign/blob/882eb96f06712dc19f2daa47381029b5dc533d7f/core/src/main/java/feign/SynchronousMethodHandler.java#L161) to add the interceptors (including the `SpanTerminatingInterceptor`) from the client onto the request, and then [calls](https://github.com/OpenFeign/feign/blob/882eb96f06712dc19f2daa47381029b5dc533d7f/core/src/main/java/feign/SynchronousMethodHandler.java#L98) [`execute`](https://github.com/OpenFeign/feign/blob/882eb96f06712dc19f2daa47381029b5dc533d7f/okhttp/src/main/java/feign/okhttp/OkHttpClient.java#L146)
1. Inside `execute()`, if the `connectTimeoutMillis` or `readTimeoutMillis` options are different for the request than they are in the client, then the client (currently a `RemoteOkHttpClient`) is replaced [here](https://github.com/OpenFeign/feign/blob/882eb96f06712dc19f2daa47381029b5dc533d7f/okhttp/src/main/java/feign/okhttp/OkHttpClient.java#L151) with a new client - whatever is returned by `RemoteOkHttpClient.newBuilder()`.
    - `RemoteOkHttpClient.newBuilder()` returns a new builder for its superclass (`ForwardingOkHttpClient`) [here](https://github.com/palantir/conjure-java-runtime/blob/d6abe8aecfc6ecfefec0cf6843a6f392ef453583/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java#L86). Meaning, **the client is no longer a `RemoteOkHttpClient`**.
1. The request is then converted to an OkHttpRequest [here](https://github.com/OpenFeign/feign/blob/882eb96f06712dc19f2daa47381029b5dc533d7f/okhttp/src/main/java/feign/okhttp/OkHttpClient.java#L159) using [`toOkHttpRequest()`](https://github.com/OpenFeign/feign/blob/d1199f64aec365a24551b00ec1780e56af04870d/okhttp/src/main/java/feign/okhttp/OkHttpClient.java#L48). It's important to note that this method does not add any tags to the request (i.e. the request's `tags` member is an empty map).
1. The actual network call is made with `client.newCall` [here](https://github.com/OpenFeign/feign/blob/882eb96f06712dc19f2daa47381029b5dc533d7f/okhttp/src/main/java/feign/okhttp/OkHttpClient.java#L160) - remember that the `client` is no longer a `RemoteOkHttpClient`. This is important because `RemoteOkHttpClient`'s `newCall` has [special code](https://github.com/palantir/conjure-java-runtime/blob/d6abe8aecfc6ecfefec0cf6843a6f392ef453583/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpClient.java#L118) that adds a `Tags.AttemptSpan.class` tag to the request before it is sent. But this special code isn't running, so there are still no tags on the request (the request's `tags` member is still an empty map).
1. The call is intercepted by the `SpanTerminatingInterceptor` since this interceptor was added to the request in step 1. The interceptor assumes that the `SettableDispatcherSpan` tag exists on the request (which it doesn't). [This line](https://github.com/palantir/conjure-java-runtime/blob/d6abe8aecfc6ecfefec0cf6843a6f392ef453583/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/SpanTerminatingInterceptor.java#L34) (pasted right here below) causes an NPE:
```java
// request().tag(Tags.AttemptSpan.class) == null b/c the request doesn't contain tags
DetachedSpan attemptSpan = chain.request().tag(Tags.AttemptSpan.class).attemptSpan();
```

## After this PR

A very similar bug was fixed by https://github.com/palantir/conjure-java-runtime/pull/908/, so I just mimicked the solution from there. I also added a test with the above example to make sure that clients created from `newBuilder()` don't throw on `execute()`.

==COMMIT_MSG==
Prevent NPEs for clients created from newBuilder()
==COMMIT_MSG==

<!-- ## Possible downsides? -->
<!-- Please describe any way users could be negatively affected by this PR. -->

