### PR TITLE
Fix: Don't report outcome of canceled requests to HostEventSink

### DIFF
--- a/changelog/@unreleased/pr-1291.v2.yml
+++ b/changelog/@unreleased/pr-1291.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "HostEventsSink ignores IOExceptions when the call was canceled.\uFEFF\n"
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1291

--- a/changelog/@unreleased/pr-1291.v2.yml
+++ b/changelog/@unreleased/pr-1291.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: "HostEventsSink ignores IOExceptions when the call was canceled.\uFEFF\n"
+  description: "HostEventsSink ignores IOExceptions when the call was canceled."
   links:
   - https://github.com/palantir/conjure-java-runtime/pull/1291

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
@@ -55,7 +55,9 @@ final class InstrumentedInterceptor implements Interceptor {
         try {
             response = chain.proceed(chain.request());
         } catch (IOException e) {
-            hostEventsSink.recordIoException(serviceName, hostname, port);
+            if (!chain.call().isCanceled()) {
+                hostEventsSink.recordIoException(serviceName, hostname, port);
+            }
             throw e;
         }
 

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptorTest.java
@@ -18,7 +18,6 @@ package com.palantir.conjure.java.okhttp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.Timer;
@@ -98,10 +97,7 @@ public final class InstrumentedInterceptorTest {
 
     @Test
     public void testIoExceptionRecorded() throws IOException {
-        when(chain.request()).thenReturn(REQUEST_A);
-        when(chain.proceed(any())).thenThrow(IOException.class);
-        when(chain.call()).thenReturn(call);
-        when(call.isCanceled()).thenReturn(false);
+        failedRequest(REQUEST_A, false);
 
         assertThat(hostMetrics.getMetrics()).isEmpty();
 
@@ -114,10 +110,7 @@ public final class InstrumentedInterceptorTest {
 
     @Test
     public void testIoExceptionNotRecordedWhenCancelled() throws IOException {
-        when(chain.request()).thenReturn(REQUEST_A);
-        when(chain.proceed(any())).thenThrow(IOException.class);
-        when(chain.call()).thenReturn(call);
-        when(call.isCanceled()).thenReturn(true);
+        failedRequest(REQUEST_A, true);
 
         assertThat(hostMetrics.getMetrics()).isEmpty();
 
@@ -142,5 +135,12 @@ public final class InstrumentedInterceptorTest {
                 .build();
         when(chain.request()).thenReturn(request);
         when(chain.proceed(request)).thenReturn(response);
+    }
+
+    private void failedRequest(Request request, boolean isCanceled) throws IOException {
+        when(chain.request()).thenReturn(request);
+        when(chain.proceed(request)).thenThrow(IOException.class);
+        when(chain.call()).thenReturn(call);
+        when(call.isCanceled()).thenReturn(isCanceled);
     }
 }

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptorTest.java
@@ -109,7 +109,7 @@ public final class InstrumentedInterceptorTest {
     }
 
     @Test
-    public void testIoExceptionNotRecordedWhenCancelled() throws IOException {
+    public void testIoExceptionNotRecordedWhenCanceled() throws IOException {
         failedRequest(REQUEST_A, true);
 
         assertThat(hostMetrics.getMetrics()).isEmpty();

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -102,26 +102,14 @@ public final class OkHttpClientsTest extends TestBase {
     }
 
     @Test
-    public void cancelledCallsDoNotRetry() {
+    public void cancelledCallsDoNotRetryAndDoNotReportToHostEventSink() {
         server.enqueue(new MockResponse().setHeadersDelay(1, TimeUnit.SECONDS).setBody("pong"));
         OkHttpClient client = createRetryingClient(1);
         AsyncRequest future = AsyncRequest.of(client.newCall(new Request.Builder().url(url).build()));
         future.cancelCall();
+
         assertThatExceptionOfType(UncheckedExecutionException.class).isThrownBy(() -> Futures.getUnchecked(future))
                 .satisfies(e -> assertThat(e.getCause()).hasMessage("Canceled").isInstanceOf(IOException.class));
-    }
-
-    @Test
-    public void cancelledCallsDoNotReportToHostEventSink() {
-        assertThat(hostEventsSink.getMetrics()).isEmpty();
-
-        server.enqueue(new MockResponse().setHeadersDelay(1, TimeUnit.SECONDS).setBody("pong"));
-        OkHttpClient client = createRetryingClient(1);
-        AsyncRequest future = AsyncRequest.of(client.newCall(new Request.Builder().url(url).build()));
-        future.cancelCall();
-        assertThatExceptionOfType(UncheckedExecutionException.class).isThrownBy(() -> Futures.getUnchecked(future))
-                .satisfies(e -> assertThat(e.getCause()).hasMessage("Canceled").isInstanceOf(IOException.class));
-
         assertThat(hostEventsSink.getMetrics()).isEmpty();
     }
 

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -102,7 +102,7 @@ public final class OkHttpClientsTest extends TestBase {
     }
 
     @Test
-    public void cancelledCallsDoNotRetryAndDoNotReportToHostEventSink() {
+    public void canceledCallsDoNotRetryAndDoNotReportToHostEventSink() {
         server.enqueue(new MockResponse().setHeadersDelay(1, TimeUnit.SECONDS).setBody("pong"));
         OkHttpClient client = createRetryingClient(1);
         AsyncRequest future = AsyncRequest.of(client.newCall(new Request.Builder().url(url).build()));


### PR DESCRIPTION
## Before this PR
HostEventsMetrics receives failure events for requests that were interrupted by the caller. This is particularly bad for applications that regularly interrupt long-held requests, and rely on HostEventsMetrics for monitoring.

## After this PR
==COMMIT_MSG==
HostEventsSink ignores IOExceptions when the call was canceled.
==COMMIT_MSG==

For context, OkHttp throws `IOException("Canceled")` when an async request is interrupted.