### PR TITLE
Change proxySelector FROM_ENVIRONMENT creation to parse env var as URI

### DIFF
--- a/changelog/@unreleased/pr-1578.v2.yml
+++ b/changelog/@unreleased/pr-1578.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Change proxySelector FROM_ENVIRONMENT creation to parse env var as
+    URI.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1578

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -154,9 +154,8 @@ public final class ClientConfigurations {
                         System.getenv(ENV_HTTPS_PROXY),
                         "Missing environment variable",
                         SafeArg.of("name", ENV_HTTPS_PROXY));
-                HostAndPort defaultHostAndPort = HostAndPort.fromString(defaultEnvProxy);
-                InetSocketAddress address =
-                        new InetSocketAddress(defaultHostAndPort.getHost(), defaultHostAndPort.getPort());
+                URI uri = URI.create(defaultEnvProxy);
+                InetSocketAddress address = new InetSocketAddress(uri.getHost(), uri.getPort());
                 return fixedProxySelectorFor(new Proxy(Proxy.Type.HTTP, address));
             case HTTP:
                 HostAndPort hostAndPort = HostAndPort.fromString(proxyConfig

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.client.config;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
 import com.palantir.conjure.java.api.config.service.ProxyConfiguration;
@@ -154,8 +155,7 @@ public final class ClientConfigurations {
                         System.getenv(ENV_HTTPS_PROXY),
                         "Missing environment variable",
                         SafeArg.of("name", ENV_HTTPS_PROXY));
-                URI uri = URI.create(defaultEnvProxy);
-                InetSocketAddress address = new InetSocketAddress(uri.getHost(), uri.getPort());
+                InetSocketAddress address = createInetSocketAddress(defaultEnvProxy);
                 return fixedProxySelectorFor(new Proxy(Proxy.Type.HTTP, address));
             case HTTP:
                 HostAndPort hostAndPort = HostAndPort.fromString(proxyConfig
@@ -171,6 +171,12 @@ public final class ClientConfigurations {
         }
 
         throw new IllegalStateException("Failed to create ProxySelector for proxy configuration: " + proxyConfig);
+    }
+
+    @VisibleForTesting
+    static InetSocketAddress createInetSocketAddress(String uriString) {
+        URI uri = URI.create(uriString);
+        return new InetSocketAddress(uri.getHost(), uri.getPort());
     }
 
     private static Optional<HostAndPort> meshProxy(Optional<ProxyConfiguration> proxy) {

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -145,8 +145,7 @@ public final class ClientConfigurationsTest {
 
     @Test
     public void systemEnvUri() {
-        // How environment variables for https proxy look like in deployments.
-        // http://github.palantir.build/pcloud/pcloud-docs/blob/master/docs/usage/egress.rst#using-the-http-egress-proxy
+        // How environment variables for https proxy look like.
         InetSocketAddress inetSocketAddress =
                 ClientConfigurations.createInetSocketAddress("http://zomp-ovc-gw-1:8888/");
         assertThat(inetSocketAddress.getHostString()).isEqualTo("zomp-ovc-gw-1");

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -28,6 +28,7 @@ import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.logsafe.testing.Assertions;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URI;
 import java.nio.file.Paths;
@@ -140,6 +141,16 @@ public final class ClientConfigurationsTest {
 
         assertThat(instance1).isEqualTo(instance2);
         assertThat(instance1).hasSameHashCodeAs(instance2);
+    }
+
+    @Test
+    public void systemEnvUri() {
+        // How environment variables for https proxy look like in deployments.
+        // http://github.palantir.build/pcloud/pcloud-docs/blob/master/docs/usage/egress.rst#using-the-http-egress-proxy
+        InetSocketAddress inetSocketAddress =
+                ClientConfigurations.createInetSocketAddress("http://zomp-ovc-gw-1:8888/");
+        assertThat(inetSocketAddress.getHostString()).isEqualTo("zomp-ovc-gw-1");
+        assertThat(inetSocketAddress.getPort()).isEqualTo(8888);
     }
 
     private ServiceConfiguration meshProxyServiceConfig(List<String> theUris, int maxNumRetries) {


### PR DESCRIPTION
## Before this PR
The way system.getEnv returns the host and port doesn't parse correctly with `HostAndPort.fromString`, but it does with `URI.create`.

## After this PR
==COMMIT_MSG==
Change proxySelector FROM_ENVIRONMENT creation to parse env var as URI.
==COMMIT_MSG==

Add separate method for testing not to mess with env vars

