### PR TITLE
ClientConfiguration no longer enforces failedUrlCooldown

### DIFF
--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -128,11 +128,6 @@ public interface ClientConfiguration {
             checkArgument(maxNumRetries() == 0, "If meshProxy is configured then maxNumRetries must be 0");
             checkArgument(uris().size() == 1, "If meshProxy is configured then uris must contain exactly 1 URI");
         }
-        if (nodeSelectionStrategy().equals(NodeSelectionStrategy.ROUND_ROBIN)) {
-            checkArgument(
-                    !failedUrlCooldown().isNegative() && !failedUrlCooldown().isZero(),
-                    "If nodeSelectionStrategy is ROUND_ROBIN then failedUrlCooldown must be positive");
-        }
         // Assert that timeouts are in milliseconds, not any higher precision, because feign only supports millis.
         checkTimeoutPrecision(connectTimeout(), "connectTimeout");
         checkTimeoutPrecision(readTimeout(), "readTimeout");

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -132,6 +132,7 @@ public interface ClientConfiguration {
         checkTimeoutPrecision(connectTimeout(), "connectTimeout");
         checkTimeoutPrecision(readTimeout(), "readTimeout");
         checkTimeoutPrecision(writeTimeout(), "writeTimeout");
+        checkArgument(!failedUrlCooldown().isNegative(), "failedUrlCooldown may not be negative");
     }
 
     default void checkTimeoutPrecision(Duration duration, String timeoutName) {

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -111,23 +111,6 @@ public final class ClientConfigurationsTest {
     }
 
     @Test
-    @SuppressWarnings("CheckReturnValue")
-    public void roundRobin_noCooldown() throws Exception {
-        ServiceConfiguration serviceConfig = ServiceConfiguration.builder()
-                .uris(uris)
-                .security(SslConfiguration.of(Paths.get("src/test/resources/trustStore.jks")))
-                .build();
-
-        assertThatThrownBy(() -> ClientConfiguration.builder()
-                        .from(ClientConfigurations.of(serviceConfig))
-                        .nodeSelectionStrategy(NodeSelectionStrategy.ROUND_ROBIN)
-                        .failedUrlCooldown(Duration.ofMillis(0))
-                        .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("If nodeSelectionStrategy is ROUND_ROBIN then failedUrlCooldown must be positive");
-    }
-
-    @Test
     public void overriding_tagged_metric_registry_is_convenient() {
         ServiceConfiguration serviceConfig = ServiceConfiguration.builder()
                 .uris(uris)

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -16,6 +16,8 @@
 
 package com.palantir.conjure.java.okhttp;
 
+import static com.palantir.logsafe.Preconditions.checkArgument;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -214,6 +216,12 @@ public final class OkHttpClients {
         client.addInterceptor(ResponseCapturingInterceptor.INSTANCE);
 
         // Routing
+        if (config.nodeSelectionStrategy().equals(NodeSelectionStrategy.ROUND_ROBIN)) {
+            checkArgument(
+                    !config.failedUrlCooldown().isNegative()
+                            && !config.failedUrlCooldown().isZero(),
+                    "If nodeSelectionStrategy is ROUND_ROBIN then failedUrlCooldown must be positive");
+        }
         UrlSelectorImpl urlSelector = UrlSelectorImpl.createWithFailedUrlCooldown(
                 randomizeUrlOrder ? UrlSelectorImpl.shuffle(config.uris()) : config.uris(),
                 reshuffle,

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -218,8 +218,7 @@ public final class OkHttpClients {
         // Routing
         if (config.nodeSelectionStrategy().equals(NodeSelectionStrategy.ROUND_ROBIN)) {
             checkArgument(
-                    !config.failedUrlCooldown().isNegative()
-                            && !config.failedUrlCooldown().isZero(),
+                    !config.failedUrlCooldown().isZero(),
                     "If nodeSelectionStrategy is ROUND_ROBIN then failedUrlCooldown must be positive");
         }
         UrlSelectorImpl urlSelector = UrlSelectorImpl.createWithFailedUrlCooldown(


### PR DESCRIPTION
## Before this PR

Dialogue can handle NodeSelectionStrategy.ROUND_ROBIN, but as it no longer has a blacklisting channel, it can't do anything with failedUrlCooldown.  I'd like to encourage people to leave this set to zero (and give people a warning/fail fast if they're setting an option we know will do nothing). Unfortunately validation currently prevents us from even constructing a ClientConfiguration object with round robin & failedUrlCooldown of zero.

## After this PR
==COMMIT_MSG==
The requirement for a positive failedUrlCooldown when round_robin is chosen is now enforced in OkhttpClients.create, not when constructing a ClientConfiguration object.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

