### PR TITLE
Always enable secure GCM ciphers by default

### DIFF
--- a/changelog/@unreleased/pr-1804.v2.yml
+++ b/changelog/@unreleased/pr-1804.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Always enable secure GCM ciphers by default, previously java 8 clients
+    avoided GCM ciphers by default.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1804

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -33,8 +33,6 @@ import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -52,7 +50,9 @@ public final class ClientConfigurations {
     private static final Duration DEFAULT_FAILED_URL_COOLDOWN = Duration.ZERO;
     // GCM ciphers perform poorly using a java 1.8 runtime, but improve significantly in 9 and beyond.
     // See http://openjdk.java.net/jeps/246
-    private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = !isJava8();
+    // Given the low volume of services still using java8, it's safer to avoid failing handshakes
+    // at a performance cost.
+    private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = true;
     private static final boolean DEFAULT_FALLBACK_TO_COMMON_NAME_VERIFICATION = false;
     private static final NodeSelectionStrategy DEFAULT_NODE_SELECTION_STRATEGY = NodeSelectionStrategy.PIN_UNTIL_ERROR;
     private static final int DEFAULT_MAX_NUM_RETRIES = 4;
@@ -230,10 +230,5 @@ public final class ClientConfigurations {
         public String toString() {
             return "FixedProxySelector{proxy=" + proxy + '}';
         }
-    }
-
-    private static boolean isJava8() {
-        return AccessController.doPrivileged(
-                (PrivilegedAction<Boolean>) () -> "1.8".equals(System.getProperty("java.specification.version")));
     }
 }

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -58,9 +58,7 @@ public final class ClientConfigurationsTest {
         assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
         assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(5));
         assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(5));
-        assertThat(actual.enableGcmCipherSuites())
-                .as("GCM ciphers should be used by default with JRE9+")
-                .isNotEqualTo("1.8".equals(System.getProperty("java.specification.version")));
+        assertThat(actual.enableGcmCipherSuites()).isTrue();
         assertThat(actual.enableHttp2()).isEmpty();
         assertThat(actual.fallbackToCommonNameVerification()).isFalse();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);
@@ -79,9 +77,7 @@ public final class ClientConfigurationsTest {
         assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
         assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(5));
         assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(5));
-        assertThat(actual.enableGcmCipherSuites())
-                .as("GCM ciphers should be used by default with JRE9+")
-                .isNotEqualTo("1.8".equals(System.getProperty("java.specification.version")));
+        assertThat(actual.enableGcmCipherSuites()).isTrue();
         assertThat(actual.enableHttp2()).isEmpty();
         assertThat(actual.fallbackToCommonNameVerification()).isFalse();
         assertThat(actual.proxy().select(URI.create("https://foo"))).containsExactly(Proxy.NO_PROXY);


### PR DESCRIPTION
Previously GCM ciphers were disabled by default on java 8 due
to performance problems, however at this point the vast majority
of services have upgraded and there's greater risk in continuing
to use less secure cipher suites than the performance impact on a
few straggler services.
For now clients may still override `enable-gcm-cipher-suites: false`
to opt out of GCM ciphers, however we have no intention of allowing
servers to use CBC ciphers moving forward.

==COMMIT_MSG==
Always enable secure GCM ciphers by default, previously java 8 clients avoided GCM ciphers by default.
==COMMIT_MSG==

## Possible downsides?
Some java8 services may experience degraded performance.

