### PR TITLE
Accept revapi break

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,8 @@
+versionOverrides: {}
+acceptedBreaks:
+  4.37.0:
+    com.palantir.conjure.java.runtime:okhttp-clients:
+    - code: "java.method.addedToInterface"
+      old: null
+      new: "method com.codahale.metrics.Timer com.palantir.conjure.java.okhttp.HostMetrics::getQos()"
+      justification: "ABI-safe change to rarely used class, low impact"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.palantir.gradle.revapi:gradle-revapi:0.4.1'
+        classpath 'com.palantir.gradle.revapi:gradle-revapi:1.0.4'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.netflix.nebula:gradle-dependency-lock-plugin:7.0.1'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:13.6.1'


### PR DESCRIPTION
@pkoenig10's PR added a method to an interface, which revapi now flags as a source break (not an ABI break).

https://github.com/palantir/conjure-java-runtime/pull/1262

I think this is fine, and want develop to be green again.

cc @CRogers 