### PR TITLE
GCM ciphers are enabled by default on JRE9 and beyond

### DIFF
--- a/changelog/@unreleased/pr-1539.v2.yml
+++ b/changelog/@unreleased/pr-1539.v2.yml
@@ -1,0 +1,7 @@
+type: break
+break:
+  description: |-
+    GCM ciphers are enabled by default on JRE9 and beyond. This change disables OkHttp http/2 support by default so that library upgrades don't cause OkHttp to begin negotiating http/2. Consumers which rely on http/2 must set `enable-http2: true` in the service configuration or client configuration, but keep in mind this has been found to reduce throughput by a factor of twenty.
+    Servers which still run using jdk8 are expected to incur a performance penalty due to a software GCM implementation and are recommended to upgrade as soon as possible.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1539

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -29,6 +29,8 @@ import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -44,7 +46,7 @@ public final class ClientConfigurations {
     private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration DEFAULT_BACKOFF_SLOT_SIZE = Duration.ofMillis(250);
     private static final Duration DEFAULT_FAILED_URL_COOLDOWN = Duration.ZERO;
-    private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = false;
+    private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = !isJava8();
     private static final boolean DEFAULT_FALLBACK_TO_COMMON_NAME_VERIFICATION = false;
     private static final NodeSelectionStrategy DEFAULT_NODE_SELECTION_STRATEGY = NodeSelectionStrategy.PIN_UNTIL_ERROR;
     private static final int DEFAULT_MAX_NUM_RETRIES = 4;
@@ -157,5 +159,10 @@ public final class ClientConfigurations {
             @Override
             public void connectFailed(URI _uri, SocketAddress _sa, IOException _ioe) {}
         };
+    }
+
+    private static boolean isJava8() {
+        return AccessController.doPrivileged(
+                (PrivilegedAction<Boolean>) () -> "1.8".equals(System.getProperty("java.specification.version")));
     }
 }

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -46,6 +46,8 @@ public final class ClientConfigurations {
     private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration DEFAULT_BACKOFF_SLOT_SIZE = Duration.ofMillis(250);
     private static final Duration DEFAULT_FAILED_URL_COOLDOWN = Duration.ZERO;
+    // GCM ciphers perform poorly using a java 1.8 runtime, but improve significantly in 9 and beyond.
+    // See http://openjdk.java.net/jeps/246
     private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = !isJava8();
     private static final boolean DEFAULT_FALLBACK_TO_COMMON_NAME_VERIFICATION = false;
     private static final NodeSelectionStrategy DEFAULT_NODE_SELECTION_STRATEGY = NodeSelectionStrategy.PIN_UNTIL_ERROR;

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -56,7 +56,9 @@ public final class ClientConfigurationsTest {
         assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
         assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(5));
         assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(5));
-        assertThat(actual.enableGcmCipherSuites()).isFalse();
+        assertThat(actual.enableGcmCipherSuites())
+                .as("GCM ciphers should be used by default with JRE9+")
+                .isNotEqualTo("1.8".equals(System.getProperty("java.specification.version")));
         assertThat(actual.enableHttp2()).isEmpty();
         assertThat(actual.fallbackToCommonNameVerification()).isFalse();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);
@@ -75,7 +77,9 @@ public final class ClientConfigurationsTest {
         assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
         assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(5));
         assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(5));
-        assertThat(actual.enableGcmCipherSuites()).isFalse();
+        assertThat(actual.enableGcmCipherSuites())
+                .as("GCM ciphers should be used by default with JRE9+")
+                .isNotEqualTo("1.8".equals(System.getProperty("java.specification.version")));
         assertThat(actual.enableHttp2()).isEmpty();
         assertThat(actual.fallbackToCommonNameVerification()).isFalse();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -61,7 +61,7 @@ public final class OkHttpClients {
     @VisibleForTesting
     static final int NUM_SCHEDULING_THREADS = 5;
 
-    private static final boolean DEFAULT_ENABLE_HTTP2 = true;
+    private static final boolean DEFAULT_ENABLE_HTTP2 = false;
 
     private static final ThreadFactory executionThreads = new ThreadFactoryBuilder()
             .setUncaughtExceptionHandler((thread, uncaughtException) -> log.error(


### PR DESCRIPTION
## Before this PR

On newer Java runtimes GCM ciphers outperform the current default
cipher (TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384) due to hardware support.

Enabling GCM by default must be coupled by disabling http/2 by
default in our OkHttp client to prevent existing consumers from
switching to a protocol with known implementation bugs (20x slower
upload performance using okhttp h2, connection leaks, etc).

## After this PR
==COMMIT_MSG==
GCM ciphers are enabled by default on JRE9 and beyond
==COMMIT_MSG==

## Possible downsides?
Risks:
While existing servers allow GCM ciphers to be negotiated, including
those on java 8, clients using CJR regardless of JRE version will
not negotiate GCM ciphers by default. This allows servers running
on java 8 to avoid performance pitfalls of GCM. However, most
internal services, particularly those with heavy throughput
requirements, have upgraded to JDK 11. Applications which have
already taken the upgrade to 11 will become both more secure and
more performant.

