### PR TITLE
Use SOURCE retention for immutables style annotations

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -63,6 +63,12 @@ acceptedBreaks:
       new: "method T com.palantir.conjure.java.clients.ConjureClients.WithClientOptions<T>::withHostEventsSink(com.palantir.conjure.java.client.config.HostEventsSink)"
       justification: "Compilation break will force implementers to address these methods.\
         \ Revapi confirms this is NOT an ABI break"
+  "6.13.0":
+    com.palantir.conjure.java.runtime:client-config:
+    - code: "java.class.visibilityReduced"
+      old: "@interface com.palantir.conjure.java.client.config.ImmutablesStyle"
+      new: "@interface com.palantir.conjure.java.client.config.ImmutablesStyle"
+      justification: "Hide internal annotation"
   "6.4.0":
     com.palantir.conjure.java.runtime:conjure-java-jersey-server:
     - code: "java.method.removed"

--- a/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientApiTest.java
+++ b/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientApiTest.java
@@ -320,7 +320,7 @@ public final class Retrofit2ClientApiTest extends TestBase {
                 AGENT,
                 new HostMetricsRegistry(),
                 ClientConfiguration.builder()
-                        .from(createTestConfig("https://invalid.service.dev"))
+                        .from(createTestConfig("https://service.invalid"))
                         .connectTimeout(Duration.ofMillis(10))
                         .build());
 
@@ -375,7 +375,7 @@ public final class Retrofit2ClientApiTest extends TestBase {
                 AGENT,
                 new HostMetricsRegistry(),
                 ClientConfiguration.builder()
-                        .from(createTestConfig("https://invalid.service.dev"))
+                        .from(createTestConfig("https://service.invalid"))
                         .connectTimeout(Duration.ofMillis(10))
                         .build());
 

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/ImmutablesStyle.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/ImmutablesStyle.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.java.client.config;
+package com.palantir.conjure.java.config.ssl;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/PemX509Certificate.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/PemX509Certificate.java
@@ -23,7 +23,7 @@ import com.palantir.logsafe.Preconditions;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, jdkOnly = true)
+@ImmutablesStyle
 @JsonSerialize(as = ImmutablePemX509Certificate.class)
 public abstract class PemX509Certificate {
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiterListener.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ConcurrencyLimiterListener.java
@@ -18,7 +18,6 @@ package com.palantir.conjure.java.okhttp;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.netflix.concurrency.limits.Limiter;
-import com.palantir.conjure.java.client.config.ImmutablesStyle;
 import org.immutables.value.Value;
 
 @Value.Modifiable

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetricsRegistry.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/HostMetricsRegistry.java
@@ -19,7 +19,6 @@ package com.palantir.conjure.java.okhttp;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.Suppliers;
-import com.palantir.conjure.java.client.config.ImmutablesStyle;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import java.time.Clock;

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ImmutablesStyle.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ImmutablesStyle.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.java.client.config;
+package com.palantir.conjure.java.okhttp;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemotingOkHttpCall.java
@@ -658,6 +658,7 @@ final class RemotingOkHttpCall extends ForwardingCall {
         private final UnknownRemoteException unknownRemoteException;
 
         private IoUnknownRemoteException(UnknownRemoteException unknownRemoteException) {
+            super(unknownRemoteException);
             this.unknownRemoteException = unknownRemoteException;
         }
 

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/Tags.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/Tags.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.okhttp;
 
-import com.palantir.conjure.java.client.config.ImmutablesStyle;
 import com.palantir.tracing.DetachedSpan;
 import java.util.function.Supplier;
 import org.immutables.value.Value;


### PR DESCRIPTION
See https://github.com/immutables/immutables/issues/291.

Example of similar fix in https://github.com/palantir/conjure-java-runtime-api/pull/369.

This eliminates compilation warnings for consumers that do not directly depend on immutables.