### PR TITLE
Fix PemX509Certificate deserialization from a JSON string

### DIFF
--- a/changelog/@unreleased/pr-1834.v2.yml
+++ b/changelog/@unreleased/pr-1834.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix PemX509Certificate deserialization from a JSON string
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1834

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/PemX509Certificate.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/PemX509Certificate.java
@@ -16,14 +16,15 @@
 
 package com.palantir.conjure.java.config.ssl;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.logsafe.Preconditions;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, jdkOnly = true)
 @JsonSerialize(as = ImmutablePemX509Certificate.class)
-@JsonDeserialize(as = ImmutablePemX509Certificate.class)
 public abstract class PemX509Certificate {
 
     /**
@@ -33,9 +34,16 @@ public abstract class PemX509Certificate {
      */
     public abstract String pemCertificate();
 
+    @JsonCreator(mode = Mode.DELEGATING)
     public static PemX509Certificate of(String pemCertificate) {
         return ImmutablePemX509Certificate.builder()
                 .pemCertificate(pemCertificate)
                 .build();
+    }
+
+    // Exists for backcompat, PemX509Certificate may be deserialized from either a String or JSON object.
+    @JsonCreator(mode = Mode.DELEGATING)
+    private static PemX509Certificate of(ImmutablePemX509Certificate immutablePemX509Certificate) {
+        return Preconditions.checkNotNull(immutablePemX509Certificate, "PemX509Certificate is required");
     }
 }


### PR DESCRIPTION
## Before this PR
Using jackson 2.12.0, deserialization from a string into PemX509Certificate failed. It's not clear that such deserialization was intended based on the shape of the PemX509Certificate object, but that's how it's used in some places. Best to avoid failing at runtime.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix PemX509Certificate deserialization from a JSON string
==COMMIT_MSG==

## Possible downsides?
none

