### PR TITLE
Resolve OkHttpClientsRealServerTest test flakes

### DIFF
--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ExponentialBackoff.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ExponentialBackoff.java
@@ -19,9 +19,8 @@ package com.palantir.conjure.java.okhttp;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Supplier;
+import java.util.function.DoubleSupplier;
 
 /**
  * Implements "exponential backoff with full jitter", suggesting a backoff duration chosen randomly from the interval
@@ -31,16 +30,16 @@ final class ExponentialBackoff implements BackoffStrategy {
 
     private final int maxNumRetries;
     private final Duration backoffSlotSize;
-    private final Supplier<Random> random;
+    private final DoubleSupplier random;
 
     private int retryNumber = 0;
 
     ExponentialBackoff(int maxNumRetries, Duration backoffSlotSize) {
-        this(maxNumRetries, backoffSlotSize, ThreadLocalRandom::current);
+        this(maxNumRetries, backoffSlotSize, () -> ThreadLocalRandom.current().nextDouble());
     }
 
     @VisibleForTesting
-    ExponentialBackoff(int maxNumRetries, Duration backoffSlotSize, Supplier<Random> random) {
+    ExponentialBackoff(int maxNumRetries, Duration backoffSlotSize, DoubleSupplier random) {
         this.maxNumRetries = maxNumRetries;
         this.backoffSlotSize = backoffSlotSize;
         this.random = random;
@@ -55,6 +54,6 @@ final class ExponentialBackoff implements BackoffStrategy {
 
         int upperBound = (int) Math.pow(2, retryNumber);
         return Optional.of(Duration.ofNanos(Math.round(
-                backoffSlotSize.toNanos() * random.get().nextDouble() * upperBound)));
+                backoffSlotSize.toNanos() * random.getAsDouble() * upperBound)));
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ExponentialBackoff.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ExponentialBackoff.java
@@ -35,7 +35,7 @@ final class ExponentialBackoff implements BackoffStrategy {
     private int retryNumber = 0;
 
     ExponentialBackoff(int maxNumRetries, Duration backoffSlotSize) {
-        this(maxNumRetries, backoffSlotSize, () -> ThreadLocalRandom.current().nextDouble());
+        this(maxNumRetries, backoffSlotSize, ExponentialBackoff::random);
     }
 
     @VisibleForTesting
@@ -55,5 +55,9 @@ final class ExponentialBackoff implements BackoffStrategy {
         int upperBound = (int) Math.pow(2, retryNumber);
         return Optional.of(Duration.ofNanos(Math.round(
                 backoffSlotSize.toNanos() * random.getAsDouble() * upperBound)));
+    }
+
+    private static double random() {
+        return ThreadLocalRandom.current().nextDouble();
     }
 }

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ExponentialBackoffTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ExponentialBackoffTest.java
@@ -17,11 +17,9 @@
 package com.palantir.conjure.java.okhttp;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
+import com.google.common.util.concurrent.AtomicDouble;
 import java.time.Duration;
-import java.util.Random;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,24 +30,24 @@ public final class ExponentialBackoffTest {
 
     @Test
     public void testNoRetry() {
-        Random random = mock(Random.class);
-        ExponentialBackoff backoff = new ExponentialBackoff(0, ONE_SECOND, random::nextDouble);
+        AtomicDouble random = new AtomicDouble();
+        ExponentialBackoff backoff = new ExponentialBackoff(0, ONE_SECOND, random::get);
 
         assertThat(backoff.nextBackoff()).isEmpty();
     }
 
     @Test
     public void testRetriesCorrectNumberOfTimesAndFindsRandomBackoffWithInExponentialInterval() {
-        Random random = mock(Random.class);
-        ExponentialBackoff backoff = new ExponentialBackoff(3, ONE_SECOND, random::nextDouble);
+        AtomicDouble random = new AtomicDouble();
+        ExponentialBackoff backoff = new ExponentialBackoff(3, ONE_SECOND, random::get);
 
-        when(random.nextDouble()).thenReturn(1.0);
+        random.set(1.0);
         assertThat(backoff.nextBackoff()).contains(ONE_SECOND.multipliedBy(2));
 
-        when(random.nextDouble()).thenReturn(1.0);
+        random.set(1.0);
         assertThat(backoff.nextBackoff()).contains(ONE_SECOND.multipliedBy(4));
 
-        when(random.nextDouble()).thenReturn(0.5);
+        random.set(0.5);
         assertThat(backoff.nextBackoff()).contains(ONE_SECOND.multipliedBy(4 /* 8 * 0.5 (exp * jitter), see above */));
 
         assertThat(backoff.nextBackoff()).isEmpty();

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ExponentialBackoffTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ExponentialBackoffTest.java
@@ -33,7 +33,7 @@ public final class ExponentialBackoffTest {
     @Test
     public void testNoRetry() {
         Random random = mock(Random.class);
-        ExponentialBackoff backoff = new ExponentialBackoff(0, ONE_SECOND, () -> random);
+        ExponentialBackoff backoff = new ExponentialBackoff(0, ONE_SECOND, random::nextDouble);
 
         assertThat(backoff.nextBackoff()).isEmpty();
     }
@@ -41,7 +41,7 @@ public final class ExponentialBackoffTest {
     @Test
     public void testRetriesCorrectNumberOfTimesAndFindsRandomBackoffWithInExponentialInterval() {
         Random random = mock(Random.class);
-        ExponentialBackoff backoff = new ExponentialBackoff(3, ONE_SECOND, () -> random);
+        ExponentialBackoff backoff = new ExponentialBackoff(3, ONE_SECOND, random::nextDouble);
 
         when(random.nextDouble()).thenReturn(1.0);
         assertThat(backoff.nextBackoff()).contains(ONE_SECOND.multipliedBy(2));


### PR DESCRIPTION
Provide a deterministic backoff function to ensure additional
requests aren't sent.

## Before this PR
Test flakes

## After this PR
==COMMIT_MSG==
Resolve OkHttpClientsRealServerTest test flakes
==COMMIT_MSG==

## Possible downsides?
Test might flake in other ways, if we get a bad GC this could fail.

