### PR TITLE
The dialogue feign shim uses content-length requests, not chunked

### DIFF
--- a/changelog/@unreleased/pr-1623.v2.yml
+++ b/changelog/@unreleased/pr-1623.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The dialogue feign shim uses content-length requests, not chunked
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1623

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
@@ -86,8 +86,12 @@ final class DialogueFeignClient implements feign.Client {
 
     @Override
     public feign.Response execute(Request request, Request.Options _options) throws IOException {
-        com.palantir.dialogue.Request.Builder builder =
-                com.palantir.dialogue.Request.builder().body(requestBody(request));
+        com.palantir.dialogue.Request.Builder builder = com.palantir.dialogue.Request.builder();
+        Optional<RequestBody> body = requestBody(request);
+        if (body.isPresent()) {
+            builder.body(body);
+            builder.putHeaderParams(HttpHeaders.CONTENT_LENGTH, Integer.toString(request.body().length));
+        }
         request.headers().forEach((headerName, values) -> {
             if (includeRequestHeader(headerName)) {
                 builder.putAllHeaderParams(headerName, values);

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
@@ -114,7 +114,8 @@ public final class JaxRsClientDialogueEndpointTest {
         assertThat(request.body().get().contentType()).isEqualTo("text/plain");
         assertThat(request.headerParams().asMap())
                 .containsExactly(
-                        new AbstractMap.SimpleImmutableEntry<>("Accept", ImmutableList.of("application/json")));
+                        new AbstractMap.SimpleImmutableEntry<>("Accept", ImmutableList.of("application/json")),
+                        new AbstractMap.SimpleImmutableEntry<>("Content-Length", ImmutableList.of("13")));
     }
 
     @Test
@@ -134,7 +135,9 @@ public final class JaxRsClientDialogueEndpointTest {
         Request request = requestCaptor.getValue();
         assertThat(request.body()).isPresent();
         assertThat(request.body().get().contentType()).isEqualTo("application/json");
-        assertThat(request.headerParams().asMap()).isEmpty();
+
+        assertThat(request.headerParams().asMap())
+                .containsExactly(new AbstractMap.SimpleImmutableEntry<>("Content-Length", ImmutableList.of("15")));
     }
 
     @Test


### PR DESCRIPTION
We already have the length available due to the feign requirements
that all request bodies are encoded to byte arrays. While the
difference between content-length and chunked requests is minimal,
we might as well take advantage of this data.

## After this PR
==COMMIT_MSG==
The dialogue feign shim uses content-length requests, not chunked
==COMMIT_MSG==

