### PR TITLE
Dialogue conjure client eagerly validates supported http methods

### DIFF
--- a/changelog/@unreleased/pr-1550.v2.yml
+++ b/changelog/@unreleased/pr-1550.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue conjure client eagerly validates supported http methods
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1550

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/EndpointNameHeaderEnrichmentContract.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/EndpointNameHeaderEnrichmentContract.java
@@ -54,7 +54,7 @@ public final class EndpointNameHeaderEnrichmentContract extends AbstractDelegati
                     "Unsupported HTTP method",
                     SafeArg.of("class", targetType.getSimpleName()),
                     SafeArg.of("method", method.getName()),
-                    SafeArg.of("method", httpMethod));
+                    SafeArg.of("httpMethod", httpMethod));
         }
         metadata.template().header(ENDPOINT_NAME_HEADER, method.getName());
     }

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
@@ -212,7 +212,7 @@ public final class JaxRsClientDialogueEndpointTest {
         void options();
     }
 
-    @Target({ElementType.METHOD})
+    @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
     @javax.ws.rs.HttpMethod("ARBITRARY")
     public @interface ArbitraryHttpMethod {}


### PR DESCRIPTION
## Before this PR
Requests failed lazily when methods are called rather than when clients were created.

## After this PR
==COMMIT_MSG==
Dialogue conjure client eagerly validates supported http methods
==COMMIT_MSG==

## Possible downsides?
This implementation uses the existing endpoint enriching contract
to avoid bloating the public api footprint of project.

