### PR TITLE
fix #1385: Fix a response leak when requests are canceled

### DIFF
--- a/changelog/@unreleased/pr-1414.v2.yml
+++ b/changelog/@unreleased/pr-1414.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |-
+    Fix a response leak when requests are canceled. This is a workaround for an upstream bug in okhttp.
+    The race is still possible to hit, but substantially less likely, showing severl orders of magnitude of difference in testing.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1414

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/CanceledRequestResponseLeakInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/CanceledRequestResponseLeakInterceptor.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import com.palantir.logsafe.exceptions.SafeIoException;
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+/**
+ * Workaround a bug in okhttp where cancellation in flight results in leaked responses.
+ * https://github.com/square/okhttp/blob/d28d2cec21641b61f3d34e05dd52f43a717c2d32/okhttp/src/main/java/okhttp3/RealCall.java#L210-L213
+ *
+ * Note that the race condition is still present, but substantially less likely.
+ */
+enum CanceledRequestResponseLeakInterceptor implements Interceptor {
+    INSTANCE;
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Response response = chain.proceed(chain.request());
+        if (chain.call().isCanceled()) {
+            if (response.body() != null) {
+                response.close();
+            }
+            throw new SafeIoException("Canceled");
+        }
+        return response;
+    }
+}

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -210,6 +210,9 @@ public final class OkHttpClients {
                 serviceClass,
                 enableClientQoS);
 
+        // Order is important, this interceptor must be registered first in order to
+        // minimize the race condition.
+        client.addInterceptor(CanceledRequestResponseLeakInterceptor.INSTANCE);
         client.addInterceptor(CatchThrowableInterceptor.INSTANCE);
         client.addInterceptor(SpanTerminatingInterceptor.INSTANCE);
 


### PR DESCRIPTION
This is a workaround for an upstream bug in:
https://github.com/square/okhttp/blob/d28d2cec21641b61f3d34e05dd52f43a717c2d32/okhttp/src/main/java/okhttp3/RealCall.java#L210-L213
The race is still possible to hit, but substantially less likely.

I verified this using this reproducer before and after this change: https://github.com/palantir/conjure-java-runtime/compare/develop...ckozak/reproduce_leak?expand=1

## Before this PR
Leaked connections and concurrency limiters. Services which frequently cancel requests observe substantially reduced throughput while waiting for resources to be reaped or garbage collected.

## After this PR
==COMMIT_MSG==
Fix a response leak when requests are canceled. This is a workaround for an upstream bug in okhttp.
The race is still possible to hit, but substantially less likely, showing severl orders of magnitude of difference in testing.
==COMMIT_MSG==

## Downsides

RPC is fragile, and can break just about everything else.