### PR TITLE
Indicate endpoint deprecation with a pseudo-standard header

### DIFF
--- a/changelog/@unreleased/pr-1441.v2.yml
+++ b/changelog/@unreleased/pr-1441.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Clients may discover endpoint deprecation by observing return headers.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1441

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
@@ -80,6 +80,9 @@ public enum ConjureJerseyFeature implements Feature {
         // Tracing
         context.register(new TraceEnrichingFilter());
 
+        // Deprecation
+        context.register(DeprecationReportingResponseFeature.INSTANCE);
+
         return true;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/DeprecationReportingResponseFeature.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/DeprecationReportingResponseFeature.java
@@ -47,7 +47,7 @@ enum DeprecationReportingResponseFeature implements DynamicFeature {
         INSTANCE;
 
         @Override
-        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        public void filter(ContainerRequestContext _requestContext, ContainerResponseContext responseContext) {
             responseContext.getHeaders().add(DEPRECATION, IS_DEPRECATED);
         }
     }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/DeprecationReportingResponseFeature.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/DeprecationReportingResponseFeature.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.server.jersey;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import org.glassfish.jersey.server.model.AnnotatedMethod;
+
+/**
+ * Adds HTTP response headers to indicate endpoint deprecation.
+ *
+ * <p>https://tools.ietf.org/id/draft-dalal-deprecation-header-01.html#rfc.section.2.1
+ */
+enum DeprecationReportingResponseFeature implements DynamicFeature {
+    INSTANCE;
+
+    private static final String DEPRECATION = "deprecation";
+    private static final String IS_DEPRECATED = "true";
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        final AnnotatedMethod annotatedMethod = new AnnotatedMethod(resourceInfo.getResourceMethod());
+        if (annotatedMethod.getAnnotation(Deprecated.class) != null) {
+            context.register(DeprecationReportingResponseFilter.INSTANCE, ContainerResponseFilter.class);
+        }
+    }
+
+    private enum DeprecationReportingResponseFilter implements ContainerResponseFilter {
+        INSTANCE;
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+            responseContext.getHeaders().add(DEPRECATION, IS_DEPRECATED);
+        }
+    }
+}

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/DeprecationTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/DeprecationTest.java
@@ -88,6 +88,11 @@ public final class DeprecationTest {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public interface DeprecationTestService {
+        /**
+         * Deprecated endpoint.
+         *
+         * @deprecated for testing
+         */
         @GET
         @Deprecated
         @Path("/deprecated")

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/DeprecationTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/DeprecationTest.java
@@ -1,0 +1,100 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.server.jersey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public final class DeprecationTest {
+
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> APP =
+            new DropwizardAppRule<>(DeprecationTestServer.class, "src/test/resources/test-server.yml");
+
+    private WebTarget target;
+
+    @Before
+    public void before() {
+        String endpointUri = "http://localhost:" + APP.getLocalPort();
+        JerseyClientBuilder builder = new JerseyClientBuilder();
+        Client client = builder.build();
+        target = client.target(endpointUri);
+    }
+
+    @Test
+    public void testDeprecated() throws SecurityException {
+        try (Response response = target.path("deprecated").request().get()) {
+            assertThat(response.getStatus()).isEqualTo(Status.NO_CONTENT.getStatusCode());
+            assertThat(response.getHeaderString("deprecation")).isEqualTo("true");
+        }
+    }
+
+    @Test
+    public void testUnmarked() throws SecurityException {
+        try (Response response = target.path("unmarked").request().get()) {
+            assertThat(response.getStatus()).isEqualTo(Status.NO_CONTENT.getStatusCode());
+            assertThat(response.getHeaderString("deprecation")).isNull();
+        }
+    }
+
+    public static class DeprecationTestServer extends Application<Configuration> {
+        @Override
+        public final void run(Configuration _config, final Environment env) {
+            env.jersey().register(ConjureJerseyFeature.INSTANCE);
+            env.jersey().register(new DeprecationResource());
+        }
+    }
+
+    public static final class DeprecationResource implements DeprecationTestService {
+        @Override
+        public void deprecated() {}
+
+        @Override
+        public void unmarked() {}
+    }
+
+    @Path("/")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public interface DeprecationTestService {
+        @GET
+        @Deprecated
+        @Path("/deprecated")
+        void deprecated();
+
+        @GET
+        @Path("/unmarked")
+        void unmarked();
+    }
+}


### PR DESCRIPTION
Implementation of https://github.com/palantir/conjure-java/pull/714 for jersey.

## Before this PR
Clients only know about endpoint deprecation by taking API upgrades.

## After this PR
==COMMIT_MSG==
Clients may discover endpoint deprecation by observing return headers.
==COMMIT_MSG==

This unblocks our ability to localize deprecation warnings to the places where deprecated
endpoints are invoked.

## Possible downsides
None known.