### PR TITLE
JaxRsClient dialogue implementation preserves endpoint names

### DIFF
--- a/changelog/@unreleased/pr-1545.v2.yml
+++ b/changelog/@unreleased/pr-1545.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: JaxRsClient dialogue implementation preserves endpoint names
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1545

--- a/conjure-java-jaxrs-client/build.gradle
+++ b/conjure-java-jaxrs-client/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     testImplementation project(":conjure-java-retrofit2-client")
     testImplementation project(":conjure-java-jersey-server")
     testImplementation project(':keystores')
+    testImplementation "com.palantir.dialogue:dialogue-serde"
     testImplementation "com.netflix.feign:feign-jackson"
     testImplementation "com.squareup.okhttp3:mockwebserver"
     testImplementation("io.dropwizard:dropwizard-testing") { exclude module: 'metrics-core' }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.conjure.java.api.errors.UnknownRemoteException;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.EndpointNameHeaderEnrichmentContract;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
@@ -120,6 +121,9 @@ final class DialogueFeignClient implements feign.Client {
         }
         // Tracing path template is informational only
         if (PATH_TEMPLATE.equalsIgnoreCase(headerName)) {
+            return false;
+        }
+        if (EndpointNameHeaderEnrichmentContract.ENDPOINT_NAME_HEADER.equalsIgnoreCase(headerName)) {
             return false;
         }
         return true;
@@ -315,7 +319,8 @@ final class DialogueFeignClient implements feign.Client {
         FeignRequestEndpoint(feign.Request request) {
             this.request = request;
             this.method = HttpMethod.valueOf(request.method().toUpperCase(Locale.ENGLISH));
-            endpoint = getFirstHeader(request, PATH_TEMPLATE).orElse("feign");
+            endpoint = getFirstHeader(request, EndpointNameHeaderEnrichmentContract.ENDPOINT_NAME_HEADER)
+                    .orElse("feign");
         }
 
         @Override

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.reflect.Reflection;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.EndpointNameHeaderEnrichmentContract;
 import com.palantir.conjure.java.client.jaxrs.feignimpl.QosErrorDecoder;
 import com.palantir.conjure.java.ext.refresh.Refreshable;
 import com.palantir.conjure.java.ext.refresh.RefreshableProxyInvocationHandler;
@@ -77,7 +78,7 @@ public final class JaxRsClient {
         // not used, simply for replacement
         String baseUrl = "dialogue://feign";
         return Feign.builder()
-                .contract(AbstractFeignJaxRsClientBuilder.createContract())
+                .contract(new EndpointNameHeaderEnrichmentContract(AbstractFeignJaxRsClientBuilder.createContract()))
                 .encoder(AbstractFeignJaxRsClientBuilder.createEncoder(JSON_OBJECT_MAPPER, CBOR_OBJECT_MAPPER))
                 .decoder(AbstractFeignJaxRsClientBuilder.createDecoder(JSON_OBJECT_MAPPER, CBOR_OBJECT_MAPPER))
                 .errorDecoder(new QosErrorDecoder(DialogueFeignClient.RemoteExceptionDecoder.INSTANCE))

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/EndpointNameHeaderEnrichmentContract.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/EndpointNameHeaderEnrichmentContract.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import feign.Contract;
+import feign.MethodMetadata;
+import java.lang.reflect.Method;
+
+/**
+ * Contract to capture the endpoint name (method name) and pass it to a feign client.
+ *
+ * This should be considered internal API and should not be depended upon.
+ */
+public final class EndpointNameHeaderEnrichmentContract extends AbstractDelegatingContract {
+
+    public static final String ENDPOINT_NAME_HEADER = "dialogue-endpoint-name";
+
+    public EndpointNameHeaderEnrichmentContract(Contract delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected void processMetadata(Class<?> _targetType, Method method, MethodMetadata metadata) {
+        metadata.template().header(ENDPOINT_NAME_HEADER, method.getName());
+    }
+}

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
@@ -1,0 +1,81 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.util.concurrent.Futures;
+import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Response;
+import java.io.ByteArrayInputStream;
+import java.util.AbstractMap;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public final class JaxRsClientDialogueEndpointTest {
+
+    @Test
+    public void testEndpoint() {
+        ConjureRuntime runtime = DefaultConjureRuntime.builder().build();
+        Channel channel = mock(Channel.class);
+        Response response = mock(Response.class);
+        when(response.body()).thenReturn(new ByteArrayInputStream(new byte[0]));
+        when(response.code()).thenReturn(204);
+        when(response.headers()).thenReturn(ImmutableListMultimap.of());
+        when(channel.execute(any(Endpoint.class), any(Request.class))).thenReturn(Futures.immediateFuture(response));
+        StubService service = JaxRsClient.create(StubService.class, channel, runtime);
+        service.ping();
+
+        ArgumentCaptor<Endpoint> endpointCaptor = ArgumentCaptor.forClass(Endpoint.class);
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(channel).execute(endpointCaptor.capture(), requestCaptor.capture());
+        Endpoint endpoint = endpointCaptor.getValue();
+        assertThat(endpoint.serviceName()).isEqualTo("StubService");
+        assertThat(endpoint.endpointName()).isEqualTo("ping");
+        assertThat(endpoint.httpMethod()).isEqualTo(HttpMethod.GET);
+        Request request = requestCaptor.getValue();
+        assertThat(request.body()).isEmpty();
+        assertThat(request.headerParams().asMap())
+                .containsExactly(
+                        new AbstractMap.SimpleImmutableEntry<>("Accept", ImmutableList.of("application/json")));
+    }
+
+    @Path("foo")
+    @Produces("application/json")
+    @Consumes("application/json")
+    public interface StubService {
+
+        @GET
+        @Path("path")
+        void ping();
+    }
+}


### PR DESCRIPTION
==COMMIT_MSG==
JaxRsClient dialogue implementation preserves endpoint names
==COMMIT_MSG==

