### PR TITLE
Tag internal error metric with cause

### DIFF
--- a/changelog/@unreleased/pr-1420.v2.yml
+++ b/changelog/@unreleased/pr-1420.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tags the internal error metric with cause
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1420

--- a/conjure-java-jersey-server/build.gradle
+++ b/conjure-java-jersey-server/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation "com.fasterxml.jackson.jaxrs:jackson-jaxrs-cbor-provider"
     implementation "com.fasterxml.jackson.module:jackson-module-afterburner"
     implementation "com.jcraft:jzlib"
+    implementation "com.netflix.feign:feign-core"
     implementation "com.palantir.safe-logging:safe-logging"
     implementation 'com.palantir.tokens:auth-tokens'
     implementation "com.palantir.tracing:tracing-jersey"

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
@@ -32,6 +32,10 @@ public enum ConjureJerseyFeature implements Feature {
         this.metrics = JerseyServerMetrics.of(SharedTaggedMetricRegistries.getSingleton());
     }
 
+    public JerseyServerMetrics getMetrics() {
+        return  metrics;
+    }
+
     /**
      * Configures a Jersey server w.r.t. conjure-java-runtime conventions: registers tracer filters and exception
      * mappers.

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.server.jersey;
 
-import com.codahale.metrics.Meter;
 import com.fasterxml.jackson.jaxrs.cbor.JacksonCBORProvider;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.tracing.jersey.TraceEnrichingFilter;
@@ -27,11 +26,10 @@ import javax.ws.rs.core.FeatureContext;
 public enum ConjureJerseyFeature implements Feature {
     INSTANCE;
 
-    private final Meter internalErrorMeter;
+    private final JerseyServerMetrics metrics;
 
     ConjureJerseyFeature() {
-        JerseyServerMetrics jerseyServerMetrics = JerseyServerMetrics.of(SharedTaggedMetricRegistries.getSingleton());
-        this.internalErrorMeter = jerseyServerMetrics.internalerrorAll();
+        this.metrics = JerseyServerMetrics.of(SharedTaggedMetricRegistries.getSingleton());
     }
 
     /**
@@ -41,15 +39,15 @@ public enum ConjureJerseyFeature implements Feature {
     @Override
     public boolean configure(FeatureContext context) {
         // Exception mappers
-        context.register(new IllegalArgumentExceptionMapper(internalErrorMeter));
+        context.register(new IllegalArgumentExceptionMapper(metrics));
         context.register(new NoContentExceptionMapper());
-        context.register(new RetryableExceptionMapper(internalErrorMeter));
-        context.register(new RuntimeExceptionMapper(internalErrorMeter));
+        context.register(new RetryableExceptionMapper(metrics));
+        context.register(new RuntimeExceptionMapper(metrics));
         context.register(new WebApplicationExceptionMapper());
         context.register(new RemoteExceptionMapper());
-        context.register(new ServiceExceptionMapper(internalErrorMeter));
+        context.register(new ServiceExceptionMapper(metrics));
         context.register(new QosExceptionMapper());
-        context.register(new ThrowableExceptionMapper(internalErrorMeter));
+        context.register(new ThrowableExceptionMapper(metrics));
 
         // Cbor handling
         context.register(new JacksonCBORProvider(ObjectMappers.newCborServerObjectMapper()));

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
@@ -26,7 +26,7 @@ import javax.ws.rs.core.FeatureContext;
 public enum ConjureJerseyFeature implements Feature {
     INSTANCE;
 
-    private final JerseyServerMetrics metrics;
+    private JerseyServerMetrics metrics;
 
     ConjureJerseyFeature() {
         this.metrics = JerseyServerMetrics.of(SharedTaggedMetricRegistries.getSingleton());

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
@@ -33,7 +33,7 @@ public enum ConjureJerseyFeature implements Feature {
     }
 
     public JerseyServerMetrics getMetrics() {
-        return  metrics;
+        return metrics;
     }
 
     /**

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
@@ -43,6 +43,7 @@ public enum ConjureJerseyFeature implements Feature {
         // Exception mappers
         context.register(new IllegalArgumentExceptionMapper(internalErrorMeter));
         context.register(new NoContentExceptionMapper());
+        context.register(new RetryableExceptionMapper(internalErrorMeter));
         context.register(new RuntimeExceptionMapper(internalErrorMeter));
         context.register(new WebApplicationExceptionMapper());
         context.register(new RemoteExceptionMapper());

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ErrorCause.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ErrorCause.java
@@ -16,15 +16,16 @@
 
 package com.palantir.conjure.java.server.jersey;
 
-public enum InternalErrorCause {
+public enum ErrorCause {
     RPC("rpc"),
     SERVICE_INTERNAL("serviceInternal"),
-    INTERNAL("internal");
+    INTERNAL("internal"),
+    OTHER("other");
 
     @SuppressWarnings("unused")
     private final String cause;
 
-    InternalErrorCause(String cause) {
+    ErrorCause(String cause) {
         this.cause = cause;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ErrorCause.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ErrorCause.java
@@ -20,7 +20,7 @@ public enum ErrorCause {
     RPC("rpc"),
     SERVICE_INTERNAL("serviceInternal"),
     INTERNAL("internal"),
-    OTHER("other");
+    UNKNOWN("unknown");
 
     @SuppressWarnings("unused")
     private final String cause;

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/IllegalArgumentExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/IllegalArgumentExceptionMapper.java
@@ -33,6 +33,6 @@ final class IllegalArgumentExceptionMapper extends JsonExceptionMapper<IllegalAr
 
     @Override
     ErrorCause getCause() {
-        return ErrorCause.OTHER;
+        return ErrorCause.UNKNOWN;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/IllegalArgumentExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/IllegalArgumentExceptionMapper.java
@@ -32,7 +32,7 @@ final class IllegalArgumentExceptionMapper extends JsonExceptionMapper<IllegalAr
     }
 
     @Override
-    InternalErrorCause getCause() {
-        return null;
+    ErrorCause getCause() {
+        return ErrorCause.OTHER;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/IllegalArgumentExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/IllegalArgumentExceptionMapper.java
@@ -31,6 +31,7 @@ final class IllegalArgumentExceptionMapper extends JsonExceptionMapper<IllegalAr
     ErrorType getErrorType(IllegalArgumentException _exception) {
         return ErrorType.INVALID_ARGUMENT;
     }
+
     @Override
     boolean isInternalError() {
         return false;

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/IllegalArgumentExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/IllegalArgumentExceptionMapper.java
@@ -16,15 +16,14 @@
 
 package com.palantir.conjure.java.server.jersey;
 
-import com.codahale.metrics.Meter;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import javax.ws.rs.ext.Provider;
 
 @Provider
 final class IllegalArgumentExceptionMapper extends JsonExceptionMapper<IllegalArgumentException> {
 
-    IllegalArgumentExceptionMapper(Meter internalErrorMeter) {
-        super(internalErrorMeter);
+    IllegalArgumentExceptionMapper(JerseyServerMetrics metrics) {
+        super(metrics);
     }
 
     @Override
@@ -33,7 +32,7 @@ final class IllegalArgumentExceptionMapper extends JsonExceptionMapper<IllegalAr
     }
 
     @Override
-    boolean isInternalError() {
-        return false;
+    InternalErrorCause getCause() {
+        return null;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/IllegalArgumentExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/IllegalArgumentExceptionMapper.java
@@ -31,4 +31,8 @@ final class IllegalArgumentExceptionMapper extends JsonExceptionMapper<IllegalAr
     ErrorType getErrorType(IllegalArgumentException _exception) {
         return ErrorType.INVALID_ARGUMENT;
     }
+    @Override
+    boolean isInternalError() {
+        return false;
+    }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/InternalErrorCause.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/InternalErrorCause.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,14 @@
 
 package com.palantir.conjure.java.server.jersey;
 
-import com.palantir.conjure.java.api.errors.ErrorType;
-import feign.RetryableException;
-import javax.ws.rs.ext.Provider;
+public enum InternalErrorCause {
+    RPC("rpc"),
+    SERVICE_INTERNAL("serviceInternal"),
+    INTERNAL("internal"),
+    REMOTE_INTERNAL("remoteInternal");
 
-@Provider
-final class RetryableExceptionMapper extends JsonExceptionMapper<RetryableException> {
-
-    RetryableExceptionMapper(JerseyServerMetrics metrics) {
-        super(metrics);
-    }
-
-    @Override
-    ErrorType getErrorType(RetryableException _exception) {
-        return ErrorType.INTERNAL;
-    }
-
-    @Override
-    InternalErrorCause getCause() {
-        return InternalErrorCause.RPC;
+    private final String cause;
+    InternalErrorCause(String cause) {
+        this.cause = cause;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/InternalErrorCause.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/InternalErrorCause.java
@@ -19,10 +19,10 @@ package com.palantir.conjure.java.server.jersey;
 public enum InternalErrorCause {
     RPC("rpc"),
     SERVICE_INTERNAL("serviceInternal"),
-    INTERNAL("internal"),
-    REMOTE_INTERNAL("remoteInternal");
+    INTERNAL("internal");
 
     private final String cause;
+
     InternalErrorCause(String cause) {
         this.cause = cause;
     }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/InternalErrorCause.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/InternalErrorCause.java
@@ -21,6 +21,7 @@ public enum InternalErrorCause {
     SERVICE_INTERNAL("serviceInternal"),
     INTERNAL("internal");
 
+    @SuppressWarnings("unused")
     private final String cause;
 
     InternalErrorCause(String cause) {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.server.jersey;
 
-import com.codahale.metrics.Meter;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.logsafe.SafeArg;
@@ -45,23 +44,23 @@ abstract class JsonExceptionMapper<T extends Throwable> implements ExceptionMapp
 
     private static final Logger log = LoggerFactory.getLogger(JsonExceptionMapper.class);
 
-    private final Meter internalExceptionMeter;
+    private final JerseyServerMetrics metrics;
 
-    JsonExceptionMapper(Meter internalExceptionMeter) {
-        this.internalExceptionMeter = internalExceptionMeter;
+    JsonExceptionMapper(JerseyServerMetrics metrics) {
+        this.metrics = metrics;
     }
 
     /** Returns the {@link ErrorType} that this exception corresponds to. */
     abstract ErrorType getErrorType(T exception);
 
