### PR TITLE
RemotingOkHttpCall logs backoff state prior to retry

### DIFF
--- a/changelog/@unreleased/pr-1412.v2.yml
+++ b/changelog/@unreleased/pr-1412.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: RemotingOkHttpCall safe-logs backoff state prior to retry including
+    the slot size, retry number, and max retries.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1412

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ExponentialBackoff.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ExponentialBackoff.java
@@ -60,4 +60,13 @@ final class ExponentialBackoff implements BackoffStrategy {
     private static double random() {
         return ThreadLocalRandom.current().nextDouble();
     }
+
+    @Override
+    public String toString() {
+        return "ExponentialBackoff{" +
+                "maxNumRetries=" + maxNumRetries +
+                ", backoffSlotSize=" + backoffSlotSize +
+                ", retryNumber=" + retryNumber +
+                '}';
+    }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ExponentialBackoff.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ExponentialBackoff.java
@@ -63,10 +63,7 @@ final class ExponentialBackoff implements BackoffStrategy {
 
     @Override
     public String toString() {
-        return "ExponentialBackoff{" +
-                "maxNumRetries=" + maxNumRetries +
-                ", backoffSlotSize=" + backoffSlotSize +
-                ", retryNumber=" + retryNumber +
-                '}';
+        return "ExponentialBackoff{maxNumRetries="
+                + maxNumRetries + ", backoffSlotSize=" + backoffSlotSize + ", retryNumber=" + retryNumber + '}';
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -275,11 +275,17 @@ final class RemotingOkHttpCall extends ForwardingCall {
                 }
 
                 retryIfAllowed(callback, call, exception, () -> {
-                    log.info("Retrying call after failure",
-                            SafeArg.of("backoffMillis", backoff.get().toMillis()),
-                            UnsafeArg.of("requestUrl", call.request().url().toString()),
-                            UnsafeArg.of("redirectToUrl", redirectTo.get().toString()),
-                            exception);
+                    if (log.isInfoEnabled()) {
+                        log.info(
+                                "Retrying call after failure",
+                                SafeArg.of("backoffMillis", backoff.get().toMillis()),
+                                // toString required because this object is mutable, and the logger may
+                                // format this value asynchronously.
+                                SafeArg.of("backoffState", backoffStrategy.toString()),
+                                UnsafeArg.of("requestUrl", call.request().url().toString()),
+                                UnsafeArg.of("redirectToUrl", redirectTo.get().toString()),
+                                exception);
+                    }
                     Tags.AttemptSpan nextAttempt = createNextAttempt();
                     Request redirectedRequest = request().newBuilder()
                             .url(redirectTo.get())


### PR DESCRIPTION
## Before this PR
Not much helpful safe-logged data on retry.

## After this PR
==COMMIT_MSG==
RemotingOkHttpCall safe-logs backoff state prior to retry including the slot size, retry number, and max retries.
==COMMIT_MSG==

## Possible downsides?
string allocation, however in this case we're already in a suboptimal path, a string is the least of our worries.

