### PR TITLE
okhttp clients sets SO_KEEPALIVE

### DIFF
--- a/changelog/@unreleased/pr-1256.v2.yml
+++ b/changelog/@unreleased/pr-1256.v2.yml
@@ -1,6 +1,7 @@
 type: improvement
 improvement:
   description: All outgoing connections created by our OkhttpClients will now have
-    SO_KEEPALIVE enabled. This should make clients more responsive to a server hang-up.
+    SO_KEEPALIVE enabled. This should make clients more responsive to a router getting
+    terminated.
   links:
   - https://github.com/palantir/conjure-java-runtime/pull/1256

--- a/changelog/@unreleased/pr-1256.v2.yml
+++ b/changelog/@unreleased/pr-1256.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: All outgoing connections created by our OkhttpClients will now have
+    SO_KEEPALIVE enabled. This should make clients more responsive to a server hang-up.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1256

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -65,7 +65,8 @@ public final class ClientConfigurations {
      */
     public static ClientConfiguration of(ServiceConfiguration config) {
         return ClientConfiguration.builder()
-                .sslSocketFactory(SslSocketFactories.createSslSocketFactory(config.security()))
+                .sslSocketFactory(
+                        new KeepAliveSslSocketFactory(SslSocketFactories.createSslSocketFactory(config.security())))
                 .trustManager(SslSocketFactories.createX509TrustManager(config.security()))
                 .uris(config.uris())
                 .connectTimeout(config.connectTimeout().orElse(DEFAULT_CONNECT_TIMEOUT))

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ForwardingSslSocketFactory.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ForwardingSslSocketFactory.java
@@ -1,0 +1,80 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketException;
+import javax.net.ssl.SSLSocketFactory;
+
+abstract class ForwardingSslSocketFactory extends SSLSocketFactory {
+
+    abstract SSLSocketFactory getDelegate();
+
+    abstract Socket wrap(Socket socket) throws SocketException;
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return getDelegate().getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return getDelegate().getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException {
+        return wrap(getDelegate().createSocket(socket, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(Socket socket, InputStream consumed, boolean autoClose) throws IOException {
+        return wrap(getDelegate().createSocket(socket, consumed, autoClose));
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return wrap(getDelegate().createSocket());
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return wrap(getDelegate().createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return wrap(getDelegate().createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return wrap(getDelegate().createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(
+            InetAddress address,
+            int port,
+            InetAddress localAddress,
+            int localPort) throws IOException {
+        return wrap(getDelegate().createSocket(address, port, localAddress, localPort));
+    }
+}

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/KeepAliveSslSocketFactory.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/KeepAliveSslSocketFactory.java
@@ -22,7 +22,11 @@ import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Enables {@link java.net.StandardSocketOptions#SO_KEEPALIVE}. By default this will only send a packet after two
- * hours (which is long after our timeouts), but this can be lowered to a useful timeout at the OS level.
+ * hours (which is long after our timeouts), but this can be lowered to be useful in the kernel, e.g.:
+ *
+ * net.ipv4.tcp_keepalive_time = 20
+ * net.ipv4.tcp_keepalive_intvl = 5
+ * net.ipv4.tcp_keepalive_probes = 3
  */
 final class KeepAliveSslSocketFactory extends ForwardingSslSocketFactory {
     private final SSLSocketFactory delegate;

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/KeepAliveSslSocketFactory.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/KeepAliveSslSocketFactory.java
@@ -1,0 +1,48 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.config;
+
+import java.net.Socket;
+import java.net.SocketException;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * Enables {@link java.net.StandardSocketOptions#SO_KEEPALIVE}. By default this will only send a packet after two
+ * hours (which is long after our timeouts), but this can be lowered to a useful timeout at the OS level.
+ */
+final class KeepAliveSslSocketFactory extends ForwardingSslSocketFactory {
+    private final SSLSocketFactory delegate;
+
+    KeepAliveSslSocketFactory(SSLSocketFactory delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    SSLSocketFactory getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    Socket wrap(Socket socket) throws SocketException {
+        socket.setKeepAlive(true);
+        return socket;
+    }
+
+    public String toString() {
+        return "ConfigurableSslSocketFactory{delegate=" + delegate + '}';
+    }
+}

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/KeepAliveSslSocketFactory.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/KeepAliveSslSocketFactory.java
@@ -47,6 +47,6 @@ final class KeepAliveSslSocketFactory extends ForwardingSslSocketFactory {
     }
 
     public String toString() {
-        return "ConfigurableSslSocketFactory{delegate=" + delegate + '}';
+        return "KeepAliveSslSocketFactory{delegate=" + delegate + '}';
     }
 }


### PR DESCRIPTION
## Before this PR

As per the internal thread "SO_KEEPALIVE on Java sockets", c-j-r's default read timeout of 5 minutes means that after a network change, a client can sit there waiting for bytes that will never arrive for 5 minutes before retrying.

## After this PR
==COMMIT_MSG==
All outgoing connections created by our OkhttpClients will now have SO_KEEPALIVE enabled. This should make clients more responsive to a router getting terminated.
==COMMIT_MSG==

See `4.2.3.6  TCP Keep-Alives` in https://www.ietf.org/rfc/rfc1122.txt

- [x] before merging, add tests.

## Possible downsides?

- this stuff all delegates to the OS, so if the OS does crazy things we're boned.
- if some of our upstream servers don't respond correctly to these packets, _successful connections will stop working_




<!-- Please describe any way users could be negatively affected by this PR. -->

