### PR TITLE
Update the conjure okhttp client connection pool

### DIFF
--- a/changelog/@unreleased/pr-1450.v2.yml
+++ b/changelog/@unreleased/pr-1450.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Update the conjure okhttp client connection pool to allow up to 1000
+    idle connections (increased from 100) and reduce the keepalive time to 55 seconds
+    (from 10 minutes). This should provide greater throughput in RPC bound environments.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1450

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -85,7 +85,12 @@ public final class OkHttpClients {
     private static final Dispatcher dispatcher;
 
     /** Shared connection pool. */
-    private static final ConnectionPool connectionPool = new ConnectionPool(100, 10, TimeUnit.MINUTES);
+    private static final ConnectionPool connectionPool = new ConnectionPool(
+            1000,
+            // Most servers use a one minute keepalive for idle connections, by using a shorter keepalive on
+            // clients we can avoid race conditions where the attempts to reuse a connection as the server
+            // closes it, resulting in unnecessary I/O exceptions and retrial.
+            55, TimeUnit.SECONDS);
 
     private static DispatcherMetricSet dispatcherMetricSet;
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -90,7 +90,8 @@ public final class OkHttpClients {
             // Most servers use a one minute keepalive for idle connections, by using a shorter keepalive on
             // clients we can avoid race conditions where the attempts to reuse a connection as the server
             // closes it, resulting in unnecessary I/O exceptions and retrial.
-            55, TimeUnit.SECONDS);
+            55,
+            TimeUnit.SECONDS);
 
     private static DispatcherMetricSet dispatcherMetricSet;
 


### PR DESCRIPTION
1. Allow up to 1000 idle connections, increased from 100. Many services
   constantly saturate over 250 threads waiting on RPC from other services,
   unless http/2 is used this model cannot effectively reuse connections.
   This isn't a good reason to use a more complex protocol with more overhead
   and lower throughput.
2. Decreased the idle connection keep-alive duration from ten minutes to
   fifty-five seconds to avoid a race condition where the server closes
   an idle connection before the server. By reducing this timeout we are
   able to provide a higher maximum idle connection count without as much
   risk of holding resources unnecessarily long.

## After this PR
==COMMIT_MSG==
Update the conjure okhttp client connection pool to allow up to 1000 idle connections (increased from 100) and reduce the keepalive time to 55 seconds (from 10 minutes). This should provide greater throughput in RPC bound environments.
==COMMIT_MSG==

