### PR TITLE
Fix: Wrap certificate input stream in BufferedInputStream to avoid single byte reads from X509Factory 

### DIFF
--- a/changelog/@unreleased/pr-1588.v2.yml
+++ b/changelog/@unreleased/pr-1588.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Copy certificate files to memory before delegating to avoid inefficient
+    single byte disk reads from X509Factory
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1588

--- a/changelog/@unreleased/pr-1588.v2.yml
+++ b/changelog/@unreleased/pr-1588.v2.yml
@@ -1,6 +1,5 @@
 type: fix
 fix:
-  description: Copy certificate files to memory before delegating to avoid inefficient
-    single byte disk reads from X509Factory
+  description: Wrap InpuStream in BufferedInputStream before handing it off to X509Factory to avoid expensive single byte disk reads
   links:
   - https://github.com/palantir/conjure-java-runtime/pull/1588

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/DefaultCas.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/DefaultCas.java
@@ -19,13 +19,11 @@ package com.palantir.conjure.java.config.ssl;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
-import com.google.common.io.ByteStreams;
+import com.google.common.io.Resources;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
@@ -56,14 +54,11 @@ final class DefaultCas {
     private static Map<String, X509Certificate> getTrustedCertificates() {
         ImmutableMap.Builder<String, X509Certificate> certificateMap = ImmutableMap.builder();
         try {
-            InputStream certificateResource = DefaultCas.class.getResourceAsStream(CA_CERTIFICATES_CRT);
-            ByteArrayOutputStream inMemoryCertificates = new ByteArrayOutputStream();
-            ByteStreams.copy(certificateResource, inMemoryCertificates);
-            List<X509Certificate> caCertificates =
-                    KeyStores.readX509Certificates(new ByteArrayInputStream(inMemoryCertificates.toByteArray()))
-                            .stream()
-                            .map(cert -> (X509Certificate) cert)
-                            .collect(Collectors.toList());
+            List<X509Certificate> caCertificates = KeyStores.readX509Certificates(
+                            new ByteArrayInputStream(Resources.toByteArray(Resources.getResource(CA_CERTIFICATES_CRT))))
+                    .stream()
+                    .map(cert -> (X509Certificate) cert)
+                    .collect(Collectors.toList());
             int index = 0;
             for (X509Certificate cert : caCertificates) {
                 String certificateCommonName =

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/DefaultCas.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/DefaultCas.java
@@ -42,7 +42,7 @@ final class DefaultCas {
      * This should be updated by running `./gradlew regenerateCAs` whenever the Java version we use to compile changes,
      * to ensure we pick up new CAs or revoke insecure ones.
      */
-    private static final String CA_CERTIFICATES_CRT = "/ca-certificates.crt";
+    private static final String CA_CERTIFICATES_CRT = "ca-certificates.crt";
 
     private static final Supplier<Map<String, X509Certificate>> TRUSTED_CERTIFICATES =
             Suppliers.memoize(DefaultCas::getTrustedCertificates);

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/KeyStores.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/KeyStores.java
@@ -98,10 +98,8 @@ final class KeyStores {
         keyStore = createKeyStore();
 
         for (File currFile : getFilesForPath(path)) {
-            try {
-                byte[] fileBytes = Files.readAllBytes(currFile.toPath());
-                addCertificatesToKeystore(
-                        keyStore, currFile.getName(), readX509Certificates(new ByteArrayInputStream(fileBytes)));
+            try (InputStream in = new BufferedInputStream(Files.newInputStream(currFile.toPath()))) {
+                addCertificatesToKeystore(keyStore, currFile.getName(), readX509Certificates(in));
             } catch (IOException e) {
                 throw new RuntimeException(
                         String.format("IOException encountered when opening '%s'", currFile.toPath()), e);
@@ -331,9 +329,7 @@ final class KeyStores {
     }
 
     static List<Certificate> readX509Certificates(InputStream certificateIn) throws CertificateException {
-        return CertificateFactory.getInstance("X.509")
-                .generateCertificates(new BufferedInputStream(certificateIn))
-                .stream()
+        return CertificateFactory.getInstance("X.509").generateCertificates(certificateIn).stream()
                 .map(cert -> getCertFromCache((X509Certificate) cert))
                 .collect(Collectors.toList());
     }

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/KeyStores.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/KeyStores.java
@@ -22,6 +22,7 @@ import com.google.common.base.Throwables;
 import com.google.common.io.BaseEncoding;
 import com.palantir.conjure.java.config.ssl.pkcs1.Pkcs1PrivateKeyReader;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileFilter;
@@ -330,7 +331,9 @@ final class KeyStores {
     }
 
     static List<Certificate> readX509Certificates(InputStream certificateIn) throws CertificateException {
-        return CertificateFactory.getInstance("X.509").generateCertificates(certificateIn).stream()
+        return CertificateFactory.getInstance("X.509")
+                .generateCertificates(new BufferedInputStream(certificateIn))
+                .stream()
                 .map(cert -> getCertFromCache((X509Certificate) cert))
                 .collect(Collectors.toList());
     }

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/KeyStores.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/KeyStores.java
@@ -97,8 +97,10 @@ final class KeyStores {
         keyStore = createKeyStore();
 
         for (File currFile : getFilesForPath(path)) {
-            try (InputStream in = Files.newInputStream(currFile.toPath())) {
-                addCertificatesToKeystore(keyStore, currFile.getName(), readX509Certificates(in));
+            try {
+                byte[] fileBytes = Files.readAllBytes(currFile.toPath());
+                addCertificatesToKeystore(
+                        keyStore, currFile.getName(), readX509Certificates(new ByteArrayInputStream(fileBytes)));
             } catch (IOException e) {
                 throw new RuntimeException(
                         String.format("IOException encountered when opening '%s'", currFile.toPath()), e);

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
@@ -34,7 +34,6 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
 import java.security.cert.CertificateParsingException;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.spec.InvalidKeySpecException;
@@ -148,9 +147,9 @@ public final class KeyStoresTests {
 
         assertThatThrownBy(() -> KeyStores.createTrustStoreFromCertificates(certFolder.toPath()))
                 .isInstanceOf(RuntimeException.class)
-                .hasCauseInstanceOf(CertificateException.class)
-                .hasMessageContaining(String.format(
-                        "Could not read file at \"%s\" as an X.509 certificate", tempDirFile.getAbsolutePath()));
+                .hasCauseInstanceOf(IOException.class)
+                .hasMessageContaining(
+                        String.format("IOException encountered when opening '%s'", tempDirFile.getAbsolutePath()));
     }
 
     @Test

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
@@ -34,6 +34,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
 import java.security.cert.CertificateParsingException;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.spec.InvalidKeySpecException;
@@ -147,9 +148,9 @@ public final class KeyStoresTests {
 
         assertThatThrownBy(() -> KeyStores.createTrustStoreFromCertificates(certFolder.toPath()))
                 .isInstanceOf(RuntimeException.class)
-                .hasCauseInstanceOf(IOException.class)
-                .hasMessageContaining(
-                        String.format("IOException encountered when opening '%s'", tempDirFile.getAbsolutePath()));
+                .hasCauseInstanceOf(CertificateException.class)
+                .hasMessageContaining(String.format(
+                        "Could not read file at \"%s\" as an X.509 certificate", tempDirFile.getAbsolutePath()));
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
We defer certificate reading to certificate factory which does single byte reads

## After this PR
==COMMIT_MSG==
Copy certificate files to memory before delegating to avoid inefficient single byte disk reads from X509Factory
==COMMIT_MSG==

The problematic method is https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/sun/security/provider/X509Factory.java#L547

## Possible downsides?
We consume few hundred kilobytes extra memory when reading certificates

