### PR TITLE
Propagate error code and name for 401 and 403 responses

### DIFF
--- a/changelog/@unreleased/pr-2019.v2.yml
+++ b/changelog/@unreleased/pr-2019.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Jersey endpoints now preserve the error code and error name when propagating
+    remote exceptions with 401 or 403 status codes.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2019

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
@@ -22,7 +22,6 @@ import com.palantir.logsafe.SafeArg;
 import java.util.UUID;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.ExceptionMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,25 +77,13 @@ abstract class JsonExceptionMapper<T extends Throwable> extends ListenableExcept
     }
 
     static Response createResponse(int httpErrorCode, String errorCode, String errorName, String errorInstanceId) {
-        ResponseBuilder builder = Response.status(httpErrorCode);
-        try {
-            builder.entity(SerializableError.builder()
-                            .errorCode(errorCode)
-                            .errorName(errorName)
-                            .errorInstanceId(errorInstanceId)
-                            .build())
-                    .type(MediaType.APPLICATION_JSON);
-        } catch (RuntimeException e) {
-            log.warn(
-                    "Unable to translate exception to json",
-                    SafeArg.of("errorInstanceId", errorInstanceId),
-                    SafeArg.of("errorName", errorName),
-                    e);
-            builder = Response.status(httpErrorCode);
-            builder.type(MediaType.TEXT_PLAIN);
-            builder.entity("Unable to translate exception to json. Refer to the server logs with this errorInstanceId: "
-                    + errorInstanceId);
-        }
-        return builder.build();
+        return Response.status(httpErrorCode)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(SerializableError.builder()
+                        .errorCode(errorCode)
+                        .errorName(errorName)
+                        .errorInstanceId(errorInstanceId)
+                        .build())
+                .build();
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
@@ -59,7 +59,7 @@ final class RemoteExceptionMapper extends ListenableExceptionMapper<RemoteExcept
                     "Encountered a remote exception",
                     SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
                     SafeArg.of("errorName", exception.getError().errorName()),
-                    SafeArg.of("status", exception.getStatus()),
+                    SafeArg.of("statusCode", exception.getStatus()),
                     exception);
 
             return Response.status(exception.getStatus())
@@ -75,7 +75,7 @@ final class RemoteExceptionMapper extends ListenableExceptionMapper<RemoteExcept
                     "Encountered a remote exception. Mapping to an internal error before propagating",
                     SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
                     SafeArg.of("errorName", exception.getError().errorName()),
-                    SafeArg.of("status", exception.getStatus()),
+                    SafeArg.of("statusCode", exception.getStatus()),
                     exception);
 
             ServiceException propagatedException = new ServiceException(ErrorType.INTERNAL, exception);

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/RemoteExceptionMapper.java
@@ -40,8 +40,8 @@ import org.slf4j.LoggerFactory;
  * response is then thrown as a {@link RemoteException} at the call point in server A. If server A does not catch this
  * exception and it raises up the call stack back into Jersey, execution enters this {@link RemoteExceptionMapper}.
  *
- * <p>To preserve debuggability, the exception and HTTP status code from B's exception are logged at WARN level, but not
- * propagated to caller to avoid an unintentional dependency on the remote exception.
+ * <p>Exception with HTTP status codes other than 401 and 403 are not propagated to caller to avoid an unintentional
+ * dependency on the remote exception.
  */
 @Provider
 final class RemoteExceptionMapper extends ListenableExceptionMapper<RemoteException> {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
@@ -21,7 +21,6 @@ import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.SafeArg;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,23 +54,13 @@ final class ServiceExceptionMapper extends ListenableExceptionMapper<ServiceExce
                     exception);
         }
 
-        ResponseBuilder builder = Response.status(httpStatus);
-        try {
-            SerializableError error = SerializableError.builder()
-                    .from(SerializableError.forException(exception))
-                    .build();
-            builder.type(MediaType.APPLICATION_JSON);
-            builder.entity(error);
-        } catch (RuntimeException e) {
-            log.warn(
-                    "Unable to translate exception to json",
-                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
-                    e);
-            // simply write out the exception message
-            builder.type(MediaType.TEXT_PLAIN);
-            builder.entity("Unable to translate exception to json. Refer to the server logs with this errorInstanceId: "
-                    + exception.getErrorInstanceId());
-        }
-        return builder.build();
+        SerializableError error = SerializableError.builder()
+                .from(SerializableError.forException(exception))
+                .build();
+
+        return Response.status(httpStatus)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(error)
+                .build();
     }
 }

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
@@ -54,13 +54,9 @@ final class ServiceExceptionMapper extends ListenableExceptionMapper<ServiceExce
                     exception);
         }
 
