### PR TITLE
Improvement: Add method for constructing KeyManager out of SslConfiguration

### DIFF
--- a/changelog/@unreleased/pr-1401.v2.yml
+++ b/changelog/@unreleased/pr-1401.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Expose method for converting SslConfiguration into a KeyManager. Allows
+    augmenting sslsockets used by conjure java runtime with additional certificates.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1401

--- a/changelog/@unreleased/pr-1401.v2.yml
+++ b/changelog/@unreleased/pr-1401.v2.yml
@@ -1,6 +1,0 @@
-type: improvement
-improvement:
-  description: Expose method for converting SslConfiguration into a KeyManager. Allows
-    augmenting sslsockets used by conjure java runtime with additional certificates.
-  links:
-  - https://github.com/palantir/conjure-java-runtime/pull/1401

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/SslSocketFactories.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/SslSocketFactories.java
@@ -69,15 +69,7 @@ public final class SslSocketFactories {
      */
     public static SSLContext createSslContext(SslConfiguration config) {
         TrustManager[] trustManagers = createTrustManagers(config);
-
-        KeyManager[] keyManagers = null;
-        if (config.keyStorePath().isPresent()) {
-            keyManagers = createKeyManagerFactory(
-                    config.keyStorePath().get(),
-                    config.keyStorePassword().get(),
-                    config.keyStoreType(),
-                    config.keyStoreKeyAlias()).getKeyManagers();
-        }
+        KeyManager[] keyManagers = createKeyManagers(config);
 
         return createSslContext(trustManagers, keyManagers);
     }
@@ -175,6 +167,22 @@ public final class SslSocketFactories {
                     X509TrustManager.class.getSimpleName(),
                     trustManager.getClass().getSimpleName()));
         }
+    }
+
+    /**
+     * Create {@link KeyManager} array from the provided configuration.
+     *
+     * @param config an {@link SslConfiguration} describing at least the trust store configuration
+     * @return an {@link KeyManager} array according to the input configuration
+     */
+    public static KeyManager[] createKeyManagers(SslConfiguration config) {
+        return config.keyStorePath()
+                .map(keyStorePath -> createKeyManagerFactory(
+                        keyStorePath,
+                        config.keyStorePassword().get(),
+                        config.keyStoreType(),
+                        config.keyStoreKeyAlias()).getKeyManagers())
+                .orElse(null);
     }
 
     private static TrustManagerFactory createTrustManagerFactory(


### PR DESCRIPTION
## Before this PR
It's hard to augment sslconfiguration with additional certificates. While you can get access to trust manager you can't access keymanager (nor produce keymanager/keystore out of sslconfiguration) which makes altering ssl settings of the ssl sockets impossible 

## After this PR
==COMMIT_MSG==
Expose method for converting SslConfiguration into a KeyManager. Allows augmenting sslsockets used by conjure java runtime with additional certificates. 
==COMMIT_MSG==

## Possible downsides?
We're adding one  more method to the api, however, it's pretty low level and has very specialized usecase thus limiting possibility for abuse. 
