### PR TITLE
Implement unknown remote exception

### DIFF
--- a/changelog/@unreleased/pr-1298.v2.yml
+++ b/changelog/@unreleased/pr-1298.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Throw UnknownRemoteException instead of SafeIoException for non-Conjure
+    error responses.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1298

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemoteExceptionResponseHandler.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemoteExceptionResponseHandler.java
@@ -55,6 +55,7 @@ enum RemoteExceptionResponseHandler implements ResponseHandler<RemoteException> 
             try {
                 body = toString(response.body().byteStream());
             } catch (IOException e) {
+                log.warn("Failed to read response body", e);
                 return Optional.empty();
             }
             try {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -24,6 +24,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.netflix.concurrency.limits.Limiter;
 import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.UnknownRemoteException;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
@@ -51,8 +52,6 @@ import okhttp3.internal.http.UnrepeatableRequestBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// TODO(rfink): Consider differentiating the IOExceptions thrown/returned by this class, add better error messages, #628
-
 /**
  * An OkHttp {@link Call} implementation that handles standard retryable error status such as 308, 429, 503, and
  * connection errors. Calls are rescheduled on a given scheduler and executed on a given executor.
@@ -63,7 +62,8 @@ final class RemotingOkHttpCall extends ForwardingCall {
 
     private static final ResponseHandler<RemoteException> remoteExceptionHandler =
             RemoteExceptionResponseHandler.INSTANCE;
-    private static final ResponseHandler<IOException> ioExceptionHandler = IoExceptionResponseHandler.INSTANCE;
+    private static final ResponseHandler<UnknownRemoteException> unknownRemoteExceptionHandler =
+            UnknownRemoteExceptionResponseHandler.INSTANCE;
     private static final ResponseHandler<QosException> qosHandler = QosExceptionResponseHandler.INSTANCE;
 
     private final BackoffStrategy backoffStrategy;
@@ -141,6 +141,14 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 RemoteException correctStackTrace = new RemoteException(
                         wrappedException.getError(),
                         wrappedException.getStatus());
+                correctStackTrace.initCause(e);
+                throw correctStackTrace;
+            } else if (e.getCause() instanceof IoUnknownRemoteException) {
+                UnknownRemoteException wrappedException = ((IoUnknownRemoteException) e.getCause())
+                        .getUnknownRemoteException();
+                UnknownRemoteException correctStackTrace = new UnknownRemoteException(
+                        wrappedException.getStatus(),
+                        wrappedException.getBody());
                 correctStackTrace.initCause(e);
                 throw correctStackTrace;
             } else if (e.getCause() instanceof IOException) {
@@ -290,9 +298,10 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 }
 
                 // Catch-all: handle all other responses
-                Optional<IOException> ioException = ioExceptionHandler.handle(errorResponseSupplier.get());
-                if (ioException.isPresent()) {
-                    callback.onFailure(call, ioException.get());
+                Optional<UnknownRemoteException> unknownHttpError = unknownRemoteExceptionHandler.handle(
+                        errorResponseSupplier.get());
+                if (unknownHttpError.isPresent()) {
+                    callback.onFailure(call, new IoUnknownRemoteException(unknownHttpError.get()));
                     return;
                 }
 
@@ -524,5 +533,18 @@ final class RemotingOkHttpCall extends ForwardingCall {
         Tags.AttemptSpan previousAttempt = request().tag(Tags.AttemptSpan.class);
         DetachedSpan entireSpan = request().tag(Tags.EntireSpan.class).get();
         return previousAttempt.nextAttempt(entireSpan);
+    }
+
+    private static final class IoUnknownRemoteException extends IOException {
+
+        private final UnknownRemoteException unknownRemoteException;
+
+        private IoUnknownRemoteException(UnknownRemoteException unknownRemoteException) {
+            this.unknownRemoteException = unknownRemoteException;
+        }
+
+        private UnknownRemoteException getUnknownRemoteException() {
+            return unknownRemoteException;
+        }
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UnknownRemoteExceptionResponseHandler.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/UnknownRemoteExceptionResponseHandler.java
@@ -17,40 +17,37 @@
 package com.palantir.conjure.java.okhttp;
 
 import com.google.common.io.CharStreams;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.UnsafeArg;
-import com.palantir.logsafe.exceptions.SafeIoException;
+import com.palantir.conjure.java.api.errors.UnknownRemoteException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import javax.ws.rs.core.HttpHeaders;
 import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-enum IoExceptionResponseHandler implements ResponseHandler<IOException> {
+enum UnknownRemoteExceptionResponseHandler implements ResponseHandler<UnknownRemoteException> {
     INSTANCE;
 
+    private static final Logger log = LoggerFactory.getLogger(UnknownRemoteExceptionResponseHandler.class);
+
     @Override
-    public Optional<IOException> handle(Response response) {
+    public Optional<UnknownRemoteException> handle(Response response) {
         if (response.isSuccessful() || response.code() == MoreHttpCodes.SWITCHING_PROTOCOLS) {
             return Optional.empty();
         }
 
+        String body;
         try {
-            String body = response.body() != null && response.body().byteStream() != null
-                    ? toString(response.body().byteStream())
-                    : "<empty>";
-
-            return Optional.of(new SafeIoException(
-                    "Failed to parse response body as SerializableError",
-                    SafeArg.of("code", response.code()),
-                    UnsafeArg.of("body", body),
-                    SafeArg.of("contentType", response.header(HttpHeaders.CONTENT_TYPE))));
+            body = response.body() != null ? toString(response.body().byteStream()) : "<empty>";
         } catch (IOException e) {
-            return Optional.of(new SafeIoException("Failed to read response body", e));
+            log.warn("Failed to read response body", e);
+            body = "Failed to read response body";
         }
+
+        return Optional.of(new UnknownRemoteException(response.code(), body));
     }
 
     private static String toString(InputStream body) throws IOException {


### PR DESCRIPTION
## Before this PR
Non-Conjure servers (or proxies in front of Conjure servers) will usually return a response error body that cannot be parsed as a Conjure exception. In such cases, CJR currently throws a SafeIoException where the only way to retrieve the status code is to parse the exception message itself.

## After this PR
A structured exception is raised allowing the client to interrogate, log, monitor, etc. the status codes from the server.

## Possible downsides?
* Will break logic written to parse exception messages.
* ~Until https://github.com/palantir/conjure-java-runtime-api/pull/374 merges, there is a regression in the safe-logged arguments~
