### PR TITLE
Test retrofit ListenableFuture tracing

### DIFF
--- a/changelog/@unreleased/pr-1361.v2.yml
+++ b/changelog/@unreleased/pr-1361.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix Retrofit ListenableFuture trace propagation (and maybe others?)
+    by wrapping OkHttpClient dispatcher executor service with Tracers.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1361

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/TracerTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/TracerTest.java
@@ -82,6 +82,7 @@ public final class TracerTest extends TestBase {
                 Maps.immutableEntry(SpanType.LOCAL, "OkHttp: attempt 0"),
                 Maps.immutableEntry(SpanType.LOCAL, "OkHttp: client-side-concurrency-limiter 0/10"),
                 Maps.immutableEntry(SpanType.LOCAL, "OkHttp: dispatcher"),
+                Maps.immutableEntry(SpanType.LOCAL, "OkHttp: callback"),
                 Maps.immutableEntry(SpanType.CLIENT_OUTGOING, "OkHttp: wait-for-headers"),
                 Maps.immutableEntry(SpanType.CLIENT_OUTGOING, "OkHttp: wait-for-body"));
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -81,7 +81,7 @@ public final class OkHttpClients {
      * </ol>
      */
     private static final ExecutorService executionExecutor =
-            Executors.newCachedThreadPool(executionThreads);
+            Tracers.wrap(Executors.newCachedThreadPool(executionThreads));
 
     /** Shared dispatcher with static executor service. */
     private static final Dispatcher dispatcher;

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -70,7 +70,7 @@ public final class OkHttpClients {
             .build();
     /**
      * The {@link ExecutorService} used for the {@link Dispatcher}s of all OkHttp clients created through this class.
-     * Similar to OkHttp's default, but with two modifications:
+     * Similar to OkHttp's default, but with three modifications:
      * <ol>
      *     <li>A logging uncaught exception handler</li>
      *     <li>
@@ -78,10 +78,13 @@ public final class OkHttpClients {
      *         thread blocks waiting for the result. Most of our usage falls into this category. This allows
      *         JVM shutdown to occur cleanly without waiting a full minute after the last request completes.
      *     </li>
+     *     <li>
+     *         Tracing information is propagated from the caller to the OkHtttp callback.
+     *     </li>
      * </ol>
      */
     private static final ExecutorService executionExecutor =
-            Tracers.wrap(Executors.newCachedThreadPool(executionThreads));
+            Tracers.wrap("OkHttp: callback", Executors.newCachedThreadPool(executionThreads));
 
     /** Shared dispatcher with static executor service. */
     private static final Dispatcher dispatcher;


### PR DESCRIPTION
TraceIDs don't seem to propagate from requests to ListenableFuture callbacks