### PR TITLE
Provide client-side warnings on deprecated endpoint invocations

### DIFF
--- a/changelog/@unreleased/pr-1438.v2.yml
+++ b/changelog/@unreleased/pr-1438.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Provide client-side warnings on deprecated endpoint invocations
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1438

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DeprecationWarningInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DeprecationWarningInterceptor.java
@@ -23,6 +23,13 @@ import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * An interceptor that logs warnings when the response from a server contains the "deprecation" header. Logs include
+ * the content of the "server" header when it is provided, and always include the provided {@code serviceClassName} so
+ * that consumers applying this interceptor can locate the cause of the deprecation.
+ *
+ * <p>Note: endpoint information is not included because endpoint-level details are not available at this level.
+ */
 final class DeprecationWarningInterceptor implements Interceptor {
     private static final Logger log = LoggerFactory.getLogger(DeprecationWarningInterceptor.class);
     private final String serviceClassName;

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DeprecationWarningInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DeprecationWarningInterceptor.java
@@ -49,7 +49,7 @@ final class DeprecationWarningInterceptor implements Interceptor {
 
         String deprecationHeader = response.header("deprecation");
         if (deprecationHeader != null) {
-            clientMetrics.deprecations(serviceClassName);
+            clientMetrics.deprecations(serviceClassName).mark();
 
             if (loggingRateLimiter.tryAcquire(1)) {
                 log.warn(

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DeprecationWarningInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DeprecationWarningInterceptor.java
@@ -25,9 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An interceptor that logs warnings when the response from a server contains the "deprecation" header. Logs include
- * the content of the "server" header when it is provided, and always include the provided {@code serviceClassName} so
- * that consumers applying this interceptor can locate the cause of the deprecation.
+ * An interceptor that logs warnings when the response from a server contains the "deprecation" header. Logs include the
+ * content of the "server" header when it is provided, and always include the provided {@code serviceClassName} so that
+ * consumers applying this interceptor can locate the cause of the deprecation.
  *
  * <p>Note: endpoint information is not included because endpoint-level details are not available at this level.
  */

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DeprecationWarningInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DeprecationWarningInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+import com.palantir.logsafe.SafeArg;
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class DeprecationWarningInterceptor implements Interceptor {
+    private static final Logger log = LoggerFactory.getLogger(DeprecationWarningInterceptor.class);
+    private final String serviceClassName;
+
+    private DeprecationWarningInterceptor(String serviceClassName) {
+        this.serviceClassName = serviceClassName;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Response response = chain.proceed(chain.request());
+
+        if (response.isSuccessful()) {
+            String deprecationHeader = response.header("deprecation");
+            if (deprecationHeader != null) {
+                log.warn("Using a deprecated endpoint when connecting to service",
+                        SafeArg.of("serviceClass", serviceClassName),
+                        SafeArg.of("service", response.header("server", "no server header provided")));
+            }
+        }
+
+        return response;
+    }
+
+    static Interceptor create(Class<?> serviceClass) {
+        return new DeprecationWarningInterceptor(serviceClass.getSimpleName());
+    }
+}

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
@@ -71,9 +71,7 @@ final class InstrumentedInterceptor implements Interceptor {
     }
 
     static InstrumentedInterceptor create(
-            ClientMetrics clientMetrics,
-            HostEventsSink hostEventsSink,
-            Class<?> serviceClass) {
+            ClientMetrics clientMetrics, HostEventsSink hostEventsSink, Class<?> serviceClass) {
         return new InstrumentedInterceptor(clientMetrics, hostEventsSink, serviceClass.getSimpleName());
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
@@ -19,7 +19,6 @@ package com.palantir.conjure.java.okhttp;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Stopwatch;
-import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
@@ -34,10 +33,9 @@ final class InstrumentedInterceptor implements Interceptor {
     private final Timer responseTimer;
     private final Meter ioExceptionMeter;
 
-    InstrumentedInterceptor(TaggedMetricRegistry registry, HostEventsSink hostEventsSink, String serviceName) {
+    InstrumentedInterceptor(ClientMetrics clientMetrics, HostEventsSink hostEventsSink, String serviceName) {
         this.hostEventsSink = hostEventsSink;
         this.serviceName = serviceName;
-        ClientMetrics clientMetrics = ClientMetrics.of(registry);
         this.responseTimer = clientMetrics.response(serviceName);
         this.ioExceptionMeter = clientMetrics
                 .responseError()
@@ -73,7 +71,9 @@ final class InstrumentedInterceptor implements Interceptor {
     }
 
     static InstrumentedInterceptor create(
-            TaggedMetricRegistry registry, HostEventsSink hostEventsSink, Class<?> serviceClass) {
-        return new InstrumentedInterceptor(registry, hostEventsSink, serviceClass.getSimpleName());
+            ClientMetrics clientMetrics,
+            HostEventsSink hostEventsSink,
+            Class<?> serviceClass) {
+        return new InstrumentedInterceptor(clientMetrics, hostEventsSink, serviceClass.getSimpleName());
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -218,9 +218,9 @@ public final class OkHttpClients {
         if (enableClientQoS) {
             client.addInterceptor(new ConcurrencyLimitingInterceptor());
         }
-        client.addInterceptor(DeprecationWarningInterceptor.create(serviceClass));
-        client.addInterceptor(
-                InstrumentedInterceptor.create(config.taggedMetricRegistry(), hostEventsSink, serviceClass));
+        ClientMetrics clientMetrics = ClientMetrics.of(config.taggedMetricRegistry());
+        client.addInterceptor(DeprecationWarningInterceptor.create(clientMetrics, serviceClass));
+        client.addInterceptor(InstrumentedInterceptor.create(clientMetrics, hostEventsSink, serviceClass));
         client.addInterceptor(OkhttpTraceInterceptor.INSTANCE);
         client.addInterceptor(UserAgentInterceptor.of(augmentUserAgent(userAgent, serviceClass)));
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -218,6 +218,7 @@ public final class OkHttpClients {
         if (enableClientQoS) {
             client.addInterceptor(new ConcurrencyLimitingInterceptor());
         }
+        client.addInterceptor(DeprecationWarningInterceptor.create(serviceClass));
         client.addInterceptor(
                 InstrumentedInterceptor.create(config.taggedMetricRegistry(), hostEventsSink, serviceClass));
         client.addInterceptor(OkhttpTraceInterceptor.INSTANCE);

--- a/okhttp-clients/src/main/metrics/okhttp-metrics.yml
+++ b/okhttp-clients/src/main/metrics/okhttp-metrics.yml
@@ -42,6 +42,10 @@ namespaces:
         type: meter
         tags: [reason, service-name]
         docs: Rate of errors received by reason and service-name. Currently only errors with reason `IOException` are reported.
+      deprecations:
+        type: meter
+        tags: [service-name]
+        docs: Rate of deprecated endpoints being invoked.
   com.palantir.conjure.java:
     shortName: Okhttp
     docs: Conjure okhttp client metrics.

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptorTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptorTest.java
@@ -62,7 +62,7 @@ public final class InstrumentedInterceptorTest {
     public void before() {
         registry = new DefaultTaggedMetricRegistry();
         hostMetrics = new HostMetricsRegistry();
-        interceptor = new InstrumentedInterceptor(registry, hostMetrics, "client");
+        interceptor = new InstrumentedInterceptor(ClientMetrics.of(registry), hostMetrics, "client");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Clients invoking deprecated endpoints have no local signaling about those deprecations

## After this PR
Clients invoking deprecated endpoints will log a warning indicating which service class and, when available, the details of the server indicating access to a deprecated endpoint.

==COMMIT_MSG==
Provide client-side warnings on deprecated endpoint invocations
==COMMIT_MSG==

## Possible downsides?
More logging traffic, possible/nominal performance hit for checking one more header.

