### PR TITLE
Add failure meter with IOException tag

### DIFF
--- a/changelog/@unreleased/pr-1305.v2.yml
+++ b/changelog/@unreleased/pr-1305.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
-  description: Adds a meter, `client.response.failure` with tag `reason:IOException`
+  description: Adds a meter, `client.response.error` with tag `reason:IOException`
     when a request fails due to an IOException
   links:
   - https://github.com/palantir/conjure-java-runtime/pull/1305

--- a/changelog/@unreleased/pr-1305.v2.yml
+++ b/changelog/@unreleased/pr-1305.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Adds a meter, `client.response.failure` with tag `reason:IOException`
+    when a request fails due to an IOException
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1305

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
@@ -45,7 +45,7 @@ final class InstrumentedInterceptor implements Interceptor {
         this.serviceName = serviceName;
         this.responseTimer = registry.timer(name());
         this.ioExceptionMeter = registry.meter(MetricName.builder()
-                .safeName("client.response.failure")
+                .safeName("client.response.error")
                 .putSafeTags("reason", "IOException")
                 .putSafeTags(SERVICE_NAME_TAG, serviceName)
                 .build());

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
@@ -40,12 +40,12 @@ final class InstrumentedInterceptor implements Interceptor {
     private final Timer responseTimer;
     private final Meter ioExceptionMeter;
 
-
     InstrumentedInterceptor(TaggedMetricRegistry registry, HostEventsSink hostEventsSink, String serviceName) {
         this.hostEventsSink = hostEventsSink;
         this.serviceName = serviceName;
         this.responseTimer = registry.timer(name());
-        this.ioExceptionMeter = registry.meter(MetricName.builder().safeName("client.response.failure")
+        this.ioExceptionMeter = registry.meter(MetricName.builder()
+                .safeName("client.response.failure")
                 .putSafeTags("reason", "IOException")
                 .putSafeTags(SERVICE_NAME_TAG, serviceName)
                 .build());


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Currently, if an outage happens or a service is throwing a lot of 500 responses, it can be due to timeouts when hitting a service. This metric will make it easier to identify which service is causing the timeouts. 

If service A sends requests to service B, this will let:

- service A have a dashboard showing that requests to B are timing out
- service B have a dashboard listing services which are timing out on it

## After this PR
==COMMIT_MSG==
Adds a meter, `client.response.error` with tag `reason:IOException` when a request fails due to an IOException
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

more metrics = more money