### PR TITLE
Use raw binary in Smile encoding

### DIFF
--- a/changelog/@unreleased/pr-2134.v2.yml
+++ b/changelog/@unreleased/pr-2134.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Smile encoding now uses the raw binary format.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2134

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
@@ -65,11 +66,13 @@ public final class ObjectMappers {
      * <p>Settings:
      *
      * <ul>
+     *   <li>Disable 7-bit binary encoding.
      *   <li>Ignore unknown properties found during deserialization.
      * </ul>
      */
     public static ObjectMapper newSmileClientObjectMapper() {
-        return withDefaultModules(new ObjectMapper(new SmileFactory()))
+        return withDefaultModules(
+                        new ObjectMapper(new SmileFactory().disable(SmileGenerator.Feature.ENCODE_BINARY_AS_7BIT)))
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
@@ -106,11 +109,13 @@ public final class ObjectMappers {
      * <p>Settings:
      *
      * <ul>
+     *   <li>Disable 7-bit binary encoding.
      *   <li>Throw on unknown properties found during deserialization.
      * </ul>
      */
     public static ObjectMapper newSmileServerObjectMapper() {
-        return withDefaultModules(new ObjectMapper(new SmileFactory()))
+        return withDefaultModules(
+                        new ObjectMapper(new SmileFactory().disable(SmileGenerator.Feature.ENCODE_BINARY_AS_7BIT)))
                 .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 


### PR DESCRIPTION
## Before this PR
Binary data was encoded in Smile's 7-bit format, resulting in a 14% increase in the encoded size and requiring more computation to encode and decode.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Smile encoding now uses the raw binary format.
==COMMIT_MSG==

The raw format just directly copies the bytes through unmodified. This does mean that the encoded representation can include embedded control characters like the smile EOS marker, but we don't use that when serializing anyway.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

