### PR TITLE
ClientConfiguration equality works again

### DIFF
--- a/changelog/@unreleased/pr-1269.v2.yml
+++ b/changelog/@unreleased/pr-1269.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Multiple calls to ClientConfigurations.of() with the same arguments
+    will once again produce an equal ClientConfiguration object. This fixes a regression
+    introduce in 4.37.0
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1269

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/KeepAliveSslSocketFactory.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/KeepAliveSslSocketFactory.java
@@ -16,8 +16,10 @@
 
 package com.palantir.conjure.java.client.config;
 
+import com.palantir.logsafe.Preconditions;
 import java.net.Socket;
 import java.net.SocketException;
+import java.util.Objects;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
@@ -32,7 +34,7 @@ final class KeepAliveSslSocketFactory extends ForwardingSslSocketFactory {
     private final SSLSocketFactory delegate;
 
     KeepAliveSslSocketFactory(SSLSocketFactory delegate) {
-        this.delegate = delegate;
+        this.delegate = Preconditions.checkNotNull(delegate, "delegate must not be null");
     }
 
     @Override
@@ -48,5 +50,22 @@ final class KeepAliveSslSocketFactory extends ForwardingSslSocketFactory {
 
     public String toString() {
         return "KeepAliveSslSocketFactory{delegate=" + delegate + '}';
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        KeepAliveSslSocketFactory that = (KeepAliveSslSocketFactory) other;
+        return delegate.equals(that.delegate);
     }
 }

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -25,6 +25,7 @@ import com.google.common.net.HostAndPort;
 import com.palantir.conjure.java.api.config.service.ProxyConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.logsafe.testing.Assertions;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.io.IOException;
@@ -154,6 +155,19 @@ public final class ClientConfigurationsTest {
         try (Socket socket = config.sslSocketFactory().createSocket("google.com", 443)) {
             assertThat(socket.getKeepAlive()).describedAs("keepAlives enabled").isTrue();
         }
+    }
+
+    @Test
+    public void sensible_equality_and_hashcode() {
+        SslConfiguration sslConfiguration = SslConfiguration.of(Paths.get("src/test/resources/trustStore.jks"));
+        SSLSocketFactory socketFactory = SslSocketFactories.createSslSocketFactory(sslConfiguration);
+        X509TrustManager x509TrustManager = SslSocketFactories.createX509TrustManager(sslConfiguration);
+
+        ClientConfiguration instance1 = ClientConfigurations.of(uris, socketFactory, x509TrustManager);
+        ClientConfiguration instance2 = ClientConfigurations.of(uris, socketFactory, x509TrustManager);
+
+        assertThat(instance1).isEqualTo(instance2);
+        assertThat(instance1).hasSameHashCodeAs(instance2);
     }
 
     private ServiceConfiguration meshProxyServiceConfig(List<String> theUris, int maxNumRetries) {


### PR DESCRIPTION
## Before this PR

In https://github.com/palantir/conjure-java-runtime/pull/1256, I introduced a KeepAliveSocketFactory class which was intended to be entirely an implementation detail.

However, some internal consumers have been unable to pick up this change due to their mockito tests failing, because setting up a mock with `when(ClientConfigurations.of(a,b,c)).then` doesn't match later invocations because I broken equality of the ClientConfiguration class (by including the KeepAliveSocketFactory).

## After this PR
==COMMIT_MSG==
Multiple calls to ClientConfigurations.of() with the same arguments will once again produce an equal ClientConfiguration object. This fixes a regression introduce in 4.37.0
==COMMIT_MSG==

## Possible downsides?
-??

