### PR TITLE
Deprecate WebPreconditions

### DIFF
--- a/changelog/@unreleased/pr-1363.v2.yml
+++ b/changelog/@unreleased/pr-1363.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`WebPreconditions` is now marked as deprecated.'
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1363

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/WebPreconditions.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/WebPreconditions.java
@@ -25,7 +25,10 @@ import javax.ws.rs.BadRequestException;
  * Wrapper around some of Guava's {@link Preconditions} to make its exceptions more http-friendly exceptions. It
  * includes other useful web-oriented checks like {@link #checkNotEmpty(String, Object)} and excludes less relevant ones
  * (like {@link Preconditions#checkState(boolean)}.
+ *
+ * @deprecated Use {@link com.palantir.conjure.java.api.errors.ServiceException}.
  */
+@Deprecated
 public final class WebPreconditions {
 
     private WebPreconditions() {}


### PR DESCRIPTION
It may not be obvious to users that `WebPreconditions` throws JAX-RS exceptions. This PR deprecates `WebPreconditions` to clearly signal that users should migrate to service exceptions.
