### PR TITLE
Include UserAgent in ClientConfiguration

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -64,3 +64,19 @@ acceptedBreaks:
       old: null
       new: "method java.util.Optional<java.lang.Boolean> com.palantir.conjure.java.client.config.ClientConfiguration::enableHttp2()"
       justification: "immutables interfaces are not for extension"
+  "4.66.0":
+    com.palantir.conjure.java.runtime:client-config:
+    - code: "java.method.addedToInterface"
+      old: null
+      new: "method java.util.Optional<com.palantir.conjure.java.api.config.service.UserAgent>\
+        \ com.palantir.conjure.java.client.config.ClientConfiguration::userAgent()"
+      justification: "Added optional field to an immutables interface"
+    com.palantir.conjure.java.runtime:conjure-java-jackson-serialization: []
+    com.palantir.conjure.java.runtime:conjure-java-jaxrs-client: []
+    com.palantir.conjure.java.runtime:conjure-java-jersey-server: []
+    com.palantir.conjure.java.runtime:conjure-java-retrofit2-client: []
+    com.palantir.conjure.java.runtime:conjure-scala-jaxrs-client: []
+    com.palantir.conjure.java.runtime:jetty-http2-agent: []
+    com.palantir.conjure.java.runtime:keystores: []
+    com.palantir.conjure.java.runtime:okhttp-clients: []
+    com.palantir.conjure.java.runtime:refresh-utils: []

--- a/changelog/@unreleased/pr-1501.v2.yml
+++ b/changelog/@unreleased/pr-1501.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ClientConfiguration contains an optional<UserAgent> field
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1501

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -22,6 +22,7 @@ import com.google.common.net.HostAndPort;
 import com.palantir.conjure.java.api.config.service.BasicCredentials;
 import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
+import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -117,6 +118,9 @@ public interface ClientConfiguration {
 
     /** Both per-request and global metrics are recorded in this registry. */
     TaggedMetricRegistry taggedMetricRegistry();
+
+    /** An identifier to distinguish this caller in the request logs of upstream services. */
+    Optional<UserAgent> userAgent();
 
     @Value.Check
     default void check() {

--- a/gradle/verifier.gradle
+++ b/gradle/verifier.gradle
@@ -49,9 +49,9 @@ idea {
         generatedSourceDirs += sourceSets.generatedJersey.java.srcDirs
         generatedSourceDirs += sourceSets.generatedRetrofit.java.srcDirs
         scopes.COMPILE.plus += [
-            configurations.generatedObjectsCompile,
-            configurations.generatedJerseyCompile,
-            configurations.generatedRetrofitCompile]
+            configurations.generatedObjectsCompileClasspath,
+            configurations.generatedJerseyCompileClasspath,
+            configurations.generatedRetrofitCompileClasspath]
     }
 }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -153,13 +153,17 @@ public final class OkHttpClients {
             Class<?> serviceClass) {
         boolean reshuffle =
                 !config.nodeSelectionStrategy().equals(NodeSelectionStrategy.PIN_UNTIL_ERROR_WITHOUT_RESHUFFLE);
-        ClientConfiguration config1 = ClientConfiguration.builder()
-                .from(config)
-                .userAgent(userAgent)
-                .build();
+        ClientConfiguration config1 =
+                ClientConfiguration.builder().from(config).userAgent(userAgent).build();
 
-        return createInternal(client, config1, hostEventsSink, serviceClass, RANDOMIZE, reshuffle, () ->
-                new ExponentialBackoff(config1.maxNumRetries(), config1.backoffSlotSize()));
+        return createInternal(
+                client,
+                config1,
+                hostEventsSink,
+                serviceClass,
+                RANDOMIZE,
+                reshuffle,
+                () -> new ExponentialBackoff(config1.maxNumRetries(), config1.backoffSlotSize()));
     }
 
     @VisibleForTesting

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsRealServerTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsRealServerTest.java
@@ -70,7 +70,6 @@ public class OkHttpClientsRealServerTest extends TestBase {
                             .maxNumRetries(10)
                             .backoffSlotSize(Duration.ofSeconds(3))
                             .build(),
-                    AGENT,
                     hostEventsSink,
                     OkHttpClientsTest.class,
                     () -> new ReproducibleExponentialBackoff(10, Duration.ofSeconds(3)));
