### PR TITLE
DialogueFeignClient Endpoint implements modern `renderPath`

### DIFF
--- a/changelog/@unreleased/pr-2100.v2.yml
+++ b/changelog/@unreleased/pr-2100.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: DialogueFeignClient Endpoint implements modern `renderPath`
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2100

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
@@ -56,7 +56,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -355,7 +354,7 @@ final class DialogueFeignClient implements feign.Client {
         }
 
         @Override
-        public void renderPath(Map<String, String> _params, UrlBuilder url) {
+        public void renderPath(ListMultimap<String, String> _params, UrlBuilder url) {
             String target = request.url();
             Preconditions.checkState(
                     target.startsWith(baseUrl),


### PR DESCRIPTION
==COMMIT_MSG==
DialogueFeignClient Endpoint implements modern `renderPath`
==COMMIT_MSG==

