### PR TITLE
Make dialogue-target an api dependency

### DIFF
--- a/changelog/@unreleased/pr-1802.v2.yml
+++ b/changelog/@unreleased/pr-1802.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    Make dialogue-target an api dependency
+
+    `ConjureRuntime` and `Channel` classes are exposed in `JaxRsClient` public API. Unless a consumer pulls in dialogue-target from some other dependency, this results in a `NoClassDefFoundError`.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1802

--- a/conjure-java-jaxrs-client/build.gradle
+++ b/conjure-java-jaxrs-client/build.gradle
@@ -9,11 +9,11 @@ dependencies {
     api "javax.ws.rs:javax.ws.rs-api"
     // TODO(dsanduleac): Should be implementation, but can't because we expose feign.TextDelegateEncoder
     api "com.netflix.feign:feign-core"
+    api "com.palantir.dialogue:dialogue-target"
 
     implementation "com.palantir.dialogue:dialogue-apache-hc5-client"
     implementation "com.palantir.dialogue:dialogue-core"
     implementation "com.palantir.dialogue:dialogue-serde"
-    implementation "com.palantir.dialogue:dialogue-target"
 
     implementation project(":conjure-java-jackson-serialization")
     implementation project(":keystores")


### PR DESCRIPTION
`ConjureRuntime` and `Channel` classes are exposed in `JaxRsClient` public API. Unless a consumer pulls in dialogue-target from some other dependency, this results in a `NoClassDefFoundError` at runtime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-java-runtime/1802)
<!-- Reviewable:end -->
