### PR TITLE
Fix unnecessary trailing slash in pathless endpoints

### DIFF
--- a/changelog/@unreleased/pr-1634.v2.yml
+++ b/changelog/@unreleased/pr-1634.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix unnecessary trailing slash in pathless endpoints
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1634

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
@@ -361,8 +361,10 @@ final class DialogueFeignClient implements feign.Client {
             String trailing = target.substring(baseUrl.length() + trailingOffset);
             int queryParamsStart = trailing.indexOf('?');
             String queryPortion = queryParamsStart == -1 ? trailing : trailing.substring(0, queryParamsStart);
-            for (String pathSegment : pathSplitter.split(queryPortion)) {
-                url.pathSegment(urlDecode(pathSegment));
+            if (!queryPortion.isEmpty()) {
+                for (String pathSegment : pathSplitter.split(queryPortion)) {
+                    url.pathSegment(urlDecode(pathSegment));
+                }
             }
             if (queryParamsStart != -1) {
                 String querySegments = trailing.substring(queryParamsStart + 1);

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientPathParamHandlingTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientPathParamHandlingTest.java
@@ -42,7 +42,7 @@ public final class JaxRsClientPathParamHandlingTest extends TestBase {
                 Service.class,
                 AGENT,
                 NoOpHostEventsSink.INSTANCE,
-                createTestConfig("http://localhost:" + server.getPort()));
+                createTestConfig("http://localhost:" + server.getPort() + "/api"));
         MockResponse mockResponse = new MockResponse().setResponseCode(200);
         server.enqueue(mockResponse);
     }
@@ -57,26 +57,36 @@ public final class JaxRsClientPathParamHandlingTest extends TestBase {
         @GET
         @Path("begin/{path}/end")
         void innerPath(@PathParam("path") String path);
+
+        @GET
+        void simple();
     }
 
     @Test
     public void wildcardPathParameterSlashesAreEncoded() throws Exception {
         client.complexPath("foo/bar");
         RecordedRequest takeRequest = server.takeRequest();
-        assertThat(takeRequest.getRequestLine()).isEqualTo("GET /complex/foo%2Fbar HTTP/1.1");
+        assertThat(takeRequest.getRequestLine()).isEqualTo("GET /api/complex/foo%2Fbar HTTP/1.1");
     }
 
     @Test
     public void wildcardPathParameterAllowsEmptyString() throws Exception {
         client.complexPath("");
         RecordedRequest takeRequest = server.takeRequest();
-        assertThat(takeRequest.getRequestLine()).isEqualTo("GET /complex/ HTTP/1.1");
+        assertThat(takeRequest.getRequestLine()).isEqualTo("GET /api/complex/ HTTP/1.1");
     }
 
     @Test
     public void innerPathParameterAllowsEmptyString() throws Exception {
         client.innerPath("");
         RecordedRequest takeRequest = server.takeRequest();
-        assertThat(takeRequest.getRequestLine()).isEqualTo("GET /begin//end HTTP/1.1");
+        assertThat(takeRequest.getRequestLine()).isEqualTo("GET /api/begin//end HTTP/1.1");
+    }
+
+    @Test
+    public void simplestPath() throws Exception {
+        client.simple();
+        RecordedRequest takeRequest = server.takeRequest();
+        assertThat(takeRequest.getRequestLine()).isEqualTo("GET /api HTTP/1.1");
     }
 }


### PR DESCRIPTION
==COMMIT_MSG==
Fix unnecessary trailing slash in pathless endpoints
==COMMIT_MSG==
