### PR TITLE
Fix: Deduplicate certificates deserialized from same security config amongst different clients

### DIFF
--- a/changelog/@unreleased/pr-1452.v2.yml
+++ b/changelog/@unreleased/pr-1452.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Store certificates in static cache in KeyStores class (similar to X509Factory
+    in jdk) that keys certificates by encoded representation of certificate.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1452

--- a/keystores/build.gradle
+++ b/keystores/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api "com.palantir.conjure.java.api:ssl-config"
     implementation "com.google.guava:guava"
     implementation "com.palantir.safe-logging:preconditions"
+    implementation "com.github.ben-manes.caffeine:caffeine"
 
     testImplementation project(":conjure-java-jackson-serialization")
     testImplementation("com.netflix.feign:feign-jaxrs") {

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/KeyStores.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/KeyStores.java
@@ -56,10 +56,8 @@ import java.util.stream.Collectors;
 
 final class KeyStores {
 
-    private static final Cache<EqualByteArray, X509Certificate> certCache = Caffeine.newBuilder()
-            .maximumSize(1024)
-            .softValues()
-            .build();
+    private static final Cache<EqualByteArray, X509Certificate> certCache =
+            Caffeine.newBuilder().maximumSize(1024).softValues().build();
 
     /**
      * Pattern that matches a single RSA key in a PEM file. Has a capture group that captures the content of the key
@@ -330,9 +328,7 @@ final class KeyStores {
     }
 
     private static List<Certificate> readX509Certificates(InputStream certificateIn) throws CertificateException {
-        return CertificateFactory.getInstance("X.509")
-                .generateCertificates(certificateIn)
-                .stream()
+        return CertificateFactory.getInstance("X.509").generateCertificates(certificateIn).stream()
                 .map(cert -> getCertFromCache((X509Certificate) cert))
                 .collect(Collectors.toList());
     }

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
@@ -33,6 +33,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateParsingException;
 import java.security.interfaces.RSAPrivateCrtKey;
@@ -58,6 +59,20 @@ public final class KeyStoresTests {
                                 TestConstants.CA_DER_CERT_PATH.getFileName().toString() + "-0")
                         .toString())
                 .contains("CN=testCA");
+    }
+
+    @Test
+    public void testCertificatesEqualityFromSameFile() throws GeneralSecurityException {
+        String certName = TestConstants.CA_DER_CERT_PATH.getFileName().toString() + "-0";
+
+        KeyStore trustStore = KeyStores.createTrustStoreFromCertificates(TestConstants.CA_DER_CERT_PATH);
+        assertThat(trustStore.size()).isEqualTo(1);
+        Certificate certificate = trustStore.getCertificate(certName);
+
+        KeyStore secondTrustStore = KeyStores.createTrustStoreFromCertificates(TestConstants.CA_DER_CERT_PATH);
+        assertThat(secondTrustStore.size()).isEqualTo(1);
+        Certificate secondCertificate = secondTrustStore.getCertificate(certName);
+        assertThat(certificate).isSameAs(secondCertificate);
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
We would store certificates read from sslconfiguration once per client instead of once per certificate/configuration

## After this PR
==COMMIT_MSG==
Store certificates in static cache in KeyStores class (similar to X509Factory in jdk) that keys certificates by encoded representation of certificate.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

