### PR TITLE
Provide a non-deprecated NoOpHostEventsSink implementation

### DIFF
--- a/changelog/@unreleased/pr-1959.v2.yml
+++ b/changelog/@unreleased/pr-1959.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Provide a non-deprecated NoOpHostEventsSink implementation
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1959

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/NoOpHostEventsSink.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/NoOpHostEventsSink.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.config;
+
+/**
+ * A no-op implementation of {@link HostEventsSink} which discards all inputs.
+ */
+public enum NoOpHostEventsSink implements HostEventsSink {
+    INSTANCE;
+
+    @Override
+    public void record(String _serviceName, String _hostname, int _port, int _statusCode, long _micros) {}
+
+    @Override
+    public void recordIoException(String _serviceName, String _hostname, int _port) {}
+
+    @Override
+    public HostEventCallback callback(String _serviceName, String _hostname, int _port) {
+        return NoOpHostEventCallback.INSTANCE;
+    }
+
+    private enum NoOpHostEventCallback implements HostEventCallback {
+        INSTANCE;
+
+        @Override
+        public void record(int _statusCode, long _micros) {}
+
+        @Override
+        public void recordIoException() {}
+    }
+}


### PR DESCRIPTION
==COMMIT_MSG==
Provide a non-deprecated NoOpHostEventsSink implementation
==COMMIT_MSG==
