### PR TITLE
Implement a host metrics registry callback

### DIFF
--- a/changelog/@unreleased/pr-1568.v2.yml
+++ b/changelog/@unreleased/pr-1568.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement a host metrics registry callback
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1568

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
@@ -26,4 +26,25 @@ public interface HostEventsSink {
     void record(String serviceName, String hostname, int port, int statusCode, long micros);
 
     void recordIoException(String serviceName, String hostname, int port);
+
+    default HostEventCallback callback(String serviceName, String hostname, int port) {
+        return new HostEventCallback() {
+            @Override
+            public void record(int statusCode, long micros) {
+                HostEventsSink.this.record(serviceName, hostname, port, statusCode, micros);
+            }
+
+            @Override
+            public void recordIoException() {
+                HostEventsSink.this.recordIoException(serviceName, hostname, port);
+            }
+        };
+    }
+
+    interface HostEventCallback {
+
+        void record(int statusCode, long micros);
+
+        void recordIoException();
+    }
 }

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/HostMetricsRegistryTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/HostMetricsRegistryTest.java
@@ -50,4 +50,24 @@ public final class HostMetricsRegistryTest {
         HostMetrics hostMetrics = Iterables.getOnlyElement(hostRegistry.getMetrics());
         assertThat(hostMetrics.getIoExceptions().getCount()).isEqualTo(1);
     }
+
+    @Test
+    public void testMetricsUpdated_callback() {
+        assertThat(hostRegistry.getMetrics()).isEmpty();
+
+        hostRegistry.callback("service", "host", 8080).record(200, 1);
+
+        HostMetrics hostMetrics = Iterables.getOnlyElement(hostRegistry.getMetrics());
+        assertThat(hostMetrics.get2xx().getSnapshot().getMin()).isEqualTo(1_000);
+    }
+
+    @Test
+    public void testIoExceptionsUpdated_callback() {
+        assertThat(hostRegistry.getMetrics()).isEmpty();
+
+        hostRegistry.callback("service", "host", 8080).recordIoException();
+
+        HostMetrics hostMetrics = Iterables.getOnlyElement(hostRegistry.getMetrics());
+        assertThat(hostMetrics.getIoExceptions().getCount()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
This simplifies the complexity for callers which can be composed
around individual targets.

## After this PR
==COMMIT_MSG==
Implement a host metrics registry callback
==COMMIT_MSG==

## Possible downsides?
Larger API surface

