### PR TITLE
Opt out of object-mapper optimizations by default in jdk16+

### DIFF
--- a/changelog/@unreleased/pr-2137.v2.yml
+++ b/changelog/@unreleased/pr-2137.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Opt out of invasive object-mapper optimizations by default in jdk16+
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2137

--- a/conjure-java-jackson-optimizations/src/main/java/com/palantir/conjure/java/jackson/optimizations/ObjectMapperOptimizations.java
+++ b/conjure-java-jackson-optimizations/src/main/java/com/palantir/conjure/java/jackson/optimizations/ObjectMapperOptimizations.java
@@ -27,20 +27,29 @@ import java.util.List;
 public final class ObjectMapperOptimizations {
 
     private static final boolean NO_OPTIMIZATIONS =
-            // These optimizations are not used within graalvm because they leverage dynamic class creation
-            // The nativeimage check should not be refactored into a utility method which may reduce our ability to
+            // These optimizations are not used within graalvm because they leverage dynamic class creation The
+            // nativeimage check should not be refactored into a utility method which may reduce our ability to
             // tree-shake.
             System.getProperty("org.graalvm.nativeimage.imagecode") != null
                     // This may be globally configured with a system property
-                    // We disable afterburner optimizations by default on java 16+ where internal access is
-                    // restricted by https://openjdk.java.net/jeps/396 and https://openjdk.java.net/jeps/403
-                    || Boolean.parseBoolean(System.getProperty(
-                            "com.palantir.conjure.java.jackson.optimizations.disabled",
-                            Runtime.version().feature() >= 16 ? "true" : "false"));
+                    || readProperty(
+                            "com.palantir.conjure.java.jackson.optimizations.disabled", shouldDisableByDefault());
 
     public static List<? extends com.fasterxml.jackson.databind.Module> createModules() {
         return NO_OPTIMIZATIONS ? List.of() : List.<com.fasterxml.jackson.databind.Module>of(new AfterburnerModule());
     }
 
     private ObjectMapperOptimizations() {}
+
+    /**
+     * We disable afterburner optimizations by default on java 16+ where internal access is
+     * restricted by https://openjdk.java.net/jeps/396 and https://openjdk.java.net/jeps/403.
+     */
+    private static boolean shouldDisableByDefault() {
+        return Runtime.version().feature() >= 16;
+    }
+
+    private static boolean readProperty(String property, boolean defaultValue) {
+        return Boolean.parseBoolean(System.getProperty(property, Boolean.toString(defaultValue)));
+    }
 }


### PR DESCRIPTION
Note that this can be overridden on java 16 for experimentation,
however we do not recommend doing so. I considered checking for
`--illegal-access=(permit|warn|debug)` in the jvm args, however
that may be set for other reasons, and we will not test afterburner
on java 16, so it would introduce more risk than it's worth.

## Before this PR
Conjure ser/de fails on java 16+

## After this PR
==COMMIT_MSG==
Opt out of invasive object-mapper optimizations by default in jdk16+
==COMMIT_MSG==

## Possible downsides?
Possible performance regressions, however there's too much risk using afterburner on jdk16+, and blackbird has proven risky.