### PR TITLE
Respond with 401 when missing credentials

### DIFF
--- a/changelog/@unreleased/pr-1389.v2.yml
+++ b/changelog/@unreleased/pr-1389.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Missing credentials will result in a 401 UNAUTHORIZED from Jersey servers.
+    Previously we responded with a 400, which isn't as accurate as we would like.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1389

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
@@ -50,7 +50,7 @@ public final class AuthHeaderParamConverterProvider implements ParamConverterPro
         @Override
         public AuthHeader fromString(final String value) {
             if (value == null) {
-                return null;
+                throw UnauthorizedException.missingCredentials();
             }
             try {
                 return AuthHeader.valueOf(value);

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
@@ -49,7 +49,7 @@ public final class BearerTokenParamConverterProvider implements ParamConverterPr
         @Override
         public BearerToken fromString(final String value) {
             if (value == null) {
-                return null;
+                throw UnauthorizedException.missingCredentials();
             }
             try {
                 return BearerToken.valueOf(value);

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/AuthTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/AuthTest.java
@@ -41,7 +41,6 @@ import javax.ws.rs.core.Response.Status;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public final class AuthTest {
@@ -73,17 +72,6 @@ public final class AuthTest {
     }
 
     @Test
-    public void testAuthHeader_allowsNull() throws SecurityException {
-        Response response = target.path("authHeader")
-                .request()
-                .get();
-
-        assertThat(response.getStatus()).isEqualTo(Status.NO_CONTENT.getStatusCode());
-        assertThat(response.readEntity(String.class)).isEmpty();
-    }
-
-    @Test
-    @Ignore
     public void testAuthHeader_missingCredentials() throws SecurityException {
         Response response = target.path("authHeader")
                 .request()
@@ -154,17 +142,6 @@ public final class AuthTest {
     }
 
     @Test
-    public void testBearerToken_allowsNull() throws SecurityException {
-        Response response = target.path("bearerToken")
-                .request()
-                .get();
-
-        assertThat(response.getStatus()).isEqualTo(Status.NO_CONTENT.getStatusCode());
-        assertThat(response.readEntity(String.class)).isEqualTo("");
-    }
-
-    @Test
-    @Ignore
     public void testBearerToken_missingCredentials() throws SecurityException {
         Response response = target.path("bearerToken")
                 .request()
@@ -219,7 +196,7 @@ public final class AuthTest {
     public static final class AuthTestResource implements AuthTestService {
         @Override
         public String getAuthHeader(AuthHeader value) {
-            return value != null ? value.toString() : null;
+            return value.toString();
         }
 
         @Override
@@ -234,7 +211,7 @@ public final class AuthTest {
 
         @Override
         public String getBearerToken(BearerToken value) {
-            return value != null ? value.toString() : null;
+            return value.toString();
         }
 
         @Override


### PR DESCRIPTION
Fixes #1373. Follow-up to #1374.

## Before this PR
Missing authentication credentials will result in a 400. This is unfortunate because it will propagate as a 500.

## After this PR
Missing authentication credentials will result in a 401.

After this PR Jersey and Undertow servers will have equivalent behavior when handling authentication credentials, see https://github.com/palantir/conjure-java/pull/656.

## Possible downsides?
This is a potentially breaking change for any services that rely on authentication credentials being nullable.
