### PR TITLE
JaxRsClient.create methods produce clients with reasonable `equals`

### DIFF
--- a/changelog/@unreleased/pr-2115.v2.yml
+++ b/changelog/@unreleased/pr-2115.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: JaxRsClient.create methods produce clients with reasonable `equals`
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2115

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientEqualityTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientEqualityTest.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import org.junit.Test;
+
+public final class JaxRsClientEqualityTest extends TestBase {
+
+    @Test
+    public void assertEqualsSelf() {
+        TestService instance = newTestServiceClient(8123);
+        assertThat(instance).isEqualTo(instance);
+    }
+
+    @Test
+    public void assertNotEqualsDifferentPort() {
+        assertThat(newTestServiceClient(1234)).isNotEqualTo(newTestServiceClient(4321));
+    }
+
+    @Test
+    public void assertNotEqualsSamePort() {
+        int port = 1234;
+        assertThat(newTestServiceClient(port))
+                .as("The factory doesn't have a cache, these instances are different")
+                .isNotEqualTo(newTestServiceClient(port));
+    }
+
+    private TestService newTestServiceClient(int port) {
+        return JaxRsClient.create(
+                TestService.class,
+                AGENT,
+                new HostMetricsRegistry(),
+                ClientConfiguration.builder()
+                        .from(createTestConfig("http://localhost:" + port))
+                        .maxNumRetries(1)
+                        .build());
+    }
+}


### PR DESCRIPTION
Previously all clients for the same interface would evaluate as
equal due to the way Feign computes equality.

## After this PR
==COMMIT_MSG==
JaxRsClient.create methods produce clients with reasonable `equals`
==COMMIT_MSG==
