### PR TITLE
Http2 requires gcm ciphers to be enabled

### DIFF
--- a/changelog/@unreleased/pr-1445.v2.yml
+++ b/changelog/@unreleased/pr-1445.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Http2 requires gcm ciphers to be enabled. Previously http/2 could be
+    negotiated with servers that failed to fully implement the http/2 specification
+    as defined in https://tools.ietf.org/html/rfc7540#section-9.2.2
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1445

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -44,6 +44,7 @@ import okhttp3.ConnectionSpec;
 import okhttp3.Credentials;
 import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import okhttp3.TlsVersion;
 import okhttp3.internal.Util;
 import org.slf4j.Logger;
@@ -244,6 +245,12 @@ public final class OkHttpClients {
 
         // cipher setup
         client.connectionSpecs(createConnectionSpecs(config.enableGcmCipherSuites()));
+        // gcm ciphers are required for http/2 per https://tools.ietf.org/html/rfc7540#section-9.2.2
+        // some servers fail to implement this piece of the specification, which can violate our
+        // assumptions.
+        if (!config.enableGcmCipherSuites()) {
+            client.protocols(ImmutableList.of(Protocol.HTTP_1_1));
+        }
 
         // increase default connection pool from 5 @ 5 minutes to 100 @ 10 minutes
         client.connectionPool(connectionPool);

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -248,6 +248,7 @@ public final class OkHttpClients {
         // gcm ciphers are required for http/2 per https://tools.ietf.org/html/rfc7540#section-9.2.2
         // some servers fail to implement this piece of the specification, which can violate our
         // assumptions.
+        // This check can be removed once we've migrated to TLSv1.3+
         if (!config.enableGcmCipherSuites()) {
             client.protocols(ImmutableList.of(Protocol.HTTP_1_1));
         }


### PR DESCRIPTION
## Before this PR

Previously http/2 could be negotiated with servers that failed
to fully implement the http/2 specification as defined in
https://tools.ietf.org/html/rfc7540#section-9.2.2

## After this PR
==COMMIT_MSG==
Http2 requires gcm ciphers to be enabled. Previously http/2 could be negotiated with servers that failed to fully implement the http/2 specification as defined in https://tools.ietf.org/html/rfc7540#section-9.2.2
==COMMIT_MSG==

## Possible downsides?
In some scenarios it's possible clients may drop back from http/2 to http/1.1, particularly those connecting to an nginx instance rather than another java service.

