### PR TITLE
FROM_ENVIRONMENT proxy selector to behave as no proxy if env var not set

### DIFF
--- a/changelog/@unreleased/pr-1874.v2.yml
+++ b/changelog/@unreleased/pr-1874.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`ClientConfigurations` built with a `FROM_ENVIRONMENT` proxy will now behave as if there is no proxy if the `https_proxy` environment variable is not set, instead of throwing.'
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1874

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -23,8 +23,6 @@ import com.palantir.conjure.java.api.config.service.ProxyConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
-import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import java.io.IOException;
@@ -151,10 +149,10 @@ public final class ClientConfigurations {
             case DIRECT:
                 return fixedProxySelectorFor(Proxy.NO_PROXY);
             case FROM_ENVIRONMENT:
-                String defaultEnvProxy = Preconditions.checkNotNull(
-                        System.getenv(ENV_HTTPS_PROXY),
-                        "Missing environment variable",
-                        SafeArg.of("name", ENV_HTTPS_PROXY));
+                String defaultEnvProxy = System.getenv(ENV_HTTPS_PROXY);
+                if (defaultEnvProxy == null) {
+                    return fixedProxySelectorFor(Proxy.NO_PROXY);
+                }
                 InetSocketAddress address = createInetSocketAddress(defaultEnvProxy);
                 return fixedProxySelectorFor(new Proxy(Proxy.Type.HTTP, address));
             case HTTP:

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -23,6 +23,7 @@ import com.palantir.conjure.java.api.config.service.ProxyConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import java.io.IOException;
@@ -36,9 +37,13 @@ import java.util.List;
 import java.util.Optional;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Utilities for creating {@link ClientConfiguration} instances. */
 public final class ClientConfigurations {
+
+    private static final Logger log = LoggerFactory.getLogger(ClientConfigurations.class);
 
     // Defaults for parameters that are optional in ServiceConfiguration.
     private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(10);
@@ -151,8 +156,10 @@ public final class ClientConfigurations {
             case FROM_ENVIRONMENT:
                 String defaultEnvProxy = System.getenv(ENV_HTTPS_PROXY);
                 if (defaultEnvProxy == null) {
+                    log.info("Proxy environment variable not set, using no proxy");
                     return fixedProxySelectorFor(Proxy.NO_PROXY);
                 }
+                log.info("Using proxy from environment variable", UnsafeArg.of("proxy", defaultEnvProxy));
                 InetSocketAddress address = createInetSocketAddress(defaultEnvProxy);
                 return fixedProxySelectorFor(new Proxy(Proxy.Type.HTTP, address));
             case HTTP:


### PR DESCRIPTION
## Before this PR
`ClientConfigurations` built with a `FROM_ENVIRONMENT` proxy would throw if the `https_proxy` environment variable was not set.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`ClientConfigurations` built with a `FROM_ENVIRONMENT` proxy will now behave as if there is no proxy if the `https_proxy` environment variable is not set, instead of throwing.
==COMMIT_MSG==

## Possible downsides?
Users who were relying on the exception being thrown as a validation that the proxy is set might now see the client silently be constructed without a proxy.
