### PR TITLE
ConjureClients has a withHostEventsSink method

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,42 +1,9 @@
-versionOverrides: {}
 acceptedBreaks:
-  "4.49.0":
-    com.palantir.conjure.java.runtime:okhttp-clients: []
-    com.palantir.conjure.java.runtime:refresh-utils: []
-    com.palantir.conjure.java.runtime:jetty-http2-agent: []
-    com.palantir.conjure.java.runtime:keystores:
-    - code: "java.class.removed"
-      old: "class com.palantir.conjure.java.config.ssl.pkcs1.Pkcs1Readers"
-      new: null
-      justification: "Replaced by internal implementation that doesn't require service\
-        \ loading"
-    - code: "java.class.removed"
-      old: "interface com.palantir.conjure.java.config.ssl.pkcs1.Pkcs1Reader"
-      new: null
-      justification: "Replaced by internal implementation that doesn't require service\
-        \ loading"
-    com.palantir.conjure.java.runtime:conjure-java-jackson-serialization: []
-    com.palantir.conjure.java.runtime:conjure-scala-jaxrs-client: []
-    com.palantir.conjure.java.runtime:conjure-java-jaxrs-client: []
-    com.palantir.conjure.java.runtime:conjure-java-jersey-server: []
-    com.palantir.conjure.java.runtime:conjure-java-retrofit2-client: []
-    com.palantir.conjure.java.runtime:client-config: []
   "4.37.0":
     com.palantir.conjure.java.runtime:okhttp-clients:
     - code: "java.method.addedToInterface"
-      old: null
       new: "method com.codahale.metrics.Timer com.palantir.conjure.java.okhttp.HostMetrics::getQos()"
       justification: "ABI-safe change to rarely used class, low impact"
-  "4.58.0":
-    com.palantir.conjure.java.runtime:conjure-java-jersey-server:
-    - code: "java.class.visibilityReduced"
-      old: "class com.palantir.conjure.java.server.jersey.JerseyServerMetrics"
-      new: "class com.palantir.conjure.java.server.jersey.JerseyServerMetrics"
-      justification: "Reverting after discussion. Not used by any consumer."
-    - code: "java.method.visibilityReduced"
-      old: "method com.codahale.metrics.Meter com.palantir.conjure.java.server.jersey.JerseyServerMetrics::internalerrorAll(java.lang.String)"
-      new: "method com.codahale.metrics.Meter com.palantir.conjure.java.server.jersey.JerseyServerMetrics::internalerrorAll(java.lang.String)"
-      justification: "Reverting after discussion. Not used by any consumer."
   "4.45.0":
     com.palantir.conjure.java.runtime:conjure-java-jersey-server:
     - code: "java.method.parameterTypeChanged"
@@ -49,40 +16,50 @@ acceptedBreaks:
       new: "parameter void com.palantir.conjure.java.server.jersey.Java8OptionalParamConverterProvider::<init>(===org.glassfish.jersey.internal.inject.InjectionManager===)"
       justification: "Classes are implementation details - only public for injection\
         \ purposes"
+  "4.49.0":
+    com.palantir.conjure.java.runtime:keystores:
+    - code: "java.class.removed"
+      old: "class com.palantir.conjure.java.config.ssl.pkcs1.Pkcs1Readers"
+      justification: "Replaced by internal implementation that doesn't require service\
+        \ loading"
+    - code: "java.class.removed"
+      old: "interface com.palantir.conjure.java.config.ssl.pkcs1.Pkcs1Reader"
+      justification: "Replaced by internal implementation that doesn't require service\
+        \ loading"
+  "4.58.0":
+    com.palantir.conjure.java.runtime:conjure-java-jersey-server:
+    - code: "java.class.visibilityReduced"
+      old: "class com.palantir.conjure.java.server.jersey.JerseyServerMetrics"
+      new: "class com.palantir.conjure.java.server.jersey.JerseyServerMetrics"
+      justification: "Reverting after discussion. Not used by any consumer."
+    - code: "java.method.visibilityReduced"
+      old: "method com.codahale.metrics.Meter com.palantir.conjure.java.server.jersey.JerseyServerMetrics::internalerrorAll(java.lang.String)"
+      new: "method com.codahale.metrics.Meter com.palantir.conjure.java.server.jersey.JerseyServerMetrics::internalerrorAll(java.lang.String)"
+      justification: "Reverting after discussion. Not used by any consumer."
   "4.64.0":
