### PR TITLE
Revert "Apply concurrency limiting only to network requests (#1431)"

### DIFF
--- a/changelog/@unreleased/pr-1432.v2.yml
+++ b/changelog/@unreleased/pr-1432.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Revert concurrency limiter interceptor order change which could prevent
+    cached resources from releasing concurrency limiters.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1432

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -216,7 +216,7 @@ public final class OkHttpClients {
 
         // Intercept calls to augment request meta data
         if (enableClientQoS) {
-            client.addNetworkInterceptor(new ConcurrencyLimitingInterceptor());
+            client.addInterceptor(new ConcurrencyLimitingInterceptor());
         }
         client.addInterceptor(
                 InstrumentedInterceptor.create(config.taggedMetricRegistry(), hostEventsSink, serviceClass));


### PR DESCRIPTION
This reverts commit c445d7ec05f92020de8bcd3dd4dfe9b28bfdda61.

Patch would prevent limiters for cached resources from being released.

==COMMIT_MSG==
Revert concurrency limiter interceptor order change which could prevent cached resources from releasing concurrency limiters.
==COMMIT_MSG==

