### PR TITLE
Add user agent to ClientConfigurations functions

### DIFF
--- a/changelog/@unreleased/pr-1573.v2.yml
+++ b/changelog/@unreleased/pr-1573.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Adds a utility function to create a `ClientConfiguration` with a user agent
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1573

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
 import com.palantir.conjure.java.api.config.service.ProxyConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
+import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -103,6 +104,23 @@ public final class ClientConfigurations {
      */
     public static ClientConfiguration of(
             List<String> uris, SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
+        return of(uris, sslSocketFactory, trustManager, Optional.empty());
+    }
+
+    /**
+     * Creates a new {@link ClientConfiguration} instance from the given SSL configuration, URIs, and user agent,
+     * filling in all other configuration with the defaults specified as constants in this class.
+     */
+    public static ClientConfiguration of(
+            List<String> uris, SSLSocketFactory sslSocketFactory, X509TrustManager trustManager, UserAgent userAgent) {
+        return of(uris, sslSocketFactory, trustManager, Optional.of(userAgent));
+    }
+
+    private static ClientConfiguration of(
+            List<String> uris,
+            SSLSocketFactory sslSocketFactory,
+            X509TrustManager trustManager,
+            Optional<UserAgent> userAgent) {
         return ClientConfiguration.builder()
                 .sslSocketFactory(sslSocketFactory)
                 .trustManager(trustManager)
@@ -123,6 +141,7 @@ public final class ClientConfigurations {
                 .retryOnTimeout(RETRY_ON_TIMEOUT_DEFAULT)
                 .retryOnSocketException(RETRY_ON_SOCKET_EXCEPTION_DEFAULT)
                 .taggedMetricRegistry(SharedTaggedMetricRegistries.getSingleton())
+                .userAgent(userAgent)
                 .build();
     }
 


### PR DESCRIPTION
## Before this PR
ClientConfigurations doesn't provide a straightforward utility to provide user agent.  Because Dialogue requires that the userAgent field is set, you end up having to do something a bit clunky:

```
        return ClientConfiguration.builder()
                .from(ClientConfigurations.of(uris, sslSocket, trustManager))
                .userAgent(userAgent)
                .build();
```



## After this PR
==COMMIT_MSG==
Adds a utility function to create a `ClientConfiguration` with a user agent.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

