### PR TITLE
Don't share connection pools

### DIFF
--- a/changelog/@unreleased/pr-1533.v2.yml
+++ b/changelog/@unreleased/pr-1533.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Don't share connection pools between clients.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1533

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DispatcherMetricSet.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DispatcherMetricSet.java
@@ -23,20 +23,17 @@ import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricSet;
 import java.util.Map;
-import okhttp3.ConnectionPool;
 import okhttp3.Dispatcher;
 
 class DispatcherMetricSet implements TaggedMetricSet {
 
     private final ImmutableMap<MetricName, Metric> metrics;
 
-    DispatcherMetricSet(Dispatcher dispatcher, ConnectionPool connectionPool) {
+    DispatcherMetricSet(Dispatcher dispatcher) {
         TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
         OkhttpMetrics okhttpMetrics = OkhttpMetrics.of(registry);
         okhttpMetrics.dispatcherCallsQueued(dispatcher::queuedCallsCount);
         okhttpMetrics.dispatcherCallsRunning(dispatcher::runningCallsCount);
-        okhttpMetrics.connectionPoolConnectionsTotal(connectionPool::connectionCount);
-        okhttpMetrics.connectionPoolConnectionsIdle(connectionPool::idleConnectionCount);
         this.metrics = ImmutableMap.copyOf(registry.getMetrics());
     }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -265,7 +265,7 @@ public final class OkHttpClients {
         if (!config.enableGcmCipherSuites() || !config.enableHttp2().orElse(DEFAULT_ENABLE_HTTP2)) {
             client.protocols(ImmutableList.of(Protocol.HTTP_1_1));
         }
-        
+
         client.connectionPool(newConnectionPool());
 
         client.dispatcher(dispatcher);
@@ -328,14 +328,14 @@ public final class OkHttpClients {
                         .build(),
                 ConnectionSpec.CLEARTEXT);
     }
-    
+
     private static ConnectionPool newConnectionPool() {
         return new ConnectionPool(
-            1000,
-            // Most servers use a one minute keepalive for idle connections, by using a shorter keepalive on
-            // clients we can avoid race conditions where the attempts to reuse a connection as the server
-            // closes it, resulting in unnecessary I/O exceptions and retrial.
-            55,
-            TimeUnit.SECONDS);
+                1000,
+                // Most servers use a one minute keepalive for idle connections, by using a shorter keepalive on
+                // clients we can avoid race conditions where the attempts to reuse a connection as the server
+                // closes it, resulting in unnecessary I/O exceptions and retrial.
+                55,
+                TimeUnit.SECONDS);
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -99,7 +99,7 @@ public final class OkHttpClients {
         // Must be less than maxRequests so a single slow host does not block all requests
         dispatcher.setMaxRequestsPerHost(256);
 
-        dispatcherMetricSet = new DispatcherMetricSet(dispatcher, connectionPool);
+        dispatcherMetricSet = new DispatcherMetricSet(dispatcher);
     }
 
     /** The {@link ScheduledExecutorService} used for recovering leaked limits. */

--- a/okhttp-clients/src/main/metrics/okhttp-metrics.yml
+++ b/okhttp-clients/src/main/metrics/okhttp-metrics.yml
@@ -56,9 +56,3 @@ namespaces:
       dispatcher.calls.running:
         type: gauge
         docs: Reports the number of active outgoing requests.
-      connection-pool.connections.total:
-        type: gauge
-        docs: Total number of connections in the connection pool.
-      connection-pool.connections.idle:
-        type: gauge
-        docs: Number of idle connections in the connection pool.

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -226,8 +226,6 @@ public final class OkHttpClientsTest extends TestBase {
 
         assertThat(Collections2.transform(registry.getMetrics().keySet(), MetricName::safeName))
                 .contains(
-                        "com.palantir.conjure.java.connection-pool.connections.idle",
-                        "com.palantir.conjure.java.connection-pool.connections.total",
                         "com.palantir.conjure.java.dispatcher.calls.queued",
                         "com.palantir.conjure.java.dispatcher.calls.running");
     }


### PR DESCRIPTION
Internally, we've seen a number of issues that appear to be related to connection pool reuse between clients. What we think we see is that a client is hanging onto a connection (which after some period is actually dead, so holding no resources), but the ConnectionPool itself manages a deque of connections, which it synchronizes access too. After long enough runtime, this queue becomes so long that accessing it times out.

Now, the curious thing here is that this connection pool reuse is totally pointless! Reuse relies on the respective connections having the same SSLSocketFactory. And, the tritium instrumentation we do does identity equals - and so this cannot possibly cause any reuse at all.