### PR TITLE
Support TLSv1.3 ciphers

### DIFF
--- a/changelog/@unreleased/pr-1666.v2.yml
+++ b/changelog/@unreleased/pr-1666.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support TLSv1.3 ciphers
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1666

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
@@ -33,11 +33,13 @@ public final class CipherSuites {
             "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
             "TLS_RSA_WITH_AES_256_CBC_SHA",
             "TLS_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_CHACHA20_POLY1305_SHA256",
             "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-            "TLS_EMPTY_RENEGOTIATION_INFO_SCSV");
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256");
 
     private static final ImmutableList<String> GCM_CIPHER_SUITES = ImmutableList.of(
+            "TLS_AES_256_GCM_SHA384",
+            "TLS_AES_128_GCM_SHA256",
             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
             "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
@@ -46,8 +48,8 @@ public final class CipherSuites {
             "TLS_RSA_WITH_AES_128_GCM_SHA256");
 
     private static final ImmutableList<String> ALL_CIPHER_SUITES = ImmutableList.<String>builder()
-            .addAll(FAST_CIPHER_SUITES)
             .addAll(GCM_CIPHER_SUITES)
+            .addAll(FAST_CIPHER_SUITES)
             .build();
 
     /**


### PR DESCRIPTION
Remove the legacy cipher marker for pre-tls1.2 as nothing
allows older protocols anymore.

==COMMIT_MSG==
Support TLSv1.3 ciphers
==COMMIT_MSG==

