### PR TITLE
[controversial] eliminate warnings from afterburner (blocker for Java 17)

### DIFF
--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -129,10 +129,18 @@ public final class ObjectMappers {
      * </ul>
      */
     public static ObjectMapper withDefaultModules(ObjectMapper mapper) {
+        AfterburnerModule afterburnerModule = new AfterburnerModule();
+
+        // Disabling this avoids 'Illegal reflective access' warnings on Java 9+
+        // (https://github.com/FasterXML/jackson-modules-base/issues/37).
+        // Downside is that only 'public' properties can be accessed, whereas before 'protected' and 'package access'
+        // properties can be accessed.
+        afterburnerModule.setUseValueClassLoader(false);
+
         return mapper.registerModule(new GuavaModule())
                 .registerModule(new ShimJdk7Module())
                 .registerModule(new Jdk8Module().configureAbsentsAsNulls(true))
-                .registerModule(new AfterburnerModule())
+                .registerModule(afterburnerModule)
                 .registerModule(new JavaTimeModule())
                 .registerModule(new LenientLongModule())
                 // we strongly recommend using built-in java.time classes instead of joda ones. Joda deserialization

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -141,11 +141,11 @@ public final class ObjectMappersTest {
         assertThat(MAPPER.readValue("{\"value\":\"1\"}", LongBean.class)).isEqualTo(new LongBean(1L));
     }
 
-    static final class LongBean {
+    public static final class LongBean {
         @JsonProperty
         private long value;
 
-        LongBean() {}
+        public LongBean() {}
 
         LongBean(long value) {
             setValue(value);
@@ -199,11 +199,11 @@ public final class ObjectMappersTest {
                 .isEqualTo(new OptionalLongBean(OptionalLong.of(1L)));
     }
 
-    static final class OptionalLongBean {
+    public static final class OptionalLongBean {
         @JsonProperty
         private OptionalLong value = OptionalLong.empty();
 
-        OptionalLongBean() {}
+        public OptionalLongBean() {}
 
         OptionalLongBean(OptionalLong value) {
             setValue(value);


### PR DESCRIPTION
## Before this PR

The LTS Java 17  arriving in September has [JEP 403: Strongly Encapsulate JDK Internals](https://openjdk.java.net/jeps/403) which is gonna cause sad times for afterburner's calls to `java.lang.ClassLoader.findLoadedClass`.

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.fasterxml.jackson.module.afterburner.util.MyClassLoader (file:/Users/dfox/.gradle/caches/modules-2/files-2.1/com.fasterxml.jackson.module/jackson-module-afterburner/2.12.3/500ccbff14a9fb0d6ae9338c39b2d7822c5b2c05/jackson-module-afterburner-2.12.3.jar) to method java.lang.ClassLoader.findLoadedClass(java.lang.String)
WARNING: Please consider reporting this to the maintainers of com.fasterxml.jackson.module.afterburner.util.MyClassLoader
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

Apparently this one setting gets rid of the problem: https://github.com/FasterXML/jackson-modules-base/issues/37#issuecomment-414137656

## After this PR
==COMMIT_MSG==
ObjectMappers configure the Jackson Afterburner module differently in order to eliminate `An illegal reflective access operation has occurred` warnings which will become hard blockers in Java 17.

Unfortunately this means afterburner will no longer be able to construct instances of package private objects, so any package private objects will no longer deserialize).
==COMMIT_MSG==

## Possible downsides?

- Honestly I think we can't actually merge this, it'll just cause horrible P0s where some project didn't realize they had package-private objects deep in their DB somewhere.