-    com.palantir.conjure.java.runtime:okhttp-clients: []
-    com.palantir.conjure.java.runtime:refresh-utils: []
-    com.palantir.conjure.java.runtime:jetty-http2-agent: []
-    com.palantir.conjure.java.runtime:keystores: []
-    com.palantir.conjure.java.runtime:conjure-java-jackson-serialization: []
-    com.palantir.conjure.java.runtime:conjure-scala-jaxrs-client: []
-    com.palantir.conjure.java.runtime:conjure-java-jaxrs-client: []
-    com.palantir.conjure.java.runtime:conjure-java-jersey-server: []
-    com.palantir.conjure.java.runtime:conjure-java-retrofit2-client: []
     com.palantir.conjure.java.runtime:client-config:
     - code: "java.method.addedToInterface"
-      old: null
       new: "method java.util.Optional<java.lang.Boolean> com.palantir.conjure.java.client.config.ClientConfiguration::enableHttp2()"
       justification: "immutables interfaces are not for extension"
   "4.66.0":
     com.palantir.conjure.java.runtime:client-config:
     - code: "java.method.addedToInterface"
-      old: null
       new: "method java.util.Optional<com.palantir.conjure.java.api.config.service.UserAgent>\
         \ com.palantir.conjure.java.client.config.ClientConfiguration::userAgent()"
       justification: "Added optional field to an immutables interface"
-    com.palantir.conjure.java.runtime:conjure-java-jackson-serialization: []
-    com.palantir.conjure.java.runtime:conjure-java-jaxrs-client: []
-    com.palantir.conjure.java.runtime:conjure-java-jersey-server: []
-    com.palantir.conjure.java.runtime:conjure-java-retrofit2-client: []
-    com.palantir.conjure.java.runtime:conjure-scala-jaxrs-client: []
-    com.palantir.conjure.java.runtime:jetty-http2-agent: []
-    com.palantir.conjure.java.runtime:keystores: []
-    com.palantir.conjure.java.runtime:okhttp-clients: []
-    com.palantir.conjure.java.runtime:refresh-utils: []
   "5.8.0":
     com.palantir.conjure.java.runtime:client-config:
     - code: "java.method.addedToInterface"
       new: "method java.util.Optional<com.palantir.conjure.java.client.config.HostEventsSink>\
         \ com.palantir.conjure.java.client.config.ClientConfiguration::hostEventsSink()"
       justification: "Adding optional field to immutable object won't break people"
+  "5.9.0":
+    com.palantir.conjure.java.runtime:client-config:
+    - code: "java.method.addedToInterface"
+      new: "method T com.palantir.conjure.java.clients.ConjureClients.WithClientOptions<T>::withFailedUrlCooldown(java.time.Duration)"
+      justification: "Compilation break will force implementers to address these methods.\
+        \ Revapi confirms this is NOT an ABI break"
+    - code: "java.method.addedToInterface"
+      new: "method T com.palantir.conjure.java.clients.ConjureClients.WithClientOptions<T>::withHostEventsSink(com.palantir.conjure.java.client.config.HostEventsSink)"
+      justification: "Compilation break will force implementers to address these methods.\
+        \ Revapi confirms this is NOT an ABI break"

--- a/changelog/@unreleased/pr-1592.v2.yml
+++ b/changelog/@unreleased/pr-1592.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: ConjureClients has a withHostEventsSink method to allow modifying the
+    ClientConfiguration HostEventsSink
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1592

