### PR TITLE
LeakDetector creates stack traces dynamically for 5 minutes after a leak is detected

### DIFF
--- a/changelog/@unreleased/pr-1421.v2.yml
+++ b/changelog/@unreleased/pr-1421.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: LeakDetector creates stack traces dynamically for 5 minutes after a
+    leak is detected
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1421

--- a/okhttp-clients/src/main/metrics/okhttp-metrics.yml
+++ b/okhttp-clients/src/main/metrics/okhttp-metrics.yml
@@ -58,3 +58,7 @@ namespaces:
       connection-pool.connections.idle:
         type: gauge
         docs: Number of idle connections in the connection pool.
+      leak.detection:
+        type: meter
+        tags: [resource]
+        docs: Reports the rate that resource leaks are detected by resource type.

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/LeakDetectorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/LeakDetectorTest.java
@@ -26,7 +26,17 @@ import org.junit.Test;
 
 public class LeakDetectorTest {
     private final List<Optional<RuntimeException>> leaks = new ArrayList<>();
-    private final LeakDetector<String> leakDetector = new LeakDetector<>(String.class, leaks::add);
+    private final LeakDetector<String> leakDetector = new LeakDetector<>(String.class, new LeakDetector.Reporter() {
+        @Override
+        public void onLeakDetected(Optional<RuntimeException> stacktrace) {
+            leaks.add(stacktrace);
+        }
+
+        @Override
+        public boolean createStackTrace() {
+            return LeakDetector.isTraceLoggingEnabled();
+        }
+    });
 
     @Test
     public void detectsLeaks() {


### PR DESCRIPTION
## Before this PR
Debugging concurrency limiter leaks required iteration, for configuration changes.

## After this PR
==COMMIT_MSG==
LeakDetector creates stack traces dynamically for 5 minutes after a leak is detected
==COMMIT_MSG==

## Possible downsides?
Creating exceptions is expensive, but not nearly as expensive as waiting for leaked resources.