-        SerializableError error = SerializableError.builder()
-                .from(SerializableError.forException(exception))
-                .build();
-
         return Response.status(httpStatus)
                 .type(MediaType.APPLICATION_JSON)
-                .entity(error)
+                .entity(SerializableError.forException(exception))
                 .build();
     }
 }

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
@@ -121,6 +121,7 @@ public final class ExceptionMappingTest {
         assertThat(error.errorInstanceId()).isEqualTo("errorInstanceId");
         assertThat(error.errorCode()).isEqualTo(ErrorType.INTERNAL.code().toString());
         assertThat(error.errorName()).isEqualTo(ErrorType.INTERNAL.name());
+        assertThat(error.parameters()).isEmpty();
     }
 
     @Test
@@ -131,8 +132,9 @@ public final class ExceptionMappingTest {
 
         SerializableError error = response.readEntity(SerializableError.class);
         assertThat(error.errorInstanceId()).isEqualTo("errorInstanceId");
-        assertThat(error.errorCode()).isEqualTo(ErrorType.UNAUTHORIZED.code().toString());
-        assertThat(error.errorName()).isEqualTo(ErrorType.UNAUTHORIZED.name());
+        assertThat(error.errorCode()).isEqualTo("errorCode");
+        assertThat(error.errorName()).isEqualTo("errorName");
+        assertThat(error.parameters()).isEmpty();
     }
 
     @Test
@@ -143,9 +145,9 @@ public final class ExceptionMappingTest {
 
         SerializableError error = response.readEntity(SerializableError.class);
         assertThat(error.errorInstanceId()).isEqualTo("errorInstanceId");
-        assertThat(error.errorCode())
-                .isEqualTo(ErrorType.PERMISSION_DENIED.code().toString());
-        assertThat(error.errorName()).isEqualTo(ErrorType.PERMISSION_DENIED.name());
+        assertThat(error.errorCode()).isEqualTo("errorCode");
+        assertThat(error.errorName()).isEqualTo("errorName");
+        assertThat(error.parameters()).isEmpty();
     }
 
     @Test

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
@@ -275,6 +275,7 @@ public final class ExceptionMappingTest {
                             .errorInstanceId("errorInstanceId")
                             .errorCode("errorCode")
                             .errorName("errorName")
+                            .putParameters("arg", "value")
                             .build(),
                     REMOTE_EXCEPTION_STATUS_CODE);
         }
@@ -286,6 +287,7 @@ public final class ExceptionMappingTest {
                             .errorInstanceId("errorInstanceId")
                             .errorCode("errorCode")
                             .errorName("errorName")
+                            .putParameters("arg", "value")
                             .build(),
                     UNAUTHORIZED_STATUS_CODE);
         }
@@ -297,6 +299,7 @@ public final class ExceptionMappingTest {
                             .errorInstanceId("errorInstanceId")
                             .errorCode("errorCode")
                             .errorName("errorName")
+                            .putParameters("arg", "value")
                             .build(),
                     PERMISSION_DENIED_STATUS_CODE);
         }


### PR DESCRIPTION
## Context
Our internal authorization service throws specific, useful errors when writes are denied due to lack of permissions or constraint violations.

We often want these errors to be visible to end users so they can understand why a particular request failed. Unfortunately, there are often multiple services between end users and the authorization service. In order to communicate these errors to end users, we would have to define these errors in a very large number of services and add manual logic to propagate them.

The corresponding conjure-java PR for Undertow endpoints is https://github.com/palantir/conjure-java/pull/1399.


## Before this PR
Remote exceptions with 401 and 403 statuses are propagate as the corresponding generic `ErrorType`.

## After this PR
Remote exceptions with 401 and 403 statuses are propagated preserving the error code and error name. Parameters are still not propagated.