### PR TITLE
Improvement: Support decoding response values into Optional<ResponseBody> in retrofit clients

### DIFF
--- a/changelog/@unreleased/pr-1321.v2.yml
+++ b/changelog/@unreleased/pr-1321.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Decode `Optional<ResponseBody>` return value types as optionals of
+    binary stream instead of mistakenly treating them as json responses
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1321

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/OptionalResponseBodyConverterFactory.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/OptionalResponseBodyConverterFactory.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.retrofit2;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+public final class OptionalResponseBodyConverterFactory extends Converter.Factory {
+    public static final OptionalResponseBodyConverterFactory INSTANCE = new OptionalResponseBodyConverterFactory();
+
+    private OptionalResponseBodyConverterFactory() {}
+
+    @Nullable
+    @Override
+    public Converter<ResponseBody, ?> responseBodyConverter(
+            Type type,
+            Annotation[] _annotations,
+            Retrofit _retrofit) {
+        if (type instanceof ParameterizedType) {
+            Type innerType = getParameterUpperBound(0, (ParameterizedType) type);
+            Class<?> rwaInnerClass = getRawType(innerType);
+            if (ResponseBody.class.isAssignableFrom(rwaInnerClass)) {
+                return OptionalResponseBodyConverter.INSTANCE;
+            }
+        }
+        return null;
+    }
+
+    private enum OptionalResponseBodyConverter implements Converter<ResponseBody, Optional<ResponseBody>> {
+        INSTANCE;
+
+        @Override
+        public Optional<ResponseBody> convert(ResponseBody value) {
+            return Optional.ofNullable(value);
+        }
+    }
+
+}

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/OptionalResponseBodyConverterFactory.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/OptionalResponseBodyConverterFactory.java
@@ -51,7 +51,7 @@ public final class OptionalResponseBodyConverterFactory extends Converter.Factor
 
         @Override
         public Optional<ResponseBody> convert(ResponseBody value) {
-            return Optional.ofNullable(value);
+            return Optional.of(value);
         }
     }
 

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/OptionalResponseBodyConverterFactory.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/OptionalResponseBodyConverterFactory.java
@@ -38,8 +38,8 @@ public final class OptionalResponseBodyConverterFactory extends Converter.Factor
             Retrofit _retrofit) {
         if (type instanceof ParameterizedType) {
             Type innerType = getParameterUpperBound(0, (ParameterizedType) type);
-            Class<?> rwaInnerClass = getRawType(innerType);
-            if (ResponseBody.class.isAssignableFrom(rwaInnerClass)) {
+            Class<?> rawInnerClass = getRawType(innerType);
+            if (ResponseBody.class.isAssignableFrom(rawInnerClass)) {
                 return OptionalResponseBodyConverter.INSTANCE;
             }
         }

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
@@ -55,6 +55,7 @@ public final class Retrofit2ClientBuilder {
         Retrofit retrofit = new Retrofit.Builder()
                 .client(client)
                 .baseUrl(addTrailingSlash(config.uris().get(0)))
+                .addConverterFactory(OptionalResponseBodyConverterFactory.INSTANCE)
                 .addConverterFactory(
                         new CborConverterFactory(
                                 new NeverReturnNullConverterFactory(

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
@@ -55,6 +55,7 @@ public final class Retrofit2ClientBuilder {
         Retrofit retrofit = new Retrofit.Builder()
                 .client(client)
                 .baseUrl(addTrailingSlash(config.uris().get(0)))
+                // These get evaluated first, but only for successful responses that are not 204 or 205
                 .addConverterFactory(OptionalResponseBodyConverterFactory.INSTANCE)
                 .addConverterFactory(
                         new CborConverterFactory(
@@ -63,6 +64,7 @@ public final class Retrofit2ClientBuilder {
                                                 JacksonConverterFactory.create(OBJECT_MAPPER))),
                                 CBOR_OBJECT_MAPPER))
                 .addConverterFactory(OptionalObjectToStringConverterFactory.INSTANCE)
+                // These get evaluated last, to convert the original Call into the response type expected by the client
                 .addCallAdapterFactory(
                         new QosExceptionThrowingCallAdapterFactory(
                                 new CoerceNullValuesCallAdapterFactory(

--- a/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/Retrofit2OptionalBinaryHandlingTest.java
+++ b/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/Retrofit2OptionalBinaryHandlingTest.java
@@ -1,0 +1,128 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.retrofit2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.java.okhttp.NoOpHostEventsSink;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import okhttp3.HttpUrl;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okio.Buffer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.http.GET;
+
+@RunWith(Parameterized.class)
+public final class Retrofit2OptionalBinaryHandlingTest extends TestBase {
+    @Rule
+    public final MockWebServer server = new MockWebServer();
+
+    private HttpUrl url;
+    private Service proxy;
+
+    @Parameterized.Parameters(name = "{index}: code {0} body: \"{1}\"")
+    public static Collection<Object[]> responses() {
+        Buffer nullValueBuffer = new Buffer();
+        nullValueBuffer.write("null".getBytes(StandardCharsets.UTF_8));
+        Buffer emptyBuffer = new Buffer();
+        return Arrays.asList(new Object[][] {
+                {200, nullValueBuffer, false},
+                {200, emptyBuffer, false},
+                {204, emptyBuffer, true}
+        });
+    }
+
+    @Parameterized.Parameter
+    public int code;
+
+    @Parameterized.Parameter(1)
+    public Buffer body;
+
+    @Parameterized.Parameter(2)
+    public boolean empty;
+
+    @Before
+    public void before() {
+        url = server.url("/");
+        proxy = Retrofit2Client.create(
+                Service.class,
+                AGENT,
+                NoOpHostEventsSink.INSTANCE,
+                createTestConfig(url.toString()));
+        MockResponse mockResponse = new MockResponse().setResponseCode(code).setBody(body);
+        server.enqueue(mockResponse);
+    }
+
+    public interface Service {
+        @GET("/optional/binary")
+        Call<Optional<ResponseBody>> getOptional();
+
+        @GET("/optionalFuture/binary")
+        CompletableFuture<Optional<ResponseBody>> getOptionalFuture();
+    }
+
+    @Test
+    public void testOptional() throws IOException {
+        assertCallBody(proxy.getOptional(),
+                optional -> {
+                    if (empty) {
+                        assertThat(optional).isEmpty();
+                    } else {
+                        assertThat(optional).isPresent();
+                    }
+                });
+    }
+
+    @Test
+    public void testOptionalFuture() throws Exception {
+        assertFuture(proxy.getOptionalFuture(),
+                optional -> {
+                    if (empty) {
+                        assertThat(optional).isEmpty();
+                    } else {
+                        assertThat(optional).isPresent();
+                    }
+                });
+    }
+
+    private static <T> void assertCallBody(Call<T> call, Consumer<T> assertions) throws IOException {
+        Response<T> response = call.execute();
+        assertThat(response.isSuccessful()).isTrue();
+        assertions.accept(response.body());
+    }
+
+    private static <T> void assertFuture(CompletableFuture<T> future, Consumer<T> assertions) throws Exception {
+        T value = future.get(1, TimeUnit.SECONDS);
+        assertions.accept(value);
+    }
+
+}


### PR DESCRIPTION
## Before this PR
Endpoints returning `Optional<ResponseBody>` in retrofit interfaces would fail with jackson response error even though their encoding is application/octet-stream 

## After this PR
==COMMIT_MSG==
Decode `Optional<ResponseBody>` return value types as optionals of binary stream instead of mistakenly treating them as json responses
==COMMIT_MSG==

## Possible downsides?
How do we want to handle empty 200 responses? This is a little bit different to jackson but haven't checked what spec says about this.
