### PR TITLE
Add param converters for authentication credentials

### DIFF
--- a/changelog/@unreleased/pr-1374.v2.yml
+++ b/changelog/@unreleased/pr-1374.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Missing or malformed credentials will result in a 401 UNAUTHORIZED
+    from Jersey servers. Previously we responded with a 400, which isn't as accurate
+    as we would like.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1374

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaOptionalAwareDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaOptionalAwareDecoderTest.java
@@ -82,8 +82,8 @@ public final class GuavaOptionalAwareDecoderTest extends TestBase {
     public void testThrowsNotAuthorized() {
         assertThatThrownBy(() -> service.getThrowsNotAuthorized(null))
                 .isInstanceOfSatisfying(RemoteException.class, e -> {
-                    assertThat(e.getMessage()).contains("RemoteException: javax.ws.rs.NotAuthorizedException");
-                    assertThat(e.getError().errorCode()).isEqualTo("javax.ws.rs.NotAuthorizedException");
+                    assertThat(e.getMessage()).contains("RemoteException: UNAUTHORIZED (Default:Unauthorized)");
+                    assertThat(e.getError().errorCode()).isEqualTo("UNAUTHORIZED");
                 });
     }
 
@@ -91,8 +91,8 @@ public final class GuavaOptionalAwareDecoderTest extends TestBase {
     public void testOptionalThrowsNotAuthorized() {
         assertThatThrownBy(() -> service.getOptionalThrowsNotAuthorized(null))
                 .isInstanceOfSatisfying(RemoteException.class, e -> {
-                    assertThat(e.getMessage()).contains("RemoteException: javax.ws.rs.NotAuthorizedException");
-                    assertThat(e.getError().errorCode()).isEqualTo("javax.ws.rs.NotAuthorizedException");
+                    assertThat(e.getMessage()).contains("RemoteException: UNAUTHORIZED (Default:Unauthorized)");
+                    assertThat(e.getError().errorCode()).isEqualTo("UNAUTHORIZED");
                 });
     }
 

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8OptionalAwareDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8OptionalAwareDecoderTest.java
@@ -82,8 +82,8 @@ public final class Java8OptionalAwareDecoderTest extends TestBase {
     public void testThrowsNotAuthorized() {
         assertThatThrownBy(() -> service.getThrowsNotAuthorized(null))
                 .isInstanceOfSatisfying(RemoteException.class, e -> {
-                    assertThat(e.getMessage()).contains("RemoteException: javax.ws.rs.NotAuthorizedException");
-                    assertThat(e.getError().errorCode()).isEqualTo("javax.ws.rs.NotAuthorizedException");
+                    assertThat(e.getMessage()).contains("RemoteException: UNAUTHORIZED (Default:Unauthorized)");
+                    assertThat(e.getError().errorCode()).isEqualTo("UNAUTHORIZED");
                 });
     }
 
@@ -91,8 +91,8 @@ public final class Java8OptionalAwareDecoderTest extends TestBase {
     public void testOptionalThrowsNotAuthorized() {
         assertThatThrownBy(() -> service.getOptionalThrowsNotAuthorized(null))
                 .isInstanceOfSatisfying(RemoteException.class, e -> {
-                    assertThat(e.getMessage()).contains("RemoteException: javax.ws.rs.NotAuthorizedException");
-                    assertThat(e.getError().errorCode()).isEqualTo("javax.ws.rs.NotAuthorizedException");
+                    assertThat(e.getMessage()).contains("RemoteException: UNAUTHORIZED (Default:Unauthorized)");
+                    assertThat(e.getError().errorCode()).isEqualTo("UNAUTHORIZED");
                 });
     }
 

--- a/conjure-java-jersey-server/build.gradle
+++ b/conjure-java-jersey-server/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation "com.fasterxml.jackson.module:jackson-module-afterburner"
     implementation "com.jcraft:jzlib"
     implementation "com.palantir.safe-logging:safe-logging"
+    implementation 'com.palantir.tokens:auth-tokens'
     implementation "com.palantir.tracing:tracing-jersey"
     implementation project(':conjure-java-jackson-serialization')
 

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
@@ -47,7 +47,7 @@ public final class AuthHeaderParamConverterProvider implements ParamConverterPro
         @Override
         public AuthHeader fromString(final String value) {
             if (value == null) {
-                throw UnauthorizedException.missingCredentials();
+                return null;
             }
             try {
                 return AuthHeader.valueOf(value);

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
@@ -13,16 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * Adapted from https://github.com/dropwizard/dropwizard/blob/master/dropwizard-jersey/src/main/java/io/dropwizard/jersey/optional/OptionalIntParamConverterProvider.java
- */
 
 package com.palantir.conjure.java.server.jersey;
 
 import com.palantir.logsafe.Preconditions;
+import com.palantir.tokens.auth.AuthHeader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.OptionalInt;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
@@ -30,8 +27,8 @@ import org.glassfish.jersey.internal.inject.Custom;
 
 @Custom
 @Provider
-public final class Java8OptionalIntParamConverterProvider implements ParamConverterProvider {
-    private final OptionalIntParamConverter paramConverter = new OptionalIntParamConverter();
+public final class AuthHeaderParamConverterProvider implements ParamConverterProvider {
+    private final AuthHeaderParamConverter paramConverter = new AuthHeaderParamConverter();
 
     @Override
     @SuppressWarnings("unchecked")
@@ -39,27 +36,26 @@ public final class Java8OptionalIntParamConverterProvider implements ParamConver
             final Class<T> rawType,
             final Type _genericType,
             final Annotation[] _annotations) {
-        return OptionalInt.class.equals(rawType) ? (ParamConverter<T>) paramConverter : null;
+        return AuthHeader.class.equals(rawType) ? (ParamConverter<T>) paramConverter : null;
     }
 
-    public static final class OptionalIntParamConverter implements ParamConverter<OptionalInt> {
+    public static final class AuthHeaderParamConverter implements ParamConverter<AuthHeader> {
         @Override
-        public OptionalInt fromString(final String value) {
+        public AuthHeader fromString(final String value) {
             if (value == null) {
-                return OptionalInt.empty();
+                throw UnauthorizedException.missingCredentials();
             }
-
             try {
-                return OptionalInt.of(Integer.parseInt(value));
-            } catch (NumberFormatException e) {
-                throw new IllegalStateException(e);
+                return AuthHeader.valueOf(value);
+            } catch (RuntimeException e) {
+                throw UnauthorizedException.malformedCredentials(e);
             }
         }
 
         @Override
-        public String toString(final OptionalInt value) {
+        public String toString(final AuthHeader value) {
             Preconditions.checkArgument(value != null);
-            return value.isPresent() ? Integer.toString(value.getAsInt()) : "";
+            return value.toString();
         }
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
@@ -27,6 +27,9 @@ import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.internal.inject.Custom;
 
+// The Custom annotation ensures that our custom param converters are considered first. See ParamConverterFactory.
+// This is particularly important for the AuthHeader param converter to ensure that we do not fallback to the
+// TypeValueOf param converter.
 @Custom
 @Provider
 public final class AuthHeaderParamConverterProvider implements ParamConverterProvider {
@@ -65,9 +68,9 @@ public final class AuthHeaderParamConverterProvider implements ParamConverterPro
 
     private static boolean hasAuthAnnotation(Annotation[] annotations) {
         for (Annotation annotation : annotations) {
-            if (annotation.annotationType() == HeaderParam.class) {
+            if (HeaderParam.class.equals(annotation.annotationType())) {
                 String value = ((HeaderParam) annotation).value();
-                if (value.equals(HttpHeaders.AUTHORIZATION)) {
+                if (HttpHeaders.AUTHORIZATION.equals(value)) {
                     return true;
                 }
             }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
@@ -26,6 +26,9 @@ import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.internal.inject.Custom;
 
+// The Custom annotation ensures that our custom param converters are considered first. See ParamConverterFactory.
+// This is particularly important for the BearerToken param converter to ensure that we do not fallback to the
+// TypeValueOf param converter.
 @Custom
 @Provider
 public final class BearerTokenParamConverterProvider implements ParamConverterProvider {
@@ -64,7 +67,7 @@ public final class BearerTokenParamConverterProvider implements ParamConverterPr
 
     private static boolean hasAuthAnnotation(Annotation[] annotations) {
         for (Annotation annotation : annotations) {
-            if (annotation.annotationType() == CookieParam.class) {
+            if (CookieParam.class.equals(annotation.annotationType())) {
                 return true;
             }
         }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
@@ -20,6 +20,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.tokens.auth.BearerToken;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import javax.ws.rs.CookieParam;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
@@ -35,8 +36,10 @@ public final class BearerTokenParamConverterProvider implements ParamConverterPr
     public <T> ParamConverter<T> getConverter(
             final Class<T> rawType,
             final Type _genericType,
-            final Annotation[] _annotations) {
-        return BearerToken.class.equals(rawType) ? (ParamConverter<T>) paramConverter : null;
+            final Annotation[] annotations) {
+        return BearerToken.class.equals(rawType) && hasAuthAnnotation(annotations)
+                ? (ParamConverter<T>) paramConverter
+                : null;
     }
 
     public static final class BearerTokenParamConverter implements ParamConverter<BearerToken> {
@@ -57,5 +60,15 @@ public final class BearerTokenParamConverterProvider implements ParamConverterPr
             Preconditions.checkArgument(value != null);
             return value.toString();
         }
+    }
+
+    private static boolean hasAuthAnnotation(Annotation[] annotations) {
+        for (Annotation annotation : annotations) {
+            if (annotation.annotationType() == CookieParam.class) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
@@ -46,7 +46,7 @@ public final class BearerTokenParamConverterProvider implements ParamConverterPr
         @Override
         public BearerToken fromString(final String value) {
             if (value == null) {
-                throw UnauthorizedException.missingCredentials();
+                return null;
             }
             try {
                 return BearerToken.valueOf(value);

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
@@ -53,6 +53,10 @@ public enum ConjureJerseyFeature implements Feature {
         // Cbor handling
         context.register(new JacksonCBORProvider(ObjectMappers.newCborServerObjectMapper()));
 
+        // Auth handling
+        context.register(AuthHeaderParamConverterProvider.class);
+        context.register(BearerTokenParamConverterProvider.class);
+
         // Optional handling
         context.register(GuavaOptionalMessageBodyWriter.class);
         context.register(GuavaOptionalParamConverterProvider.class);
@@ -65,7 +69,7 @@ public enum ConjureJerseyFeature implements Feature {
         context.register(Java8OptionalLongMessageBodyWriter.class);
         context.register(Java8OptionalLongParamConverterProvider.class);
 
-        // DateTime
+        // DateTime handling
         context.register(InstantParamConverterProvider.class);
         context.register(ZonedDateTimeParamConverterProvider.class);
         context.register(OffsetDateTimeParamConverterProvider.class);

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/GuavaOptionalParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/GuavaOptionalParamConverterProvider.java
@@ -23,11 +23,13 @@ import javax.inject.Inject;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
+import org.glassfish.jersey.internal.inject.Custom;
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.internal.inject.Providers;
 import org.glassfish.jersey.internal.util.ReflectionHelper;
 import org.glassfish.jersey.internal.util.collection.ClassTypePair;
 
+@Custom
 @Provider
 public final class GuavaOptionalParamConverterProvider implements ParamConverterProvider {
     private final InjectionManager injectionManager;

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/GuavaOptionalParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/GuavaOptionalParamConverterProvider.java
@@ -29,6 +29,7 @@ import org.glassfish.jersey.internal.inject.Providers;
 import org.glassfish.jersey.internal.util.ReflectionHelper;
 import org.glassfish.jersey.internal.util.collection.ClassTypePair;
 
+// The Custom annotation ensures that our custom param converters are considered first. See ParamConverterFactory.
 @Custom
 @Provider
 public final class GuavaOptionalParamConverterProvider implements ParamConverterProvider {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/InstantParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/InstantParamConverterProvider.java
@@ -25,6 +25,7 @@ import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.internal.inject.Custom;
 
+// The Custom annotation ensures that our custom param converters are considered first. See ParamConverterFactory.
 @Custom
 @Provider
 public final class InstantParamConverterProvider implements ParamConverterProvider {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/InstantParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/InstantParamConverterProvider.java
@@ -23,7 +23,9 @@ import java.time.Instant;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
+import org.glassfish.jersey.internal.inject.Custom;
 
+@Custom
 @Provider
 public final class InstantParamConverterProvider implements ParamConverterProvider {
     private final InstantParamConverter paramConverter = new InstantParamConverter();

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalDoubleParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalDoubleParamConverterProvider.java
@@ -26,7 +26,9 @@ import java.util.OptionalDouble;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
+import org.glassfish.jersey.internal.inject.Custom;
 
+@Custom
 @Provider
 public final class Java8OptionalDoubleParamConverterProvider implements ParamConverterProvider {
     private final OptionalDoubleParamConverter paramConverter = new OptionalDoubleParamConverter();

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalDoubleParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalDoubleParamConverterProvider.java
@@ -28,6 +28,7 @@ import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.internal.inject.Custom;
 
+// The Custom annotation ensures that our custom param converters are considered first. See ParamConverterFactory.
 @Custom
 @Provider
 public final class Java8OptionalDoubleParamConverterProvider implements ParamConverterProvider {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalIntParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalIntParamConverterProvider.java
@@ -28,6 +28,7 @@ import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.internal.inject.Custom;
 
+// The Custom annotation ensures that our custom param converters are considered first. See ParamConverterFactory.
 @Custom
 @Provider
 public final class Java8OptionalIntParamConverterProvider implements ParamConverterProvider {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalLongParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalLongParamConverterProvider.java
@@ -26,7 +26,9 @@ import java.util.OptionalLong;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
+import org.glassfish.jersey.internal.inject.Custom;
 
+@Custom
 @Provider
 public final class Java8OptionalLongParamConverterProvider implements ParamConverterProvider {
     private final OptionalLongParamConverter paramConverter = new OptionalLongParamConverter();

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalLongParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalLongParamConverterProvider.java
@@ -28,6 +28,7 @@ import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.internal.inject.Custom;
 
+// The Custom annotation ensures that our custom param converters are considered first. See ParamConverterFactory.
 @Custom
 @Provider
 public final class Java8OptionalLongParamConverterProvider implements ParamConverterProvider {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalParamConverterProvider.java
@@ -30,6 +30,7 @@ import org.glassfish.jersey.internal.inject.Providers;
 import org.glassfish.jersey.internal.util.ReflectionHelper;
 import org.glassfish.jersey.internal.util.collection.ClassTypePair;
 
+// The Custom annotation ensures that our custom param converters are considered first. See ParamConverterFactory.
 @Custom
 @Provider
 public final class Java8OptionalParamConverterProvider implements ParamConverterProvider {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/Java8OptionalParamConverterProvider.java
@@ -24,11 +24,13 @@ import javax.inject.Inject;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
+import org.glassfish.jersey.internal.inject.Custom;
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.internal.inject.Providers;
 import org.glassfish.jersey.internal.util.ReflectionHelper;
 import org.glassfish.jersey.internal.util.collection.ClassTypePair;
 
+@Custom
 @Provider
 public final class Java8OptionalParamConverterProvider implements ParamConverterProvider {
     private final InjectionManager injectionManager;

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/OffsetDateTimeParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/OffsetDateTimeParamConverterProvider.java
@@ -23,7 +23,9 @@ import java.time.OffsetDateTime;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
+import org.glassfish.jersey.internal.inject.Custom;
 
+@Custom
 @Provider
 public final class OffsetDateTimeParamConverterProvider implements ParamConverterProvider {
     private final OffsetDateTimeParamConverter paramConverter = new OffsetDateTimeParamConverter();

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/OffsetDateTimeParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/OffsetDateTimeParamConverterProvider.java
@@ -25,6 +25,7 @@ import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.internal.inject.Custom;
 
+// The Custom annotation ensures that our custom param converters are considered first. See ParamConverterFactory.
 @Custom
 @Provider
 public final class OffsetDateTimeParamConverterProvider implements ParamConverterProvider {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/UnauthorizedException.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/UnauthorizedException.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.server.jersey;
+
+import com.palantir.conjure.java.api.errors.ErrorType;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response.Status;
+
+final class UnauthorizedException extends WebApplicationException {
+
+    private static final ErrorType MISSING_CREDENTIALS_ERROR_TYPE = ErrorType.create(
+            ErrorType.Code.UNAUTHORIZED,
+            "Conjure:MissingCredentials");
+    private static final ErrorType MALFORMED_CREDENTIALS_ERROR_TYPE = ErrorType.create(
+            ErrorType.Code.UNAUTHORIZED,
+            "Conjure:MalformedCredentials");
+
+    private final ErrorType errorType;
+
+    static UnauthorizedException missingCredentials() {
+        return new UnauthorizedException(MISSING_CREDENTIALS_ERROR_TYPE);
+    }
+
+    static UnauthorizedException malformedCredentials(Throwable throwable) {
+        return new UnauthorizedException(MALFORMED_CREDENTIALS_ERROR_TYPE, throwable);
+    }
+
+    private UnauthorizedException(ErrorType errorType) {
+        super(Status.UNAUTHORIZED);
+        this.errorType = errorType;
+    }
+
+    private UnauthorizedException(ErrorType errorType, Throwable throwable) {
+        super(throwable, Status.UNAUTHORIZED);
+        this.errorType = errorType;
+    }
+
+    public ErrorType getErrorType() {
+        return errorType;
+    }
+}

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapper.java
@@ -22,6 +22,7 @@ import com.palantir.logsafe.SafeArg;
 import java.util.UUID;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -54,7 +55,15 @@ final class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicat
             log.error("Error handling request", SafeArg.of("errorInstanceId", errorInstanceId), exception);
         }
 
-        if (exception instanceof ForbiddenException) {
+        if (exception instanceof NotAuthorizedException) {
+            return JsonExceptionMapper.createResponse(
+                    ErrorType.UNAUTHORIZED,
+                    errorInstanceId);
+        } else if (exception instanceof UnauthorizedException) {
+            return JsonExceptionMapper.createResponse(
+                    ((UnauthorizedException) exception).getErrorType(),
+                    errorInstanceId);
+        } else if (exception instanceof ForbiddenException) {
             return JsonExceptionMapper.createResponse(
                     ErrorType.PERMISSION_DENIED,
                     errorInstanceId);

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ZonedDateTimeParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ZonedDateTimeParamConverterProvider.java
@@ -25,6 +25,7 @@ import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.internal.inject.Custom;
 
+// The Custom annotation ensures that our custom param converters are considered first. See ParamConverterFactory.
 @Custom
 @Provider
 public final class ZonedDateTimeParamConverterProvider implements ParamConverterProvider {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ZonedDateTimeParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ZonedDateTimeParamConverterProvider.java
@@ -23,7 +23,9 @@ import java.time.ZonedDateTime;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
+import org.glassfish.jersey.internal.inject.Custom;
 
+@Custom
 @Provider
 public final class ZonedDateTimeParamConverterProvider implements ParamConverterProvider {
     private final ZonedDateTimeParamConverter paramConverter = new ZonedDateTimeParamConverter();

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/AuthTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/AuthTest.java
@@ -1,0 +1,171 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.server.jersey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.BearerToken;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public final class AuthTest {
+
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> APP = new DropwizardAppRule<>(
+            AuthTestServer.class,
+            "src/test/resources/test-server.yml");
+
+    private WebTarget target;
+
+    @Before
+    public void before() {
+        String endpointUri = "http://localhost:" + APP.getLocalPort();
+        JerseyClientBuilder builder = new JerseyClientBuilder();
+        Client client = builder.build();
+        target = client.target(endpointUri);
+    }
+
+    @Test
+    public void testAuthHeader() throws SecurityException {
+        Response response = target.path("authHeader")
+                .request()
+                .header("value", "Bearer bearerToken")
+                .get();
+        assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(response.readEntity(String.class)).isEqualTo("Bearer bearerToken");
+    }
+
+    @Test
+    public void testAuthHeader_missingCredentials() throws SecurityException {
+        Response response = target.path("authHeader")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(Status.UNAUTHORIZED.getStatusCode());
+
+        SerializableError error = response.readEntity(SerializableError.class);
+        assertThat(error.errorCode()).isEqualTo(ErrorType.UNAUTHORIZED.code().toString());
+        assertThat(error.errorName()).isEqualTo("Conjure:MissingCredentials");
+        assertThat(error.parameters()).isEmpty();
+    }
+
+    @Test
+    public void testAuthHeader_malformedCredentials() throws SecurityException {
+        Response response = target.path("authHeader")
+                .request()
+                .header("value", "")
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(Status.UNAUTHORIZED.getStatusCode());
+
+        SerializableError error = response.readEntity(SerializableError.class);
+        assertThat(error.errorCode()).isEqualTo(ErrorType.UNAUTHORIZED.code().toString());
+        assertThat(error.errorName()).isEqualTo("Conjure:MalformedCredentials");
+        assertThat(error.parameters()).isEmpty();
+    }
+
+    @Test
+    public void testBearerToken() throws SecurityException {
+        Response response = target.path("bearerToken")
+                .request()
+                .header("value", "bearerToken")
+                .get();
+        assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(response.readEntity(String.class)).isEqualTo("bearerToken");
+    }
+
+    @Test
+    public void testBearerToken_missingCredentials() throws SecurityException {
+        Response response = target.path("bearerToken")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(Status.UNAUTHORIZED.getStatusCode());
+
+        SerializableError error = response.readEntity(SerializableError.class);
+        assertThat(error.errorCode()).isEqualTo(ErrorType.UNAUTHORIZED.code().toString());
+        assertThat(error.errorName()).isEqualTo("Conjure:MissingCredentials");
+        assertThat(error.parameters()).isEmpty();
+    }
+
+    @Test
+    public void testBearerToken_malformedCredentials() throws SecurityException {
+        Response response = target.path("bearerToken")
+                .request()
+                .header("value", "")
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(Status.UNAUTHORIZED.getStatusCode());
+
+        SerializableError error = response.readEntity(SerializableError.class);
+        assertThat(error.errorCode()).isEqualTo(ErrorType.UNAUTHORIZED.code().toString());
+        assertThat(error.errorName()).isEqualTo("Conjure:MalformedCredentials");
+        assertThat(error.parameters()).isEmpty();
+    }
+
+    public static class AuthTestServer extends Application<Configuration> {
+        @Override
+        public final void run(Configuration _config, final Environment env) {
+            env.jersey().register(ConjureJerseyFeature.INSTANCE);
+            env.jersey().register(new AuthTestResource());
+        }
+    }
+
+    public static final class AuthTestResource implements AuthTestService {
+        @Override
+        public String getAuthHeader(AuthHeader value) {
+            return value.toString();
+        }
+
+        @Override
+        public String getBearerToken(BearerToken value) {
+            return value.toString();
+        }
+    }
+
+    @Path("/")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public interface AuthTestService {
+        @GET
+        @Path("/authHeader")
+        String getAuthHeader(@HeaderParam("value") AuthHeader value);
+
+        @GET
+        @Path("/bearerToken")
+        String getBearerToken(@HeaderParam("value") BearerToken value);
+    }
+}

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/AuthTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/AuthTest.java
@@ -41,6 +41,7 @@ import javax.ws.rs.core.Response.Status;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public final class AuthTest {
@@ -72,6 +73,17 @@ public final class AuthTest {
     }
 
     @Test
+    public void testAuthHeader_allowsNull() throws SecurityException {
+        Response response = target.path("authHeader")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(Status.NO_CONTENT.getStatusCode());
+        assertThat(response.readEntity(String.class)).isEmpty();
+    }
+
+    @Test
+    @Ignore
     public void testAuthHeader_missingCredentials() throws SecurityException {
         Response response = target.path("authHeader")
                 .request()
@@ -142,6 +154,17 @@ public final class AuthTest {
     }
 
     @Test
+    public void testBearerToken_allowsNull() throws SecurityException {
+        Response response = target.path("bearerToken")
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(Status.NO_CONTENT.getStatusCode());
+        assertThat(response.readEntity(String.class)).isEqualTo("");
+    }
+
+    @Test
+    @Ignore
     public void testBearerToken_missingCredentials() throws SecurityException {
         Response response = target.path("bearerToken")
                 .request()
@@ -196,7 +219,7 @@ public final class AuthTest {
     public static final class AuthTestResource implements AuthTestService {
         @Override
         public String getAuthHeader(AuthHeader value) {
-            return value.toString();
+            return value != null ? value.toString() : null;
         }
 
         @Override
@@ -211,7 +234,7 @@ public final class AuthTest {
 
         @Override
         public String getBearerToken(BearerToken value) {
-            return value.toString();
+            return value != null ? value.toString() : null;
         }
 
         @Override

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/DateTimeTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/DateTimeTest.java
@@ -43,7 +43,8 @@ import org.junit.Test;
 public final class DateTimeTest {
 
     @ClassRule
-    public static final DropwizardAppRule<Configuration> APP = new DropwizardAppRule<>(OptionalTestServer.class,
+    public static final DropwizardAppRule<Configuration> APP = new DropwizardAppRule<>(
+            DateTimeTestServer.class,
             "src/test/resources/test-server.yml");
 
     private WebTarget target;
@@ -80,7 +81,7 @@ public final class DateTimeTest {
         assertThat(response.readEntity(String.class)).isEqualTo("2017-01-02T03:04:05.060Z");
     }
 
-    public static class OptionalTestServer extends Application<Configuration> {
+    public static class DateTimeTestServer extends Application<Configuration> {
         @Override
         public final void run(Configuration _config, final Environment env) {
             env.jersey().register(ConjureJerseyFeature.INSTANCE);


### PR DESCRIPTION
## Before this PR
Malformed authentication credentials will result in a 400. This is unfortunate because it will propagate as a 500.

## After this PR
Malformed authentication credentials will result in a 401.

This change is the equivalent to part of https://github.com/palantir/conjure-java/pull/656 for Jersey servers.