@@ -123,7 +122,6 @@ public class OkHttpClientsRealServerTest extends TestBase {
                             .maxNumRetries(10)
                             .backoffSlotSize(Duration.ofSeconds(2))
                             .build(),
-                    AGENT,
                     hostEventsSink,
                     OkHttpClientsTest.class,
                     () -> new ReproducibleExponentialBackoff(10, Duration.ofSeconds(2)));

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -548,7 +548,6 @@ public final class OkHttpClientsTest extends TestBase {
     public void handlesRetryOther_redirectsToOtherUrl() throws Exception {
         OkHttpClient client = OkHttpClients.withStableUris(
                 ClientConfiguration.builder().from(createTestConfig(url, url2)).build(),
-                AGENT,
                 hostEventsSink,
                 OkHttpClientsTest.class);
         server.enqueue(new MockResponse().setResponseCode(308).addHeader(HttpHeaders.LOCATION, url2));
@@ -601,7 +600,6 @@ public final class OkHttpClientsTest extends TestBase {
                         .from(createTestConfig(url))
                         .serverQoS(ClientConfiguration.ServerQoS.PROPAGATE_429_and_503_TO_CALLER)
                         .build(),
-                AGENT,
                 hostEventsSink,
                 OkHttpClientsTest.class);
 
@@ -620,7 +618,6 @@ public final class OkHttpClientsTest extends TestBase {
                         .from(createTestConfig(url))
                         .serverQoS(ClientConfiguration.ServerQoS.PROPAGATE_429_and_503_TO_CALLER)
                         .build(),
-                AGENT,
                 hostEventsSink,
                 OkHttpClientsTest.class);
 
@@ -671,7 +668,6 @@ public final class OkHttpClientsTest extends TestBase {
                         .maxNumRetries(1)
                         .backoffSlotSize(Duration.ofMillis(10))
                         .build(),
-                AGENT,
                 hostEventsSink,
                 OkHttpClientsTest.class);
         Call call = client.newCall(new Request.Builder().url(url + "/foo?bar").build());
@@ -695,7 +691,6 @@ public final class OkHttpClientsTest extends TestBase {
                         .connectTimeout(Duration.ofMillis(50))
                         .retryOnTimeout(ClientConfiguration.RetryOnTimeout.DISABLED)
                         .build(),
-                AGENT,
                 hostEventsSink,
                 OkHttpClientsTest.class);
         Call call = client.newCall(new Request.Builder().url(url + "/foo?bar").build());
@@ -714,7 +709,6 @@ public final class OkHttpClientsTest extends TestBase {
                         .from(createTestConfig(url, url2))
                         .retryOnSocketException(ClientConfiguration.RetryOnSocketException.DANGEROUS_DISABLED)
                         .build(),
-                AGENT,
                 hostEventsSink,
                 OkHttpClientsTest.class);
         Call call = client.newCall(new Request.Builder().url(url + "/foo?bar").build());
@@ -734,7 +728,6 @@ public final class OkHttpClientsTest extends TestBase {
                         .backoffSlotSize(Duration.ofMillis(10))
                         .retryOnTimeout(ClientConfiguration.RetryOnTimeout.DANGEROUS_ENABLE_AT_RISK_OF_RETRY_STORMS)
                         .build(),
-                AGENT,
                 hostEventsSink,
                 OkHttpClientsTest.class);
         Call call = client.newCall(new Request.Builder().url(url + "/foo?bar").build());
@@ -773,7 +766,6 @@ public final class OkHttpClientsTest extends TestBase {
                         .from(createTestConfig(url, url2, url3))
                         .nodeSelectionStrategy(NodeSelectionStrategy.PIN_UNTIL_ERROR)
                         .build(),
-                AGENT,
                 hostEventsSink,
                 OkHttpClientsTest.class);
 
@@ -797,7 +789,6 @@ public final class OkHttpClientsTest extends TestBase {
                         .nodeSelectionStrategy(NodeSelectionStrategy.ROUND_ROBIN)
                         .failedUrlCooldown(Duration.ofSeconds(1))
                         .build(),
-                AGENT,
                 hostEventsSink,
                 OkHttpClientsTest.class);
 
@@ -825,7 +816,6 @@ public final class OkHttpClientsTest extends TestBase {
                         .maxNumRetries(0)
                         .backoffSlotSize(Duration.ofMillis(10))
                         .build(),
-                AGENT,
                 hostEventsSink,
                 OkHttpClientsTest.class);
 
@@ -841,15 +831,15 @@ public final class OkHttpClientsTest extends TestBase {
                 .setBodyDelay(Duration.ofSeconds(11).toMillis(), TimeUnit.MILLISECONDS)
                 .setBody("Hello, world!"));
 
+        ClientConfiguration clientConf = ClientConfigurations.of(ServiceConfiguration.builder()
+                .addUris(url)
+                // ClientConfigurations has a connectTimeout default of 10 seconds
+                .readTimeout(Duration.ZERO) // unlimited pls
+                .writeTimeout(Duration.ZERO) // unlimited pls
+                .security(SslConfiguration.of(Paths.get("src", "test", "resources", "trustStore.jks")))
+                .build());
         OkHttpClient client = OkHttpClients.withStableUris(
-                ClientConfigurations.of(ServiceConfiguration.builder()
-                        .addUris(url)
-                        // ClientConfigurations has a connectTimeout default of 10 seconds
-                        .readTimeout(Duration.ZERO) // unlimited pls
-                        .writeTimeout(Duration.ZERO) // unlimited pls
-                        .security(SslConfiguration.of(Paths.get("src", "test", "resources", "trustStore.jks")))
-                        .build()),
-                AGENT,
+                ClientConfiguration.builder().from(clientConf).userAgent(TestBase.AGENT).build(),
                 hostEventsSink,
                 OkHttpClientsTest.class);
 
@@ -967,7 +957,6 @@ public final class OkHttpClientsTest extends TestBase {
                         .maxNumRetries(maxNumRetries)
                         .backoffSlotSize(backoffSlotSize)
                         .build(),
-                AGENT,
                 hostEventsSink,
                 OkHttpClientsTest.class);
     }

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -839,7 +839,10 @@ public final class OkHttpClientsTest extends TestBase {
                 .security(SslConfiguration.of(Paths.get("src", "test", "resources", "trustStore.jks")))
                 .build());
         OkHttpClient client = OkHttpClients.withStableUris(
-                ClientConfiguration.builder().from(clientConf).userAgent(TestBase.AGENT).build(),
+                ClientConfiguration.builder()
+                        .from(clientConf)
+                        .userAgent(TestBase.AGENT)
+                        .build(),
                 hostEventsSink,
                 OkHttpClientsTest.class);
 

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/TestBase.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/TestBase.java
@@ -46,10 +46,11 @@ public abstract class TestBase {
 
     protected final ClientConfiguration createTestConfig(String... uri) {
         SslConfiguration sslConfig = SslConfiguration.of(Paths.get("src/test/resources/trustStore.jks"));
-        return ClientConfigurations.of(
+        ClientConfiguration config = ClientConfigurations.of(
                 ImmutableList.copyOf(uri),
                 SslSocketFactories.createSslSocketFactory(sslConfig),
                 SslSocketFactories.createX509TrustManager(sslConfig));
+        return ClientConfiguration.builder().from(config).userAgent(AGENT).build();
     }
 
     protected static Response responseWithCode(Request request, int code) {


### PR DESCRIPTION
## Before this PR

We have a bunch of signatures in dialogue that take in a ClientConfiguration and a UserAgent. This seems a little overly verbose, as semantically I think a user-agent is one of the pieces of information that are necessary to make outgoing requests, and therefore has a good claim to belong in ClientConfiguration.

## After this PR
==COMMIT_MSG==
ClientConfiguration contains an optional<UserAgent> field
==COMMIT_MSG==

## Possible downsides?

