### PR TITLE
CJR CipherSuites list is more restrictive, avoiding less secure ciphers

### DIFF
--- a/changelog/@unreleased/pr-2104.v2.yml
+++ b/changelog/@unreleased/pr-2104.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: CJR CipherSuites list is more restrictive, avoiding less secure ciphers
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2104

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableList;
 
 public final class CipherSuites {
 
-    private static final ImmutableList<String> FAST_CIPHER_SUITES = ImmutableList.of(
+    private static final ImmutableList<String> OTHER_CIPHER_SUITES = ImmutableList.of(
             "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
             "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
             "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
@@ -43,7 +43,7 @@ public final class CipherSuites {
 
     private static final ImmutableList<String> ALL_CIPHER_SUITES = ImmutableList.<String>builder()
             .addAll(GCM_CIPHER_SUITES)
-            .addAll(FAST_CIPHER_SUITES)
+            .addAll(OTHER_CIPHER_SUITES)
             .build();
 
     /**

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
@@ -27,12 +27,6 @@ public final class CipherSuites {
             "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
             "TLS_RSA_WITH_AES_128_CBC_SHA256",
             "TLS_RSA_WITH_AES_256_CBC_SHA256",
-            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-            "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
-            "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
-            "TLS_RSA_WITH_AES_256_CBC_SHA",
-            "TLS_RSA_WITH_AES_128_CBC_SHA",
             "TLS_CHACHA20_POLY1305_SHA256",
             "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
             "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256");
@@ -53,20 +47,16 @@ public final class CipherSuites {
             .build();
 
     /**
-     * Known fast and safe cipher suites on the JVM.
+     * This should not be used.
      *
-     * <p>In an ideal world, we'd use GCM suites, but they're an order of magnitude slower than the CBC suites, which
-     * have JVM optimizations already. We should revisit with JDK9.
+     * The Java 8 implementation of GCM ciphers was much slower than CBC suites, however in all newer releases
+     * the GCM ciphers out-perform CBC (and all other suites).
      *
-     * <p>See also:
-     *
-     * <ul>
-     *   <li>http://openjdk.java.net/jeps/246
-     *   <li>https://bugs.openjdk.java.net/secure/attachment/25422/GCM%20Analysis.pdf
-     * </ul>
+     * @deprecated No longer necessary, GCM ciphers provide the most throughput on modern JVMs.
      */
+    @Deprecated
     public static String[] fastCipherSuites() {
-        return FAST_CIPHER_SUITES.toArray(new String[0]);
+        return allCipherSuites();
     }
 
     /** Known safe GCM cipher suites. */

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/OkHttpClients.java
@@ -277,13 +277,8 @@ public final class OkHttpClients {
                     .build());
         }
 
-        // cipher setup
-        client.connectionSpecs(createConnectionSpecs(config.enableGcmCipherSuites()));
-        // gcm ciphers are required for http/2 per https://tools.ietf.org/html/rfc7540#section-9.2.2
-        // some servers fail to implement this piece of the specification, which can violate our
-        // assumptions.
-        // This check can be removed once we've migrated to TLSv1.3+
-        if (!config.enableGcmCipherSuites() || !config.enableHttp2().orElse(DEFAULT_ENABLE_HTTP2)) {
+        client.connectionSpecs(createConnectionSpecs());
+        if (!config.enableHttp2().orElse(DEFAULT_ENABLE_HTTP2)) {
             client.protocols(ImmutableList.of(Protocol.HTTP_1_1));
         }
 
@@ -339,14 +334,11 @@ public final class OkHttpClients {
         return augmentedAgent;
     }
 
-    private static ImmutableList<ConnectionSpec> createConnectionSpecs(boolean enableGcmCipherSuites) {
+    private static ImmutableList<ConnectionSpec> createConnectionSpecs() {
         return ImmutableList.of(
                 new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
                         .tlsVersions(TlsVersion.TLS_1_2)
-                        .cipherSuites(
-                                enableGcmCipherSuites
-                                        ? CipherSuites.allCipherSuites()
-                                        : CipherSuites.fastCipherSuites())
+                        .cipherSuites(CipherSuites.allCipherSuites())
                         .build(),
                 ConnectionSpec.CLEARTEXT);
     }


### PR DESCRIPTION
==COMMIT_MSG==
CJR CipherSuites list is more restrictive, avoiding less secure ciphers
==COMMIT_MSG==

## Possible downsides?
Could fail to connect to insecure servers. This is a feature.