-    abstract boolean isInternalError();
+    abstract InternalErrorCause getCause();
 
     @Override
     public final Response toResponse(T exception) {
         String errorInstanceId = UUID.randomUUID().toString();
         ErrorType errorType = getErrorType(exception);
-        if (isInternalError()) {
-            internalExceptionMeter.mark();
+        if (errorType.equals(ErrorType.INTERNAL)) {
+            this.metrics.internalerrorAll(getCause().toString()).mark();
         }
 
         if (errorType.httpErrorCode() / 100 == 4 /* client error */) {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
@@ -54,11 +54,13 @@ abstract class JsonExceptionMapper<T extends Throwable> implements ExceptionMapp
     /** Returns the {@link ErrorType} that this exception corresponds to. */
     abstract ErrorType getErrorType(T exception);
 
+    abstract boolean isInternalError();
+
     @Override
     public final Response toResponse(T exception) {
         String errorInstanceId = UUID.randomUUID().toString();
         ErrorType errorType = getErrorType(exception);
-        if (errorType.equals(ErrorType.INTERNAL)) {
+        if (isInternalError()) {
             internalExceptionMeter.mark();
         }
 

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
@@ -53,7 +53,7 @@ abstract class JsonExceptionMapper<T extends Throwable> implements ExceptionMapp
     /** Returns the {@link ErrorType} that this exception corresponds to. */
     abstract ErrorType getErrorType(T exception);
 
-    abstract InternalErrorCause getCause();
+    abstract ErrorCause getCause();
 
     @Override
     public final Response toResponse(T exception) {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RetryableExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RetryableExceptionMapper.java
@@ -18,22 +18,23 @@ package com.palantir.conjure.java.server.jersey;
 
 import com.codahale.metrics.Meter;
 import com.palantir.conjure.java.api.errors.ErrorType;
+import feign.RetryableException;
 import javax.ws.rs.ext.Provider;
 
 @Provider
-final class RuntimeExceptionMapper extends JsonExceptionMapper<RuntimeException> {
+final class RetryableExceptionMapper extends JsonExceptionMapper<RetryableException> {
 
-    RuntimeExceptionMapper(Meter internalErrorMeter) {
+    RetryableExceptionMapper(Meter internalErrorMeter) {
         super(internalErrorMeter);
     }
 
     @Override
-    ErrorType getErrorType(RuntimeException _exception) {
+    ErrorType getErrorType(RetryableException _exception) {
         return ErrorType.INTERNAL;
     }
 
     @Override
     boolean isInternalError() {
-        return true;
+        return false;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RetryableExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RetryableExceptionMapper.java
@@ -33,7 +33,7 @@ final class RetryableExceptionMapper extends JsonExceptionMapper<RetryableExcept
     }
 
     @Override
-    InternalErrorCause getCause() {
-        return InternalErrorCause.RPC;
+    ErrorCause getCause() {
+        return ErrorCause.RPC;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RuntimeExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RuntimeExceptionMapper.java
@@ -16,15 +16,14 @@
 
 package com.palantir.conjure.java.server.jersey;
 
-import com.codahale.metrics.Meter;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import javax.ws.rs.ext.Provider;
 
 @Provider
 final class RuntimeExceptionMapper extends JsonExceptionMapper<RuntimeException> {
 
-    RuntimeExceptionMapper(Meter internalErrorMeter) {
-        super(internalErrorMeter);
+    RuntimeExceptionMapper(JerseyServerMetrics metrics) {
+        super(metrics);
     }
 
     @Override
@@ -33,7 +32,7 @@ final class RuntimeExceptionMapper extends JsonExceptionMapper<RuntimeException>
     }
 
     @Override
-    boolean isInternalError() {
-        return true;
+    InternalErrorCause getCause() {
+        return InternalErrorCause.INTERNAL;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RuntimeExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RuntimeExceptionMapper.java
@@ -32,7 +32,7 @@ final class RuntimeExceptionMapper extends JsonExceptionMapper<RuntimeException>
     }
 
     @Override
-    InternalErrorCause getCause() {
-        return InternalErrorCause.INTERNAL;
+    ErrorCause getCause() {
+        return ErrorCause.INTERNAL;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
@@ -45,7 +45,7 @@ final class ServiceExceptionMapper implements ExceptionMapper<ServiceException> 
     @Override
     public Response toResponse(ServiceException exception) {
         if (exception.getErrorType().equals(ErrorType.INTERNAL)) {
-            metrics.internalerrorAll(InternalErrorCause.SERVICE_INTERNAL.toString()).mark();
+            metrics.internalerrorAll(ErrorCause.SERVICE_INTERNAL.toString()).mark();
         }
         int httpStatus = exception.getErrorType().httpErrorCode();
         if (httpStatus / 100 == 4 /* client error */) {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.server.jersey;
 
-import com.codahale.metrics.Meter;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.conjure.java.api.errors.ServiceException;
@@ -37,16 +36,16 @@ final class ServiceExceptionMapper implements ExceptionMapper<ServiceException> 
 
     private static final Logger log = LoggerFactory.getLogger(ServiceExceptionMapper.class);
 
-    private final Meter internalErrorMeter;
+    private final JerseyServerMetrics metrics;
 
-    ServiceExceptionMapper(Meter internalErrorMeter) {
-        this.internalErrorMeter = internalErrorMeter;
+    ServiceExceptionMapper(JerseyServerMetrics metrics) {
+        this.metrics = metrics;
     }
 
     @Override
     public Response toResponse(ServiceException exception) {
         if (exception.getErrorType().equals(ErrorType.INTERNAL)) {
-            internalErrorMeter.mark();
+            metrics.internalerrorAll(InternalErrorCause.SERVICE_INTERNAL.toString()).mark();
         }
         int httpStatus = exception.getErrorType().httpErrorCode();
         if (httpStatus / 100 == 4 /* client error */) {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ThrowableExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ThrowableExceptionMapper.java
@@ -31,4 +31,9 @@ final class ThrowableExceptionMapper extends JsonExceptionMapper<Throwable> {
     ErrorType getErrorType(Throwable _exception) {
         return ErrorType.INTERNAL;
     }
+
+    @Override
+    boolean isInternalError() {
+        return true;
+    }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ThrowableExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ThrowableExceptionMapper.java
@@ -32,7 +32,7 @@ final class ThrowableExceptionMapper extends JsonExceptionMapper<Throwable> {
     }
 
     @Override
-    InternalErrorCause getCause() {
-        return InternalErrorCause.INTERNAL;
+    ErrorCause getCause() {
+        return ErrorCause.INTERNAL;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ThrowableExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ThrowableExceptionMapper.java
@@ -16,15 +16,14 @@
 
 package com.palantir.conjure.java.server.jersey;
 
-import com.codahale.metrics.Meter;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import javax.ws.rs.ext.Provider;
 
 @Provider
 final class ThrowableExceptionMapper extends JsonExceptionMapper<Throwable> {
 
-    ThrowableExceptionMapper(Meter internalErrorMeter) {
-        super(internalErrorMeter);
+    ThrowableExceptionMapper(JerseyServerMetrics metrics) {
+        super(metrics);
     }
 
     @Override
@@ -33,7 +32,7 @@ final class ThrowableExceptionMapper extends JsonExceptionMapper<Throwable> {
     }
 
     @Override
-    boolean isInternalError() {
-        return true;
+    InternalErrorCause getCause() {
+        return InternalErrorCause.INTERNAL;
     }
 }

--- a/conjure-java-jersey-server/src/main/metrics/jersey-server-metrics.yml
+++ b/conjure-java-jersey-server/src/main/metrics/jersey-server-metrics.yml
@@ -8,5 +8,6 @@ namespaces:
     metrics:
       internalerror.all:
         type: meter
+        tags: [cause]
         docs: |
-          Meter of the number of non-RemoteException internal exceptions produced by this server.
+          Meter of the number of non-RemoteException internal exceptions produced by this server, tagged by cause.

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapperTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapperTest.java
@@ -35,6 +35,11 @@ public final class JsonExceptionMapperTest {
                 ErrorType getErrorType(RuntimeException _exception) {
                     return ErrorType.INVALID_ARGUMENT;
                 }
+
+                @Override
+                boolean isInternalError() {
+                    return false;
+                }
             };
 
     private final ObjectMapper objectMapper = ObjectMappers.newServerObjectMapper()

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapperTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapperTest.java
@@ -37,8 +37,8 @@ public final class JsonExceptionMapperTest {
                 }
 
                 @Override
-                InternalErrorCause getCause() {
-                    return InternalErrorCause.INTERNAL;
+                ErrorCause getCause() {
+                    return ErrorCause.INTERNAL;
                 }
             };
 
@@ -52,7 +52,7 @@ public final class JsonExceptionMapperTest {
         assertThat(entity).contains("\"errorCode\" : \"INVALID_ARGUMENT\"");
         assertThat(entity).contains("\"errorName\" : \"Default:InvalidArgument\"");
         assertThat(entity).contains("\"errorInstanceId\" : ");
-        assertThat(metrics.internalerrorAll(InternalErrorCause.INTERNAL.toString()).getCount()).isZero();
+        assertThat(metrics.internalerrorAll(ErrorCause.INTERNAL.toString()).getCount()).isZero();
     }
 
     @Test
@@ -62,7 +62,7 @@ public final class JsonExceptionMapperTest {
                 new RuntimeExceptionMapper(runtimeExceptionMetrics).toResponse(new NullPointerException("secret"));
         String entity = objectMapper.writeValueAsString(response.getEntity());
         assertThat(entity).doesNotContain("secret");
-        assertThat(runtimeExceptionMetrics.internalerrorAll(InternalErrorCause.INTERNAL.toString())
+        assertThat(runtimeExceptionMetrics.internalerrorAll(ErrorCause.INTERNAL.toString())
                 .getCount()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
This PR tags the internal error metric with either:

- "serviceInternal" for service exceptions thrown by this service
- "internal" for generic exceptions thrown by this service
- "rpc" for errors communicating with a remote service (in particular, these are Feign RetryableExceptions wrapping SafeIOExceptions) 

The primary goal of this PR is to split out logic errors caused by a service from RPC caused errors. For example we'd like to page or rollback if a service starts throwing nullPointerExceptions, but not if it's throwing RetryableExceptions due to a dependency being down. 

Follow up to this PR: https://github.com/palantir/conjure-java-runtime/pull/1336