### PR TITLE
Feign expanders are not reflectively created

### DIFF
--- a/changelog/@unreleased/pr-1989.v2.yml
+++ b/changelog/@unreleased/pr-1989.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Feign expanders are not reflectively created
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/1989

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Expanders.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Expanders.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import feign.MethodMetadata;
+import feign.Param.Expander;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Utility functionality to safely add an expander instance rather than a class reference. */
+final class Expanders {
+
+    static void add(MethodMetadata metadata, int index, Expander instance) {
+        Map<Integer, Expander> expanders = metadata.indexToExpander();
+        if (expanders == null) {
+            Map<Integer, Class<? extends Expander>> expanderClasses = metadata.indexToExpanderClass();
+            if (!expanderClasses.isEmpty()) {
+                throw new SafeIllegalStateException(
+                        "An expander class has unexpectedly been registered",
+                        SafeArg.of("unexpected", expanderClasses));
+            }
+            expanders = new HashMap<>();
+            metadata.indexToExpander(expanders);
+        }
+        expanders.put(index, instance);
+    }
+
+    private Expanders() {}
+}

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaEmptyOptionalExpander.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaEmptyOptionalExpander.java
@@ -25,6 +25,7 @@ import java.util.Objects;
  * {@link Object#toString()} of the value otherwise.
  */
 public final class GuavaEmptyOptionalExpander implements Expander {
+    public static final Expander INSTANCE = new GuavaEmptyOptionalExpander();
 
     @Override
     public String expand(Object value) {

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaNullOptionalExpander.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaNullOptionalExpander.java
@@ -25,6 +25,7 @@ import java.util.Objects;
  * of the value otherwise.
  */
 public final class GuavaNullOptionalExpander implements Expander {
+    public static final Expander INSTANCE = new GuavaNullOptionalExpander();
 
     @Override
     public String expand(Object value) {

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaOptionalAwareContract.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaOptionalAwareContract.java
@@ -51,9 +51,9 @@ public final class GuavaOptionalAwareContract extends AbstractDelegatingContract
                 FluentIterable<Class<?>> paramAnnotations =
                         FluentIterable.from(Lists.newArrayList(annotations[i])).transform(EXTRACT_CLASS);
                 if (paramAnnotations.contains(HeaderParam.class)) {
-                    metadata.indexToExpanderClass().put(i, GuavaEmptyOptionalExpander.class);
+                    Expanders.add(metadata, i, GuavaEmptyOptionalExpander.INSTANCE);
                 } else if (paramAnnotations.contains(QueryParam.class)) {
-                    metadata.indexToExpanderClass().put(i, GuavaNullOptionalExpander.class);
+                    Expanders.add(metadata, i, GuavaNullOptionalExpander.INSTANCE);
                 } else if (paramAnnotations.contains(PathParam.class)) {
                     throw new RuntimeException(String.format(
                             "Cannot use Guava Optionals with PathParams. (Class: %s, Method: %s, Param: arg%d)",

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8EmptyOptionalDoubleExpander.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8EmptyOptionalDoubleExpander.java
@@ -26,6 +26,7 @@ import java.util.OptionalDouble;
  * of the value otherwise.
  */
 public final class Java8EmptyOptionalDoubleExpander implements Expander {
+    public static final Expander INSTANCE = new Java8EmptyOptionalDoubleExpander();
 
     @Override
     public String expand(Object value) {

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8EmptyOptionalExpander.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8EmptyOptionalExpander.java
@@ -26,6 +26,7 @@ import java.util.Optional;
  * value otherwise.
  */
 public final class Java8EmptyOptionalExpander implements Expander {
+    public static final Expander INSTANCE = new Java8EmptyOptionalExpander();
 
     @Override
     public String expand(Object value) {

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8EmptyOptionalIntExpander.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8EmptyOptionalIntExpander.java
@@ -26,6 +26,7 @@ import java.util.OptionalInt;
  * the value otherwise.
  */
 public final class Java8EmptyOptionalIntExpander implements Expander {
+    public static final Expander INSTANCE = new Java8EmptyOptionalIntExpander();
 
     @Override
     public String expand(Object value) {

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8EmptyOptionalLongExpander.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8EmptyOptionalLongExpander.java
@@ -26,6 +26,7 @@ import java.util.OptionalLong;
  * the value otherwise.
  */
 public final class Java8EmptyOptionalLongExpander implements Expander {
+    public static final Expander INSTANCE = new Java8EmptyOptionalLongExpander();
 
     @Override
     public String expand(Object value) {

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8NullOptionalDoubleExpander.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8NullOptionalDoubleExpander.java
@@ -26,6 +26,7 @@ import java.util.OptionalDouble;
  * value otherwise.
  */
 public final class Java8NullOptionalDoubleExpander implements Expander {
+    public static final Expander INSTANCE = new Java8NullOptionalDoubleExpander();
 
     @Override
     public String expand(Object value) {

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8NullOptionalExpander.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8NullOptionalExpander.java
@@ -25,6 +25,7 @@ import java.util.Optional;
  * Expands Optional by using null for {@link Optional#empty()} and the {@link Object#toString()} of the value otherwise.
  */
 public final class Java8NullOptionalExpander implements Expander {
+    public static final Expander INSTANCE = new Java8NullOptionalExpander();
 
     @Override
     public String expand(Object value) {

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8NullOptionalIntExpander.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8NullOptionalIntExpander.java
@@ -26,6 +26,7 @@ import java.util.OptionalInt;
  * otherwise.
  */
 public final class Java8NullOptionalIntExpander implements Expander {
+    public static final Expander INSTANCE = new Java8NullOptionalIntExpander();
 
     @Override
     public String expand(Object value) {

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8NullOptionalLongExpander.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8NullOptionalLongExpander.java
@@ -26,6 +26,7 @@ import java.util.OptionalLong;
  * otherwise.
  */
 public final class Java8NullOptionalLongExpander implements Expander {
+    public static final Expander INSTANCE = new Java8NullOptionalLongExpander();
 
     @Override
     public String expand(Object value) {


### PR DESCRIPTION
Stateless singleton instances may be reused instead.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Feign expanders are not reflectively created
==COMMIT_MSG==

