### PR TITLE
Fix retrofit ListanableFuture when propagating QoS

### DIFF
--- a/changelog/@unreleased/pr-1479.v2.yml
+++ b/changelog/@unreleased/pr-1479.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Retrofit2 clients now correctly propagate QoS exceptions when client
+    is configured with `ServerQoS.PROPAGATE_429_and_503_TO_CALLER`
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1479

--- a/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/TestService.java
+++ b/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/TestService.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
@@ -84,4 +85,11 @@ public interface TestService {
     @GET("getJavaOptionalHeader")
     ListenableFuture<String> getGuavaOptionalHeader(
             @Header("Optional-Header") com.google.common.base.Optional<String> optionalHeader);
+
+    @GET("getResponseBody")
+    ListenableFuture<ResponseBody> getResponseBody();
+
+    /** This is to ensure that conjure-java 4.x clients still work. */
+    @GET("getCallOfResponseBody")
+    Call<ResponseBody> getCallOfResponseBody();
 }


### PR DESCRIPTION
## Before this PR

https://github.com/palantir/conjure-java-runtime/pull/1041's logic to propagate Server QOS exceptions to the caller only works when calling `retrofit2.Call#execute()`, but not `retrofit2.Call#enqueue()` which is what happens when using `ListenableFutures`.
Conjure-java only generates ListenableFuture endpoint methods since 5.0, so this means that retrofit2 APIs generated by conjure-java 5 (or with ListenableFuture enabled) would always return a null body to the caller if:
* ClientConfiguration is configured with `ServerQoS.PROPAGATE_429_and_503_TO_CALLER`
* the server returns a 429 or 503

## After this PR
==COMMIT_MSG==
Retrofit2 clients now correctly propagate QoS exceptions when client is configured with `ServerQoS.PROPAGATE_429_and_503_TO_CALLER`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

