### PR TITLE
Concurrency limiter listeners are protected against extra calls

### DIFF
--- a/changelog/@unreleased/pr-1413.v2.yml
+++ b/changelog/@unreleased/pr-1413.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Concurrency limiter listeners are protected against extra calls
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1413

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitersTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/ConcurrencyLimitersTest.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.netflix.concurrency.limits.Limiter;
+import org.junit.Test;
+
+public class ConcurrencyLimitersTest {
+
+    @Test
+    public void testAtMostOneInteractionWrapper() {
+        Limiter.Listener mockListener = mock(Limiter.Listener.class);
+        Limiter.Listener wrapped = new ConcurrencyLimiters.AtMostOneInteractionListener(mockListener);
+        wrapped.onSuccess();
+        wrapped.onIgnore();
+        verify(mockListener).onSuccess();
+        verifyNoMoreInteractions(mockListener);
+    }
+}


### PR DESCRIPTION
## Before this PR
Previously, internal state could be modified by interacting with
the same listener multiple times.

## After this PR
==COMMIT_MSG==
Concurrency limiter listeners are protected against extra calls
==COMMIT_MSG==

## Possible downsides?
It's possible this will make existing leaks worse because extra releases can not counteract leaked resources.

