### PR TITLE
Proxy selectors are resilient to DNS changes while the service is running

### DIFF
--- a/changelog/@unreleased/pr-1736.v2.yml
+++ b/changelog/@unreleased/pr-1736.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Proxy selectors are resilient to DNS changes while the service is running
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1736

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -162,7 +162,10 @@ public final class ClientConfigurations {
                         .hostAndPort()
                         .orElseThrow(() -> new SafeIllegalArgumentException(
                                 "Expected to find proxy hostAndPort configuration for HTTP proxy")));
-                InetSocketAddress addr = new InetSocketAddress(hostAndPort.getHost(), hostAndPort.getPort());
+                InetSocketAddress addr =
+                        // Proxy address must not be resolved, otherwise DNS changes while the application
+                        // is running are ignored by the application.
+                        InetSocketAddress.createUnresolved(hostAndPort.getHost(), hostAndPort.getPort());
                 return fixedProxySelectorFor(new Proxy(Proxy.Type.HTTP, addr));
             case MESH:
                 return ProxySelector.getDefault(); // MESH proxy is not a Java proxy

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -30,6 +30,7 @@ import com.palantir.logsafe.testing.Assertions;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -150,6 +151,16 @@ public final class ClientConfigurationsTest {
                 ClientConfigurations.createInetSocketAddress("http://zomp-ovc-gw-1:8888/");
         assertThat(inetSocketAddress.getHostString()).isEqualTo("zomp-ovc-gw-1");
         assertThat(inetSocketAddress.getPort()).isEqualTo(8888);
+    }
+
+    @Test
+    public void testProxyAddressIsNotResolved() {
+        ProxySelector selector = ClientConfigurations.createProxySelector(ProxyConfiguration.of("localhost:80"));
+        List<Proxy> selected = selector.select(URI.create("https://foo"));
+        assertThat(selected).hasOnlyOneElementSatisfying(proxy -> assertThat(proxy.address())
+                .isInstanceOfSatisfying(InetSocketAddress.class, address -> assertThat(address.getAddress())
+                        .as("The address must not be resolved")
+                        .isNull()));
     }
 
     private ServiceConfiguration meshProxyServiceConfig(List<String> theUris, int maxNumRetries) {


### PR DESCRIPTION
==COMMIT_MSG==
Proxy selectors are resilient to DNS changes while the service is running
==COMMIT_MSG==

