### PR TITLE
Revert "Don't share connection pools (#1533)"

### DIFF
--- a/changelog/@unreleased/pr-1534.v2.yml
+++ b/changelog/@unreleased/pr-1534.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Revert "Don't share connection pools (#1533)"
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1534

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DispatcherMetricSet.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/DispatcherMetricSet.java
@@ -23,17 +23,20 @@ import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricSet;
 import java.util.Map;
+import okhttp3.ConnectionPool;
 import okhttp3.Dispatcher;
 
 class DispatcherMetricSet implements TaggedMetricSet {
 
     private final ImmutableMap<MetricName, Metric> metrics;
 
-    DispatcherMetricSet(Dispatcher dispatcher) {
+    DispatcherMetricSet(Dispatcher dispatcher, ConnectionPool connectionPool) {
         TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
         OkhttpMetrics okhttpMetrics = OkhttpMetrics.of(registry);
         okhttpMetrics.dispatcherCallsQueued(dispatcher::queuedCallsCount);
         okhttpMetrics.dispatcherCallsRunning(dispatcher::runningCallsCount);
+        okhttpMetrics.connectionPoolConnectionsTotal(connectionPool::connectionCount);
+        okhttpMetrics.connectionPoolConnectionsIdle(connectionPool::idleConnectionCount);
         this.metrics = ImmutableMap.copyOf(registry.getMetrics());
     }
 

--- a/okhttp-clients/src/main/metrics/okhttp-metrics.yml
+++ b/okhttp-clients/src/main/metrics/okhttp-metrics.yml
@@ -56,3 +56,9 @@ namespaces:
       dispatcher.calls.running:
         type: gauge
         docs: Reports the number of active outgoing requests.
+      connection-pool.connections.total:
+        type: gauge
+        docs: Total number of connections in the connection pool.
+      connection-pool.connections.idle:
+        type: gauge
+        docs: Number of idle connections in the connection pool.

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -226,6 +226,8 @@ public final class OkHttpClientsTest extends TestBase {
 
         assertThat(Collections2.transform(registry.getMetrics().keySet(), MetricName::safeName))
                 .contains(
+                        "com.palantir.conjure.java.connection-pool.connections.idle",
+                        "com.palantir.conjure.java.connection-pool.connections.total",
                         "com.palantir.conjure.java.dispatcher.calls.queued",
                         "com.palantir.conjure.java.dispatcher.calls.running");
     }


### PR DESCRIPTION
This reverts commit 8371185592614760d96467849abc88298bfc3235.

Looking at the code some more, while my argument is correct, a thread is also booted up to clean up the pool periodically. This unfortunately means that in cases where you have issues here (and e.g. create loads and loads of clients unnecessarily), you'll also end up with a thread explosion.