### PR TITLE
Improvement: Move KeepAliveSocketFactory

### DIFF
--- a/changelog/@unreleased/pr-1416.v2.yml
+++ b/changelog/@unreleased/pr-1416.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Keep-alives are now enabled at okhttpclient construction time, rather
+    than at configuration time.  This means they can't be opted-out of.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1416

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -65,8 +65,7 @@ public final class ClientConfigurations {
      */
     public static ClientConfiguration of(ServiceConfiguration config) {
         return ClientConfiguration.builder()
-                .sslSocketFactory(
-                        new KeepAliveSslSocketFactory(SslSocketFactories.createSslSocketFactory(config.security())))
+                .sslSocketFactory(SslSocketFactories.createSslSocketFactory(config.security()))
                 .trustManager(SslSocketFactories.createX509TrustManager(config.security()))
                 .uris(config.uris())
                 .connectTimeout(config.connectTimeout().orElse(DEFAULT_CONNECT_TIMEOUT))
@@ -101,7 +100,7 @@ public final class ClientConfigurations {
             SSLSocketFactory sslSocketFactory,
             X509TrustManager trustManager) {
         return ClientConfiguration.builder()
-                .sslSocketFactory(new KeepAliveSslSocketFactory(sslSocketFactory))
+                .sslSocketFactory(sslSocketFactory)
                 .trustManager(trustManager)
                 .uris(uris)
                 .connectTimeout(DEFAULT_CONNECT_TIMEOUT)

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -28,9 +28,7 @@ import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.logsafe.testing.Assertions;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
-import java.io.IOException;
 import java.net.Proxy;
-import java.net.Socket;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -142,18 +140,6 @@ public final class ClientConfigurationsTest {
                 .build();
 
         assertThat(overridden.taggedMetricRegistry()).isNotSameAs(DefaultTaggedMetricRegistry.getDefault());
-    }
-
-    @Test
-    public void sslSocketFactory_has_keepalives_enabled() throws IOException {
-        ClientConfiguration config = ClientConfigurations.of(ServiceConfiguration.builder()
-                .uris(uris)
-                .security(SslConfiguration.of(Paths.get("src/test/resources/trustStore.jks")))
-                .build());
-
-        try (Socket socket = config.sslSocketFactory().createSocket("google.com", 443)) {
-            assertThat(socket.getKeepAlive()).describedAs("keepAlives enabled").isTrue();
-        }
     }
 
     @Test

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -70,8 +70,7 @@ public final class ClientConfigurationsTest {
         X509TrustManager trustManager = mock(X509TrustManager.class);
         ClientConfiguration actual = ClientConfigurations.of(uris, sslFactory, trustManager);
 
-        assertThat(actual.sslSocketFactory()).isInstanceOf(KeepAliveSslSocketFactory.class);
-        assertThat(((KeepAliveSslSocketFactory) actual.sslSocketFactory()).getDelegate()).isEqualTo(sslFactory);
+        assertThat(actual.sslSocketFactory()).isEqualTo(sslFactory);
         assertThat(actual.trustManager()).isEqualTo(trustManager);
         assertThat(actual.uris()).isEqualTo(uris);
         assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ForwardingSslSocketFactory.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ForwardingSslSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ForwardingSslSocketFactory.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ForwardingSslSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.java.client.config;
+package com.palantir.conjure.java.okhttp;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/KeepAliveSslSocketFactory.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/KeepAliveSslSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/KeepAliveSslSocketFactory.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/KeepAliveSslSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.java.client.config;
+package com.palantir.conjure.java.okhttp;
 
 import com.palantir.logsafe.Preconditions;
 import java.net.Socket;

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -226,7 +226,7 @@ public final class OkHttpClients {
         client.followRedirects(false); // We implement our own redirect logic.
 
         // SSL
-        client.sslSocketFactory(config.sslSocketFactory(), config.trustManager());
+        client.sslSocketFactory(new KeepAliveSslSocketFactory(config.sslSocketFactory()), config.trustManager());
         if (config.fallbackToCommonNameVerification()) {
             client.hostnameVerifier(Okhttp39HostnameVerifier.INSTANCE);
         }

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/KeepAliveSslSocketFactoryTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/KeepAliveSslSocketFactoryTest.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import com.palantir.conjure.java.config.ssl.SslSocketFactories;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.file.Paths;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.Test;
+
+public class KeepAliveSslSocketFactoryTest {
+
+    @Test
+    public void sslSocketFactory_has_keepalives_enabled() throws IOException {
+        SSLSocketFactory sslSocketFactory = SslSocketFactories.createSslSocketFactory(SslConfiguration.of(Paths.get(
+                "src/test/resources/trustStore.jks")));
+        KeepAliveSslSocketFactory keepalive = new KeepAliveSslSocketFactory(sslSocketFactory);
+        try (Socket socket = keepalive.createSocket("google.com", 443)) {
+            assertThat(socket.getKeepAlive()).describedAs("keepAlives enabled").isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR

@robert3005 is trying to rid the world of jks, but this involves constructing an SSL socket factory himself instead of using the one provided in `ClientConfigurations.of`. Unfortunately, this meant that the KeepAliveSocketFactory would not be accessible, leading to copypasta.

## After this PR
==COMMIT_MSG==
Keep-alives are now enabled at okhttpclient construction time, rather than at configuration time.  This means they can't be opted-out of.
==COMMIT_MSG==

## Possible downsides?
- you can't opt out of these anymore
- anyone who was grabbing the sslsocketfactory out of the ClientConfiguration and expecting it to have keep-alives will find they no longer have keep-alives set (e.g. dialogue???)

