### PR TITLE
Update Jersey auth converters to respect nullable annotations

### DIFF
--- a/changelog/@unreleased/pr-1443.v2.yml
+++ b/changelog/@unreleased/pr-1443.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Update Jersey auth converters to respect nullable annotations
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1443

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
@@ -52,6 +52,16 @@ public final class AuthHeaderParamConverterProvider implements ParamConverterPro
 
         private final boolean nullable;
 
+        /**
+         * This class should not be used directly.
+         *
+         * @deprecated Use AuthHeaderParamConverterProvider
+         */
+        @Deprecated
+        public AuthHeaderParamConverter() {
+            this(false);
+        }
+
         private AuthHeaderParamConverter(boolean nullable) {
             this.nullable = nullable;
         }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
@@ -34,8 +34,8 @@ import org.glassfish.jersey.internal.inject.Custom;
 @Custom
 @Provider
 public final class AuthHeaderParamConverterProvider implements ParamConverterProvider {
-    private final AuthHeaderParamConverter nonNullParamConverter = new AuthHeaderParamConverter(false);
-    private final AuthHeaderParamConverter nullableParamConverter = new AuthHeaderParamConverter(true);
+    private static final AuthHeaderParamConverter nonNullParamConverter = new AuthHeaderParamConverter(false);
+    private static final AuthHeaderParamConverter nullableParamConverter = new AuthHeaderParamConverter(true);
 
     @Override
     @SuppressWarnings("unchecked")

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/AuthHeaderParamConverterProvider.java
@@ -20,6 +20,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.tokens.auth.AuthHeader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import javax.annotation.Nullable;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.ext.ParamConverter;
@@ -33,21 +34,34 @@ import org.glassfish.jersey.internal.inject.Custom;
 @Custom
 @Provider
 public final class AuthHeaderParamConverterProvider implements ParamConverterProvider {
-    private final AuthHeaderParamConverter paramConverter = new AuthHeaderParamConverter();
+    private final AuthHeaderParamConverter nonNullParamConverter = new AuthHeaderParamConverter(false);
+    private final AuthHeaderParamConverter nullableParamConverter = new AuthHeaderParamConverter(true);
 
     @Override
     @SuppressWarnings("unchecked")
     public <T> ParamConverter<T> getConverter(
             final Class<T> rawType, final Type _genericType, final Annotation[] annotations) {
-        return AuthHeader.class.equals(rawType) && hasAuthAnnotation(annotations)
-                ? (ParamConverter<T>) paramConverter
-                : null;
+        if (AuthHeader.class.equals(rawType) && hasAuthAnnotation(annotations)) {
+            return (ParamConverter<T>)
+                    (hasNullableAnnotation(annotations) ? nullableParamConverter : nonNullParamConverter);
+        }
+        return null;
     }
 
     public static final class AuthHeaderParamConverter implements ParamConverter<AuthHeader> {
+
+        private final boolean nullable;
+
+        private AuthHeaderParamConverter(boolean nullable) {
+            this.nullable = nullable;
+        }
+
         @Override
         public AuthHeader fromString(final String value) {
             if (value == null) {
+                if (nullable) {
+                    return null;
+                }
                 throw UnauthorizedException.missingCredentials();
             }
             try {
@@ -74,6 +88,15 @@ public final class AuthHeaderParamConverterProvider implements ParamConverterPro
             }
         }
 
+        return false;
+    }
+
+    private static boolean hasNullableAnnotation(Annotation[] annotations) {
+        for (Annotation annotation : annotations) {
+            if (Nullable.class.equals(annotation.annotationType())) {
+                return true;
+            }
+        }
         return false;
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
@@ -33,8 +33,8 @@ import org.glassfish.jersey.internal.inject.Custom;
 @Custom
 @Provider
 public final class BearerTokenParamConverterProvider implements ParamConverterProvider {
-    private final BearerTokenParamConverter nonNullParamConverter = new BearerTokenParamConverter(false);
-    private final BearerTokenParamConverter nullableParamConverter = new BearerTokenParamConverter(true);
+    private static final BearerTokenParamConverter nonNullParamConverter = new BearerTokenParamConverter(false);
+    private static final BearerTokenParamConverter nullableParamConverter = new BearerTokenParamConverter(true);
 
     @Override
     @SuppressWarnings("unchecked")

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/BearerTokenParamConverterProvider.java
@@ -51,6 +51,16 @@ public final class BearerTokenParamConverterProvider implements ParamConverterPr
 
         private final boolean nullable;
 
+        /**
+         * This class should not be used directly.
+         *
+         * @deprecated Use BearerTokenParamConverterProvider
+         */
+        @Deprecated
+        public BearerTokenParamConverter() {
+            this(false);
+        }
+
         private BearerTokenParamConverter(boolean nullable) {
             this.nullable = nullable;
         }

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/AuthTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/AuthTest.java
@@ -87,7 +87,7 @@ public final class AuthTest {
         Response response = target.path("authHeaderNullable").request().get();
 
         assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
-        assertThat(response.readEntity(String.class)).isEqualTo("");
+        assertThat(response.readEntity(String.class)).isEqualTo("[no value]");
     }
 
     @Test
@@ -174,7 +174,7 @@ public final class AuthTest {
         Response response = target.path("bearerTokenNullable").request().get();
 
         assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
-        assertThat(response.readEntity(String.class)).isEqualTo("");
+        assertThat(response.readEntity(String.class)).isEqualTo("[no value]");
     }
 
     @Test
@@ -236,7 +236,7 @@ public final class AuthTest {
 
         @Override
         public String getAuthHeaderNullable(@Nullable AuthHeader value) {
-            return value == null ? "" : value.toString();
+            return value == null ? "[no value]" : value.toString();
         }
 
         @Override
@@ -256,7 +256,7 @@ public final class AuthTest {
 
         @Override
         public String getBearerTokenNullable(@Nullable BearerToken value) {
-            return value == null ? "" : value.toString();
+            return value == null ? "[no value]" : value.toString();
         }
 
         @Override

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/AuthTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/AuthTest.java
@@ -26,6 +26,7 @@ import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.CookieParam;
 import javax.ws.rs.GET;
@@ -68,6 +69,25 @@ public final class AuthTest {
 
         assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
         assertThat(response.readEntity(String.class)).isEqualTo("Bearer bearerToken");
+    }
+
+    @Test
+    public void testAuthHeaderNullable_present() throws SecurityException {
+        Response response = target.path("authHeaderNullable")
+                .request()
+                .header("Authorization", "Bearer bearerToken")
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(response.readEntity(String.class)).isEqualTo("Bearer bearerToken");
+    }
+
+    @Test
+    public void testAuthHeaderNullable_absent() throws SecurityException {
+        Response response = target.path("authHeaderNullable").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(response.readEntity(String.class)).isEqualTo("");
     }
 
     @Test
@@ -139,6 +159,25 @@ public final class AuthTest {
     }
 
     @Test
+    public void testBearerTokenNullable_present() {
+        Response response = target.path("bearerTokenNullable")
+                .request()
+                .cookie("PALANTIR_TOKEN", "bearerToken")
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(response.readEntity(String.class)).isEqualTo("bearerToken");
+    }
+
+    @Test
+    public void testBearerTokenNullable_absent() {
+        Response response = target.path("bearerTokenNullable").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(response.readEntity(String.class)).isEqualTo("");
+    }
+
+    @Test
     public void testBearerToken_missingCredentials() throws SecurityException {
         Response response = target.path("bearerToken").request().get();
 
@@ -196,6 +235,11 @@ public final class AuthTest {
         }
 
         @Override
+        public String getAuthHeaderNullable(@Nullable AuthHeader value) {
+            return value == null ? "" : value.toString();
+        }
+
+        @Override
         public String getAuthHeaderOtherHeader(AuthHeader value) {
             return value.toString();
         }
@@ -208,6 +252,11 @@ public final class AuthTest {
         @Override
         public String getBearerToken(BearerToken value) {
             return value.toString();
+        }
+
+        @Override
+        public String getBearerTokenNullable(@Nullable BearerToken value) {
+            return value == null ? "" : value.toString();
         }
 
         @Override
@@ -225,6 +274,10 @@ public final class AuthTest {
         String getAuthHeader(@HeaderParam("Authorization") AuthHeader value);
 
         @GET
+        @Path("/authHeaderNullable")
+        String getAuthHeaderNullable(@Nullable @HeaderParam("Authorization") AuthHeader value);
+
+        @GET
         @Path("/authHeaderOtherHeader")
         String getAuthHeaderOtherHeader(@HeaderParam("Other") AuthHeader value);
 
@@ -235,6 +288,10 @@ public final class AuthTest {
         @GET
         @Path("/bearerToken")
         String getBearerToken(@CookieParam("PALANTIR_TOKEN") BearerToken value);
+
+        @GET
+        @Path("/bearerTokenNullable")
+        String getBearerTokenNullable(@Nullable @CookieParam("PALANTIR_TOKEN") BearerToken value);
 
         @GET
         @Path("/bearerTokenOtherParam")


### PR DESCRIPTION
## Before this PR
This resolves a regression when new handling was added to produce
401 response codes on missing and malformed credentials. Existing
consumers who relied on explicitly marked `@Nullable` paramters
will no longer regress.

Unfortunately this took longer than expected to detect as some projects are still working on upgrading to newer Jersey :-)

## After this PR
==COMMIT_MSG==
Update Jersey auth converters to respect nullable annotations
==COMMIT_MSG==

## Possible downsides?
It's poor practice to rely on `null` in apis, optional types should be preferred. If this were not a regression, we would not allow the change.