--- a/client-config/src/main/java/com/palantir/conjure/java/clients/ConjureClients.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/clients/ConjureClients.java
@@ -21,6 +21,7 @@ import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.conjure.java.client.config.HostEventsSink;
 import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -77,6 +78,9 @@ public final class ConjureClients {
         T withTaggedMetrics(TaggedMetricRegistry metrics);
 
         T withUserAgent(UserAgent agent);
+
+        /** Per-host success/failure information will be recorded to this sink. */
+        T withHostEventsSink(HostEventsSink hostEventsSink);
     }
 
     public interface ToReloadingFactory<U> {

--- a/client-config/src/main/java/com/palantir/conjure/java/clients/ConjureClients.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/clients/ConjureClients.java
@@ -25,6 +25,7 @@ import com.palantir.conjure.java.client.config.HostEventsSink;
 import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.time.Duration;
 
 /** These interfaces are for implementing clientfactories. They are designed to be immutable. */
 public final class ConjureClients {
@@ -64,6 +65,12 @@ public final class ConjureClients {
 
         /** How should a client choose which URI to send requests to. */
         T withNodeSelectionStrategy(NodeSelectionStrategy strategy);
+
+        /**
+         * The amount of time a URL marked as failed should be avoided for subsequent calls. Implementations may
+         * ignore this value.
+         */
+        T withFailedUrlCooldown(Duration duration);
 
         T withClientQoS(ClientConfiguration.ClientQoS value);
 

--- a/client-config/src/test/java/com/palantir/conjure/java/clients/ConjureClientsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/clients/ConjureClientsTest.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.clients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.base.CaseFormat;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
+import com.palantir.conjure.java.client.config.ClientConfiguration;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+public class ConjureClientsTest {
+
+    private static final Map<String, String> INTENTIONALLY_EXCLUDED = ImmutableMap.<String, String>builder()
+            .put("retryOnSocketException", "Not implementing this until we get a request")
+            .put("taggedMetricRegistry", "Already handled by the withTaggedMetrics() method")
+            .put("meshProxy", "ClientConfigurations.of sets this up automatically")
+            .put("proxyCredentials", "ClientConfigurations.of sets this up automatically")
+            .put("sslSocketFactory", "Not expecting users to override these")
+            .put("trustManager", "Not expecting users to override these")
+            .build();
+
+    @Test
+    public void check_WithClientOptions_is_in_sync_with_ClientConfiguration() {
+        Set<String> ymlOptions = methodNames(ServiceConfiguration.class);
+        Set<String> clientConf = methodNames(ClientConfiguration.class);
+        Set<String> withMethods = methodNames(ConjureClients.WithClientOptions.class);
+
+        Sets.SetView<String> onlyConfigurableFromJava = Sets.difference(clientConf, ymlOptions);
+        List<String> unexposedOptions = onlyConfigurableFromJava.stream()
+                .filter(m -> !withMethods.contains("with" + CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_CAMEL, m)))
+                .filter(m -> !INTENTIONALLY_EXCLUDED.containsKey(m))
+                .collect(Collectors.toList());
+
+        assertThat(unexposedOptions)
+                .describedAs("Most ClientConfiguration fields can be set from "
+                        + "YAML in the ServiceConfiguration class, but any *additional* ones must be also settable "
+                        + "from the ConjureClients facade, unless there's a good reason to exclude them.")
+                .isEmpty();
+    }
+
+    private static Set<String> methodNames(Class<?> clazz) {
+        return Arrays.stream(clazz.getMethods())
+                .filter(m -> !Modifier.isStatic(m.getModifiers()) && !m.isDefault())
+                .map(Method::getName)
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
## Before this PR

I added this field to ClientConfiguration, but forgot to expose it in the facade 🤦‍♂️.

## After this PR
==COMMIT_MSG==
ConjureClients has a withHostEventsSink method to allow modifying the ClientConfiguration HostEventsSink
==COMMIT_MSG==

The reflective test is a bit weird, but I think given that I immediately screwed this up it'll probably prevent some mistakes in the future.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

