### PR TITLE
Improvement: Support multiple certificates per certificate file

### DIFF
--- a/changelog/@unreleased/pr-1418.v2.yml
+++ b/changelog/@unreleased/pr-1418.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support certificate files with multiple certificates per file
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1418

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
@@ -53,7 +53,7 @@ public final class KeyStoresTests {
         KeyStore trustStore = KeyStores.createTrustStoreFromCertificates(TestConstants.CA_DER_CERT_PATH);
 
         assertThat(trustStore.size()).isEqualTo(1);
-        assertThat(trustStore.getCertificate(TestConstants.CA_DER_CERT_PATH.getFileName().toString() + "0").toString())
+        assertThat(trustStore.getCertificate(TestConstants.CA_DER_CERT_PATH.getFileName().toString() + "-0").toString())
                 .contains("CN=testCA");
     }
 

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
@@ -25,9 +25,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
@@ -50,7 +53,7 @@ public final class KeyStoresTests {
         KeyStore trustStore = KeyStores.createTrustStoreFromCertificates(TestConstants.CA_DER_CERT_PATH);
 
         assertThat(trustStore.size()).isEqualTo(1);
-        assertThat(trustStore.getCertificate(TestConstants.CA_DER_CERT_PATH.getFileName().toString()).toString())
+        assertThat(trustStore.getCertificate(TestConstants.CA_DER_CERT_PATH.getFileName().toString() + "0").toString())
                 .contains("CN=testCA");
     }
 
@@ -63,9 +66,9 @@ public final class KeyStoresTests {
         KeyStore trustStore = KeyStores.createTrustStoreFromCertificates(certFolder.toPath());
 
         assertThat(trustStore.size()).isEqualTo(3);
-        assertThat(trustStore.getCertificate("ca.der").toString()).contains("CN=testCA");
-        assertThat(trustStore.getCertificate("server.crt").toString()).contains("CN=localhost");
-        assertThat(trustStore.getCertificate("client.cer").toString()).contains("CN=client");
+        assertThat(trustStore.getCertificate("ca.der0").toString()).contains("CN=testCA");
+        assertThat(trustStore.getCertificate("server.crt0").toString()).contains("CN=localhost");
+        assertThat(trustStore.getCertificate("client.cer0").toString()).contains("CN=client");
     }
 
     @Test
@@ -74,6 +77,18 @@ public final class KeyStoresTests {
         KeyStore trustStore = KeyStores.createTrustStoreFromCertificates(certFolder.toPath());
 
         assertThat(trustStore.size()).isZero();
+    }
+
+    @Test
+    public void testCreateTrustStoreFromMultiCertificateFile() throws IOException, KeyStoreException {
+        File certFolder = tempFolder.newFolder();
+        Path caCer = certFolder.toPath().resolve("ca.cer");
+        java.nio.file.Files.copy(TestConstants.SERVER_CERT_PEM_PATH, caCer);
+        java.nio.file.Files.write(caCer, java.nio.file.Files.readAllBytes(TestConstants.SERVER_CERT_PEM_PATH),
+                StandardOpenOption.APPEND);
+        KeyStore trustStore = KeyStores.createTrustStoreFromCertificates(caCer);
+
+        assertThat(trustStore.size()).isEqualTo(2);
     }
 
     @Test
@@ -118,7 +133,7 @@ public final class KeyStoresTests {
         KeyStore trustStore = KeyStores.createTrustStoreFromCertificates(
                 ImmutableMap.of("server.crt", PemX509Certificate.of(cert)));
 
-        assertThat(trustStore.getCertificate("server.crt").toString()).contains("CN=localhost");
+        assertThat(trustStore.getCertificate("server.crt0").toString()).contains("CN=localhost");
     }
 
     @Test

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
@@ -84,7 +84,8 @@ public final class KeyStoresTests {
         File certFolder = tempFolder.newFolder();
         Path caCer = certFolder.toPath().resolve("ca.cer");
         java.nio.file.Files.copy(TestConstants.SERVER_CERT_PEM_PATH, caCer);
-        java.nio.file.Files.write(caCer, java.nio.file.Files.readAllBytes(TestConstants.SERVER_CERT_PEM_PATH),
+        java.nio.file.Files.write(caCer,
+                java.nio.file.Files.readAllBytes(TestConstants.SERVER_CERT_PEM_PATH),
                 StandardOpenOption.APPEND);
         KeyStore trustStore = KeyStores.createTrustStoreFromCertificates(caCer);
 

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
@@ -66,9 +66,9 @@ public final class KeyStoresTests {
         KeyStore trustStore = KeyStores.createTrustStoreFromCertificates(certFolder.toPath());
 
         assertThat(trustStore.size()).isEqualTo(3);
-        assertThat(trustStore.getCertificate("ca.der0").toString()).contains("CN=testCA");
-        assertThat(trustStore.getCertificate("server.crt0").toString()).contains("CN=localhost");
-        assertThat(trustStore.getCertificate("client.cer0").toString()).contains("CN=client");
+        assertThat(trustStore.getCertificate("ca.der-0").toString()).contains("CN=testCA");
+        assertThat(trustStore.getCertificate("server.crt-0").toString()).contains("CN=localhost");
+        assertThat(trustStore.getCertificate("client.cer-0").toString()).contains("CN=client");
     }
 
     @Test
@@ -134,7 +134,7 @@ public final class KeyStoresTests {
         KeyStore trustStore = KeyStores.createTrustStoreFromCertificates(
                 ImmutableMap.of("server.crt", PemX509Certificate.of(cert)));
 
-        assertThat(trustStore.getCertificate("server.crt0").toString()).contains("CN=localhost");
+        assertThat(trustStore.getCertificate("server.crt-0").toString()).contains("CN=localhost");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
We assumed certificate files had one certificate while in practice our infra and other tooling produces multiple per file

## After this PR
==COMMIT_MSG==
Support certificate files with multiple certificates per file
==COMMIT_MSG==

## Possible downsides?
We change the aliases in the produced files, could be fixed for single certificate files

