### PR TITLE
Separate QoS responses in host metrics

### DIFF
--- a/changelog/@unreleased/pr-1262.v2.yml
+++ b/changelog/@unreleased/pr-1262.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Host metrics now measures QoS responses separately from other responses.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1262

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetrics.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetrics.java
@@ -46,19 +46,43 @@ public interface HostMetrics {
      */
     Instant lastUpdate();
 
+    /**
+     * A timer of 1xx responses.
+     */
     Timer get1xx();
 
+    /**
+     * A timer of 2xx responses.
+     */
     Timer get2xx();
 
+    /**
+     * A timer of 3xx responses.
+     */
     Timer get3xx();
 
+    /**
+     * A timer of 4xx responses, excluding 429s.
+     */
     Timer get4xx();
 
+    /**
+     * A timer of 5xx responses, excluding 503s.
+     */
     Timer get5xx();
 
+    /**
+     * A timer of 429 and 503 responses.
+     */
     Timer getQos();
 
+    /**
+     * A timer of all other responses.
+     */
     Timer getOther();
 
+    /**
+     * A timer of all failed requests.
+     */
     Meter getIoExceptions();
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetrics.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetrics.java
@@ -56,6 +56,8 @@ public interface HostMetrics {
 
     Timer get5xx();
 
+    Timer getQos();
+
     Timer getOther();
 
     Meter getIoExceptions();

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/HostMetricsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/HostMetricsTest.java
@@ -21,10 +21,8 @@ import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
-import com.google.common.collect.ImmutableMap;
 import java.time.Clock;
 import java.time.Instant;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,26 +48,53 @@ public final class HostMetricsTest {
     }
 
     @Test
-    public void testUpdateMetricUpdatesMeter() {
-        Map<Integer, Timer> testCases = ImmutableMap.<Integer, Timer>builder()
-                .put(100, hostMetrics.get1xx())
-                .put(200, hostMetrics.get2xx())
-                .put(300, hostMetrics.get3xx())
-                .put(400, hostMetrics.get4xx())
-                .put(500, hostMetrics.get5xx())
-                .put(600, hostMetrics.getOther())
-                .build();
+    public void testUpdateMetricUpdatesMeter_1xx() {
+        testUpdateMetricUpdatesMeter(100, hostMetrics.get1xx());
+    }
 
-        for (Map.Entry<Integer, Timer> testCase : testCases.entrySet()) {
-            Timer timer = testCase.getValue();
-            assertThat(timer.getCount()).isZero();
-            assertThat(timer.getSnapshot().getMin()).isEqualTo(0);
+    @Test
+    public void testUpdateMetricUpdatesMeter_2xx() {
+        testUpdateMetricUpdatesMeter(200, hostMetrics.get2xx());
+    }
 
-            hostMetrics.record(testCase.getKey(), 1);
+    @Test
+    public void testUpdateMetricUpdatesMeter_3xx() {
+        testUpdateMetricUpdatesMeter(300, hostMetrics.get3xx());
+    }
 
-            assertThat(timer.getCount()).isEqualTo(1);
-            assertThat(timer.getSnapshot().getMin()).isEqualTo(1_000);
-        }
+    @Test
+    public void testUpdateMetricUpdatesMeter_4xx() {
+        testUpdateMetricUpdatesMeter(400, hostMetrics.get4xx());
+    }
+
+    @Test
+    public void testUpdateMetricUpdatesMeter_5xx() {
+        testUpdateMetricUpdatesMeter(500, hostMetrics.get5xx());
+    }
+
+    @Test
+    public void testUpdateMetricUpdatesMeter_429() {
+        testUpdateMetricUpdatesMeter(429, hostMetrics.getQos());
+    }
+
+    @Test
+    public void testUpdateMetricUpdatesMeter_503() {
+        testUpdateMetricUpdatesMeter(503, hostMetrics.getQos());
+    }
+
+    @Test
+    public void testUpdateMetricUpdatesMeter_other() {
+        testUpdateMetricUpdatesMeter(600, hostMetrics.getOther());
+    }
+
+    private void testUpdateMetricUpdatesMeter(int statusCode, Timer timer) {
+        assertThat(timer.getCount()).isZero();
+        assertThat(timer.getSnapshot().getMin()).isEqualTo(0);
+
+        hostMetrics.record(statusCode, 1);
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getMin()).isEqualTo(1_000);
     }
 
     @Test

--- a/readme.md
+++ b/readme.md
@@ -373,5 +373,17 @@ a DNS error and the retried call succeeds against the URL from the list, then su
 The number of retries for `503` and connection errors can be configured via `ClientConfiguration#maxNumRetries` or
 `ServiceConfiguration#maxNumRetries`, defaulting to 4.
 
+#### Metrics
+
+The `HostMetricsRegistry` uses `HostMetrics` to track per-host response metrics. `HostMetrics` provides the following metrics:
+- `get1xx()`: A timer of 1xx responses.
+- `get2xx()`: A timer of 2xx responses.
+- `get3xx()`: A timer of 3xx responses.
+- `get4xx()`: A timer of 4xx responses, excluding 429s.
+- `get5xx()`: A timer of 5xx responses, excluding 503s.
+- `getQos()`: A timer of 429 and 503 responses.
+- `getOther()`: A timer of all other responses.
+- `getIoExceptions()`: A timer of all failed requests.
+
 # License
 This repository is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
## Before this PR
429 and 503 responses are included in the host metrics `get4xx` and `get5xx` timers, respectively. This can result in false positives in the `SERVICE_DEPENDENCY` health check.

## After this PR
429 and 503 are not included in the host metrics `get4xx` and `get5xx` timers. These responses are counted in a separate `getQos` timer.