### PR TITLE
Add smile object mapper factory methods

### DIFF
--- a/changelog/@unreleased/pr-1519.v2.yml
+++ b/changelog/@unreleased/pr-1519.v2.yml
@@ -1,0 +1,8 @@
+type: feature
+feature:
+  description: Add smile object mapper factory methods. These are intentionally not
+    applied to frameworks which require manual action to enable specific encodings
+    (feign, jersey, etc) and are reserved for negotiation where they can be transparently
+    tested (conjure-undertow+dialogue).
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1519

--- a/conjure-java-jackson-serialization/build.gradle
+++ b/conjure-java-jackson-serialization/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"
     compile "com.palantir.safe-logging:preconditions"
 
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-smile"
+
     testCompile "junit:junit"
     testCompile "org.assertj:assertj-core"
 }

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -58,6 +59,20 @@ public final class ObjectMappers {
     }
 
     /**
+     * Returns a default ObjectMapper which uses the cbor factory with settings adjusted for use in clients.
+     *
+     * <p>Settings:
+     *
+     * <ul>
+     *   <li>Ignore unknown properties found during deserialization.
+     * </ul>
+     */
+    public static ObjectMapper newSmileClientObjectMapper() {
+        return withDefaultModules(new ObjectMapper(new SmileFactory()))
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    /**
      * Returns a default ObjectMapper with settings adjusted for use in servers.
      *
      * <p>Settings:
@@ -81,6 +96,20 @@ public final class ObjectMappers {
      */
     public static ObjectMapper newCborServerObjectMapper() {
         return withDefaultModules(new ObjectMapper(new CBORFactory()))
+                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    /**
+     * Returns a default ObjectMapper which uses the smile factory with settings adjusted for use in servers.
+     *
+     * <p>Settings:
+     *
+     * <ul>
+     *   <li>Throw on unknown properties found during deserialization.
+     * </ul>
+     */
+    public static ObjectMapper newSmileServerObjectMapper() {
+        return withDefaultModules(new ObjectMapper(new SmileFactory()))
                 .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 

--- a/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/serialization/ScalaObjectMappers.java
+++ b/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/serialization/ScalaObjectMappers.java
@@ -34,12 +34,20 @@ public final class ScalaObjectMappers {
         return withScalaSupport(ObjectMappers.newCborClientObjectMapper());
     }
 
+    public static ObjectMapper newSmileClientObjectMapper() {
+        return withScalaSupport(ObjectMappers.newSmileClientObjectMapper());
+    }
+
     public static ObjectMapper newServerObjectMapper() {
         return withScalaSupport(ObjectMappers.newServerObjectMapper());
     }
 
     public static ObjectMapper newCborServerObjectMapper() {
         return withScalaSupport(ObjectMappers.newCborServerObjectMapper());
+    }
+
+    public static ObjectMapper newSmileServerObjectMapper() {
+        return withScalaSupport(ObjectMappers.newSmileServerObjectMapper());
     }
 
     private static ObjectMapper withScalaSupport(ObjectMapper objectMapper) {

--- a/versions.lock
+++ b/versions.lock
@@ -1,9 +1,10 @@
 # Run ./gradlew --write-locks to regenerate this file
 com.fasterxml:classmate:1.3.4 (1 constraints: 9b122713)
 com.fasterxml.jackson.core:jackson-annotations:2.10.2 (9 constraints: b4a68f5d)
-com.fasterxml.jackson.core:jackson-core:2.10.2 (14 constraints: 132a8491)
+com.fasterxml.jackson.core:jackson-core:2.10.2 (15 constraints: 4442d020)
 com.fasterxml.jackson.core:jackson-databind:2.10.2 (21 constraints: c28269fa)
 com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.2 (2 constraints: 961c8ac9)
+com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.2 (1 constraints: 3705313b)
 com.fasterxml.jackson.datatype:jackson-datatype-guava:2.10.2 (3 constraints: 8e20a352)
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.10.2 (3 constraints: 8e20a352)
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.2 (2 constraints: e4137274)


### PR DESCRIPTION
## After this PR
==COMMIT_MSG==
Add smile object mapper factory methods. These are intentionally not applied to frameworks which require manual action to enable specific encodings (feign, jersey, etc) and are reserved for negotiation where they can be transparently tested (conjure-undertow+dialogue).
==COMMIT_MSG==

## Possible downsides?
Additional dependency on smile, like cbor, and larger API footprint on factory methods. Like CBOR support this is worth the trade-off, especially given the breadth of smile use internally.
