### PR TITLE
ClientConfiguration includes Optional<HostEventsSink>

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -80,3 +80,9 @@ acceptedBreaks:
     com.palantir.conjure.java.runtime:keystores: []
     com.palantir.conjure.java.runtime:okhttp-clients: []
     com.palantir.conjure.java.runtime:refresh-utils: []
+  "5.8.0":
+    com.palantir.conjure.java.runtime:client-config:
+    - code: "java.method.addedToInterface"
+      new: "method java.util.Optional<com.palantir.conjure.java.client.config.HostEventsSink>\
+        \ com.palantir.conjure.java.client.config.ClientConfiguration::hostEventsSink()"
+      justification: "Adding optional field to immutable object won't break people"

--- a/changelog/@unreleased/pr-1591.v2.yml
+++ b/changelog/@unreleased/pr-1591.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ClientConfiguration includes `Optional<HostEventsSink>`
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1591

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -23,7 +23,6 @@ import com.palantir.conjure.java.api.config.service.BasicCredentials;
 import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.UserAgent;
-import com.palantir.conjure.java.okhttp.HostEventsSink;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -23,6 +23,7 @@ import com.palantir.conjure.java.api.config.service.BasicCredentials;
 import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.UserAgent;
+import com.palantir.conjure.java.okhttp.HostEventsSink;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -121,6 +122,9 @@ public interface ClientConfiguration {
 
     /** An identifier to distinguish this caller in the request logs of upstream services. */
     Optional<UserAgent> userAgent();
+
+    /** Per-host failures are recorded using this interface. */
+    Optional<HostEventsSink> hostEventsSink();
 
     @Value.Check
     default void check() {

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/HostEventsSink.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/HostEventsSink.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.java.okhttp;
+package com.palantir.conjure.java.client.config;
 
 /**
  * A listener for responses / exceptions coming from remote hosts.

--- a/client-config/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
@@ -17,9 +17,9 @@
 package com.palantir.conjure.java.okhttp;
 
 /**
- * A listener for responses / exceptions coming from remote hosts when using clients created from {@link OkHttpClients}.
+ * A listener for responses / exceptions coming from remote hosts.
  *
- * <p>We provide a {@link HostMetricsRegistry} implementation of this that turns these events into {@link HostMetrics}
+ * <p>We provide a {@code HostMetricsRegistry} implementation of this that turns these events into {@code HostMetrics}
  * for each remote host.
  */
 public interface HostEventsSink {

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
@@ -50,7 +50,10 @@ public final class Retrofit2ClientBuilder {
 
     public <T> T build(Class<T> serviceClass, UserAgent userAgent) {
         okhttp3.OkHttpClient client = OkHttpClients.create(
-                config, userAgent, config.hostEventsSink().orElse(NoOpHostEventsSink.INSTANCE), serviceClass);
+                config,
+                userAgent,
+                config.hostEventsSink().map(HostEventsSink::from).orElse(NoOpHostEventsSink.INSTANCE),
+                serviceClass);
 
         Retrofit retrofit = new Retrofit.Builder()
                 .client(client)

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
@@ -1,0 +1,100 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.okhttp;
+
+/**
+ * A listener for responses / exceptions coming from remote hosts.
+ *
+ * <p>We provide a {@code HostMetricsRegistry} implementation of this that turns these events into {@code HostMetrics}
+ * for each remote host.
+ * @deprecated prefer super interface
+ */
+@Deprecated
+public interface HostEventsSink extends com.palantir.conjure.java.client.config.HostEventsSink {
+    @Override
+    void record(String serviceName, String hostname, int port, int statusCode, long micros);
+
+    @Override
+    void recordIoException(String serviceName, String hostname, int port);
+
+    @Override
+    default HostEventCallback callback(String serviceName, String hostname, int port) {
+        return new HostEventCallback() {
+            @Override
+            public void record(int statusCode, long micros) {
+                HostEventsSink.this.record(serviceName, hostname, port, statusCode, micros);
+            }
+
+            @Override
+            public void recordIoException() {
+                HostEventsSink.this.recordIoException(serviceName, hostname, port);
+            }
+        };
+    }
+
+    /**
+     * @deprecated prefer super interface
+     */
+    @Deprecated
+    interface HostEventCallback extends com.palantir.conjure.java.client.config.HostEventsSink.HostEventCallback {
+
+        @Override
+        void record(int statusCode, long micros);
+
+        @Override
+        void recordIoException();
+
+        static HostEventCallback from(com.palantir.conjure.java.client.config.HostEventsSink.HostEventCallback other) {
+            if (other instanceof HostEventCallback) {
+                return (HostEventCallback) other;
+            }
+            return new HostEventCallback() {
+                @Override
+                public void record(int statusCode, long micros) {
+                    other.record(statusCode, micros);
+                }
+
+                @Override
+                public void recordIoException() {
+                    other.recordIoException();
+                }
+            };
+        }
+    }
+
+    static HostEventsSink from(com.palantir.conjure.java.client.config.HostEventsSink other) {
+        if (other instanceof HostEventsSink) {
+            return (HostEventsSink) other;
+        }
+        return new HostEventsSink() {
+            @Override
+            public void record(String serviceName, String hostname, int port, int statusCode, long micros) {
+                other.record(serviceName, hostname, port, statusCode, micros);
+            }
+
+            @Override
+            public void recordIoException(String serviceName, String hostname, int port) {
+                other.recordIoException(serviceName, hostname, port);
+            }
+
+            @Override
+            public HostEventCallback callback(String serviceName, String hostname, int port) {
+                return HostEventCallback.from(other.callback(serviceName, hostname, port));
+            }
+        };
+    }
+}

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 package com.palantir.conjure.java.okhttp;
 
 /**
- * A listener for responses / exceptions coming from remote hosts.
+ * A listener for responses / exceptions coming from remote hosts when using clients created from {@link OkHttpClients}.
  *
- * <p>We provide a {@code HostMetricsRegistry} implementation of this that turns these events into {@code HostMetrics}
+ * <p>We provide a {@link HostMetricsRegistry} implementation of this that turns these events into {@link HostMetrics}
  * for each remote host.
  * @deprecated prefer super interface
  */

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostEventsSink.java
@@ -47,6 +47,7 @@ public interface HostEventsSink extends com.palantir.conjure.java.client.config.
     }
 
     /**
+     * .
      * @deprecated prefer super interface
      */
     @Deprecated

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
@@ -19,12 +19,12 @@ package com.palantir.conjure.java.okhttp;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Stopwatch;
+import com.palantir.conjure.java.client.config.HostEventsSink;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Response;
-import com.palantir.conjure.java.client.config.HostEventsSink;
 
 /** Records metrics about the response codes of http requests. */
 final class InstrumentedInterceptor implements Interceptor {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/InstrumentedInterceptor.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Response;
+import com.palantir.conjure.java.client.config.HostEventsSink;
 
 /** Records metrics about the response codes of http requests. */
 final class InstrumentedInterceptor implements Interceptor {

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -37,6 +37,7 @@ import com.palantir.tracing.Tracers;
 import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import java.time.Clock;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -167,7 +168,7 @@ public final class OkHttpClients {
         ClientConfiguration config1 = ClientConfiguration.builder()
                 .from(config)
                 .userAgent(userAgent)
-                .hostEventsSink(hostEventsSink)
+                .hostEventsSink(Optional.ofNullable(hostEventsSink))
                 .build();
 
         return createInternal(
@@ -196,9 +197,7 @@ public final class OkHttpClients {
 
     @VisibleForTesting
     static RemotingOkHttpClient withStableUrisAndBackoff(
-            ClientConfiguration config,
-            Class<?> serviceClass,
-            Supplier<BackoffStrategy> backoffStrategy) {
+            ClientConfiguration config, Class<?> serviceClass, Supplier<BackoffStrategy> backoffStrategy) {
         return createInternal(
                 new OkHttpClient.Builder(), config, serviceClass, !RANDOMIZE, !RESHUFFLE, backoffStrategy);
     }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -197,7 +197,6 @@ public final class OkHttpClients {
     @VisibleForTesting
     static RemotingOkHttpClient withStableUrisAndBackoff(
             ClientConfiguration config,
-            HostEventsSink hostEventsSink,
             Class<?> serviceClass,
             Supplier<BackoffStrategy> backoffStrategy) {
         return createInternal(

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -163,13 +163,16 @@ public final class OkHttpClients {
             Class<?> serviceClass) {
         boolean reshuffle =
                 !config.nodeSelectionStrategy().equals(NodeSelectionStrategy.PIN_UNTIL_ERROR_WITHOUT_RESHUFFLE);
-        ClientConfiguration config1 =
-                ClientConfiguration.builder().from(config).userAgent(userAgent).build();
+
+        ClientConfiguration config1 = ClientConfiguration.builder()
+                .from(config)
+                .userAgent(userAgent)
+                .hostEventsSink(hostEventsSink)
+                .build();
 
         return createInternal(
                 client,
                 config1,
-                hostEventsSink,
                 serviceClass,
                 RANDOMIZE,
                 reshuffle,
@@ -181,8 +184,10 @@ public final class OkHttpClients {
             ClientConfiguration config, HostEventsSink hostEventsSink, Class<?> serviceClass) {
         return createInternal(
                 new OkHttpClient.Builder(),
-                config,
-                hostEventsSink,
+                ClientConfiguration.builder()
+                        .from(config)
+                        .hostEventsSink(hostEventsSink)
+                        .build(),
                 serviceClass,
                 !RANDOMIZE,
                 !RESHUFFLE,
@@ -196,19 +201,12 @@ public final class OkHttpClients {
             Class<?> serviceClass,
             Supplier<BackoffStrategy> backoffStrategy) {
         return createInternal(
-                new OkHttpClient.Builder(),
-                config,
-                hostEventsSink,
-                serviceClass,
-                !RANDOMIZE,
-                !RESHUFFLE,
-                backoffStrategy);
+                new OkHttpClient.Builder(), config, serviceClass, !RANDOMIZE, !RESHUFFLE, backoffStrategy);
     }
 
     private static RemotingOkHttpClient createInternal(
             OkHttpClient.Builder client,
             ClientConfiguration config,
-            HostEventsSink hostEventsSink,
             Class<?> serviceClass,
             boolean randomizeUrlOrder,
             boolean reshuffle,
@@ -256,7 +254,8 @@ public final class OkHttpClients {
         }
         ClientMetrics clientMetrics = ClientMetrics.of(config.taggedMetricRegistry());
         client.addInterceptor(DeprecationWarningInterceptor.create(clientMetrics, serviceClass));
-        client.addInterceptor(InstrumentedInterceptor.create(clientMetrics, hostEventsSink, serviceClass));
+        client.addInterceptor(InstrumentedInterceptor.create(
+                clientMetrics, config.hostEventsSink().orElse(NoOpHostEventsSink.INSTANCE), serviceClass));
         client.addInterceptor(OkhttpTraceInterceptor.INSTANCE);
         UserAgent agent =
                 config.userAgent().orElseThrow(() -> new SafeIllegalArgumentException("UserAgent is required"));

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsRealServerTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsRealServerTest.java
@@ -70,7 +70,6 @@ public class OkHttpClientsRealServerTest extends TestBase {
                             .maxNumRetries(10)
                             .backoffSlotSize(Duration.ofSeconds(3))
                             .build(),
-                    hostEventsSink,
                     OkHttpClientsTest.class,
                     () -> new ReproducibleExponentialBackoff(10, Duration.ofSeconds(3)));
             Future<?> future = executorService.submit((Callable<Void>) () -> {
@@ -122,7 +121,6 @@ public class OkHttpClientsRealServerTest extends TestBase {
                             .maxNumRetries(10)
                             .backoffSlotSize(Duration.ofSeconds(2))
                             .build(),
-                    hostEventsSink,
                     OkHttpClientsTest.class,
                     () -> new ReproducibleExponentialBackoff(10, Duration.ofSeconds(2)));
             Future<?> future = executorService.submit((Callable<Void>) () -> {


### PR DESCRIPTION
## Before this PR

I'm trying to pick up the new fluent client factory interface in WC, but it turns out while 99% of dialogue client logic was in open-source land, the HostEventsSink wiring was kept internal to WC.

I don't really want to regress on this.

## After this PR
==COMMIT_MSG==
ClientConfiguration includes `Optional<HostEventsSink>`
==COMMIT_MSG==

## Possible downsides?
- All the JaxRsClient methods are confusing af because they now have two ways to specify a HostEventsSink. I am so done with this repo.
