### PR TITLE
Revert hiding ImmutablesStyle

### DIFF
--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ImmutablesStyle.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ImmutablesStyle.java
@@ -25,4 +25,4 @@ import org.immutables.value.Value;
 @Target({ElementType.PACKAGE, ElementType.TYPE})
 @Retention(RetentionPolicy.SOURCE)
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, overshadowImplementation = true, jdkOnly = true)
-@interface ImmutablesStyle {}
+public @interface ImmutablesStyle {}


### PR DESCRIPTION
Reverts the breaking change in https://github.com/palantir/conjure-java-runtime/pull/1897 because the downstream effects were more painful than anticipated.