### PR TITLE
Use ObjectMapper subtypes and builders

### DIFF
--- a/conjure-java-client-verifier/src/test/java/com/palantir/verification/Cases.java
+++ b/conjure-java-client-verifier/src/test/java/com/palantir/verification/Cases.java
@@ -16,8 +16,8 @@
 
 package com.palantir.verification;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.palantir.conjure.verification.server.ClientTestCases;
 import com.palantir.conjure.verification.server.EndpointName;
@@ -41,8 +41,9 @@ public final class Cases {
 
     private static ClientTestCases deserializeTestCases(File file) {
         try {
-            return new ObjectMapper()
-                    .registerModule(new Jdk8Module())
+            return JsonMapper.builder()
+                    .addModule(new Jdk8Module())
+                    .build()
                     .readValue(file, TestCases.class)
                     .getClient();
         } catch (IOException e) {
@@ -53,8 +54,9 @@ public final class Cases {
 
     private static IgnoredClientTestCases deserializeIgnoredClientTestCases(File file) {
         try {
-            return new ObjectMapper(new YAMLFactory())
-                    .registerModule(new Jdk8Module())
+            return YAMLMapper.builder()
+                    .addModule(new Jdk8Module())
+                    .build()
                     .readValue(file, IgnoredTestCases.class)
                     .getClient();
         } catch (IOException e) {

--- a/conjure-java-client-verifier/src/test/java/com/palantir/verification/SingleParamServicesTest.java
+++ b/conjure-java-client-verifier/src/test/java/com/palantir/verification/SingleParamServicesTest.java
@@ -16,7 +16,7 @@
 
 package com.palantir.verification;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.serialization.ObjectMappers;
@@ -43,7 +43,7 @@ public class SingleParamServicesTest {
     public static final VerificationServerRule server = new VerificationServerRule();
 
     private static final Logger log = LoggerFactory.getLogger(SingleParamServicesTest.class);
-    private static final ObjectMapper objectMapper = ObjectMappers.newClientObjectMapper();
+    private static final JsonMapper jsonMapper = ObjectMappers.newClientJsonMapper();
     private static ImmutableMap<String, Object> servicesMapsJaxrs = ImmutableMap.of(
             "singlePathParamService",
             VerificationClients.singlePathParamService(server),
@@ -116,11 +116,11 @@ public class SingleParamServicesTest {
                     if ("singleHeaderService".equals(serviceName)) {
                         Type type = method.getGenericParameterTypes()[0];
                         Class<?> cls = ClassUtils.getClass(type.getTypeName());
-                        method.invoke(service, objectMapper.readValue(jsonString, cls), index);
+                        method.invoke(service, jsonMapper.readValue(jsonString, cls), index);
                     } else {
                         Type type = method.getGenericParameterTypes()[1];
                         Class<?> cls = ClassUtils.getClass(type.getTypeName());
-                        method.invoke(service, index, objectMapper.readValue(jsonString, cls));
+                        method.invoke(service, index, jsonMapper.readValue(jsonString, cls));
                     }
 
                     log.info("Successfully post param to endpoint {} and index {}", endpointName, index);

--- a/conjure-java-jackson-serialization/build.gradle
+++ b/conjure-java-jackson-serialization/build.gradle
@@ -4,14 +4,13 @@ apply plugin: 'com.palantir.revapi'
 dependencies {
     implementation project(":conjure-java-jackson-optimizations")
     api "com.fasterxml.jackson.core:jackson-databind"
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-smile"
     api "com.fasterxml.jackson.datatype:jackson-datatype-guava"
     api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-joda"
     api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
-    api "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"
     api "com.palantir.safe-logging:preconditions"
-
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-smile"
 
     testImplementation "junit:junit"
     testImplementation "org.assertj:assertj-core"

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.exc.InputCoercionException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.palantir.logsafe.Preconditions;
 import java.io.File;
 import java.io.IOException;
@@ -47,7 +47,7 @@ import java.util.OptionalLong;
 import org.junit.Test;
 
 public final class ObjectMappersTest {
-    private static final ObjectMapper MAPPER = ObjectMappers.newClientObjectMapper();
+    private static final JsonMapper MAPPER = ObjectMappers.newClientJsonMapper();
 
     @Test
     public void deserializeJdk7ModuleObject() throws IOException {
@@ -85,7 +85,7 @@ public final class ObjectMappersTest {
 
     @Test
     public void testMappersReturnNewInstance() {
-        assertThat(ObjectMappers.newClientObjectMapper()).isNotSameAs(ObjectMappers.newClientObjectMapper());
+        assertThat(ObjectMappers.newClientJsonMapper()).isNotSameAs(ObjectMappers.newClientJsonMapper());
     }
 
     @Test

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ShimJdk7ModuleTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ShimJdk7ModuleTest.java
@@ -18,7 +18,7 @@ package com.palantir.conjure.java.serialization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -28,7 +28,7 @@ public final class ShimJdk7ModuleTest {
 
     @Test
     public void testPathSerDe() throws IOException {
-        ObjectMapper mapper = new ObjectMapper().registerModule(new ShimJdk7Module());
+        JsonMapper mapper = JsonMapper.builder().addModule(new ShimJdk7Module()).build();
         String val = mapper.writeValueAsString(Paths.get("a", "b", "c"));
         assertThat(mapper.readValue(val, Path.class)).isEqualTo(Paths.get("a", "b", "c"));
     }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/AbstractFeignJaxRsClientBuilder.java
@@ -101,12 +101,12 @@ abstract class AbstractFeignJaxRsClientBuilder {
             Class<T> serviceClass,
             Channel channel,
             ConjureRuntime runtime,
-            ObjectMapper jsonObjectMapper,
-            ObjectMapper cborObjectMapper) {
+            ObjectMapper jsonMapper,
+            ObjectMapper cborMapper) {
         return Feign.builder()
                 .contract(createContract())
-                .encoder(createEncoder(jsonObjectMapper, cborObjectMapper))
-                .decoder(createDecoder(jsonObjectMapper, cborObjectMapper))
+                .encoder(createEncoder(jsonMapper, cborMapper))
+                .decoder(createDecoder(jsonMapper, cborMapper))
                 .errorDecoder(new DialogueFeignClient.RemoteExceptionDecoder(runtime))
                 .client(new DialogueFeignClient(serviceClass, channel, runtime, FeignDialogueTarget.BASE_URL))
                 .logLevel(Logger.Level.NONE) // we use Dialogue for logging. (note that NONE is the default)
@@ -179,16 +179,16 @@ abstract class AbstractFeignJaxRsClientBuilder {
                         new Java8OptionalAwareContract(new GuavaOptionalAwareContract(new JAXRSContract())))));
     }
 
-    private static Decoder createDecoder(ObjectMapper objectMapper, ObjectMapper cborObjectMapper) {
+    private static Decoder createDecoder(ObjectMapper jsonMapper, ObjectMapper cborMapper) {
         return new NeverReturnNullDecoder(
                 new Java8OptionalAwareDecoder(new GuavaOptionalAwareDecoder(new EmptyContainerDecoder(
-                        objectMapper,
+                        jsonMapper,
                         new InputStreamDelegateDecoder(new TextDelegateDecoder(
-                                new CborDelegateDecoder(cborObjectMapper, new JacksonDecoder(objectMapper))))))));
+                                new CborDelegateDecoder(cborMapper, new JacksonDecoder(jsonMapper))))))));
     }
 
-    private static Encoder createEncoder(ObjectMapper objectMapper, ObjectMapper cborObjectMapper) {
+    private static Encoder createEncoder(ObjectMapper jsonMapper, ObjectMapper cborMapper) {
         return new InputStreamDelegateEncoder(new TextDelegateEncoder(
-                new CborDelegateEncoder(cborObjectMapper, new ConjureFeignJacksonEncoder(objectMapper))));
+                new CborDelegateEncoder(cborMapper, new ConjureFeignJacksonEncoder(jsonMapper))));
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/FeignJaxRsClientBuilder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/FeignJaxRsClientBuilder.java
@@ -17,13 +17,15 @@
 package com.palantir.conjure.java.client.jaxrs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 
 public final class FeignJaxRsClientBuilder extends AbstractFeignJaxRsClientBuilder {
 
-    static final ObjectMapper JSON_OBJECT_MAPPER = ObjectMappers.newClientObjectMapper();
-    static final ObjectMapper CBOR_OBJECT_MAPPER = ObjectMappers.newCborClientObjectMapper();
+    static final JsonMapper JSON_MAPPER = ObjectMappers.newClientJsonMapper();
+    static final CBORMapper CBOR_MAPPER = ObjectMappers.newClientCborMapper();
 
     FeignJaxRsClientBuilder(ClientConfiguration config) {
         super(config);
@@ -31,11 +33,11 @@ public final class FeignJaxRsClientBuilder extends AbstractFeignJaxRsClientBuild
 
     @Override
     protected ObjectMapper getObjectMapper() {
-        return JSON_OBJECT_MAPPER;
+        return JSON_MAPPER;
     }
 
     @Override
     protected ObjectMapper getCborObjectMapper() {
-        return CBOR_OBJECT_MAPPER;
+        return CBOR_MAPPER;
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
@@ -75,7 +75,7 @@ public final class JaxRsClient {
                 serviceClass,
                 channel,
                 runtime,
-                FeignJaxRsClientBuilder.JSON_OBJECT_MAPPER,
-                FeignJaxRsClientBuilder.CBOR_OBJECT_MAPPER);
+                FeignJaxRsClientBuilder.JSON_MAPPER,
+                FeignJaxRsClientBuilder.CBOR_MAPPER);
     }
 }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/CborDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/CborDelegateDecoder.java
@@ -39,11 +39,11 @@ import java.util.Collection;
  */
 public final class CborDelegateDecoder implements Decoder {
 
-    private final ObjectMapper cborObjectMapper;
+    private final ObjectMapper cborMapper;
     private final Decoder delegate;
 
-    public CborDelegateDecoder(ObjectMapper cborObjectMapper, Decoder delegate) {
-        this.cborObjectMapper = cborObjectMapper;
+    public CborDelegateDecoder(ObjectMapper cborMapper, Decoder delegate) {
+        this.cborMapper = cborMapper;
         this.delegate = delegate;
     }
 
@@ -69,7 +69,7 @@ public final class CborDelegateDecoder implements Decoder {
             // put the byte back
             pushbackInputStream.unread(firstByte);
 
-            return cborObjectMapper.readValue(pushbackInputStream, cborObjectMapper.constructType(type));
+            return cborMapper.readValue(pushbackInputStream, cborMapper.constructType(type));
 
         } else {
             return delegate.decode(response, type);

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/CborDelegateEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/CborDelegateEncoder.java
@@ -41,11 +41,11 @@ public final class CborDelegateEncoder implements Encoder {
 
     public static final String MIME_TYPE = "application/cbor";
 
-    private final ObjectMapper cborObjectMapper;
+    private final ObjectMapper cborMapper;
     private final Encoder delegate;
 
-    public CborDelegateEncoder(ObjectMapper cborObjectMapper, Encoder delegate) {
-        this.cborObjectMapper = cborObjectMapper;
+    public CborDelegateEncoder(ObjectMapper cborMapper, Encoder delegate) {
+        this.cborMapper = cborMapper;
         this.delegate = delegate;
     }
 
@@ -63,8 +63,8 @@ public final class CborDelegateEncoder implements Encoder {
         }
 
         try {
-            JavaType javaType = cborObjectMapper.getTypeFactory().constructType(bodyType);
-            template.body(cborObjectMapper.writerFor(javaType).writeValueAsBytes(object), StandardCharsets.UTF_8);
+            JavaType javaType = cborMapper.getTypeFactory().constructType(bodyType);
+            template.body(cborMapper.writerFor(javaType).writeValueAsBytes(object), StandardCharsets.UTF_8);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateDecoder.java
@@ -32,8 +32,8 @@ public final class ConjureCborDelegateDecoder implements Decoder {
 
     private final CborDelegateDecoder delegate;
 
-    public ConjureCborDelegateDecoder(ObjectMapper cborObjectMapper, Decoder delegate) {
-        this.delegate = new CborDelegateDecoder(cborObjectMapper, delegate);
+    public ConjureCborDelegateDecoder(ObjectMapper cborMapper, Decoder delegate) {
+        this.delegate = new CborDelegateDecoder(cborMapper, delegate);
     }
 
     @Override

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureCborDelegateEncoder.java
@@ -35,8 +35,8 @@ public final class ConjureCborDelegateEncoder implements Encoder {
 
     private final Encoder delegate;
 
-    public ConjureCborDelegateEncoder(ObjectMapper cborObjectMapper, Encoder delegate) {
-        this.delegate = new CborDelegateEncoder(cborObjectMapper, delegate);
+    public ConjureCborDelegateEncoder(ObjectMapper cborMapper, Encoder delegate) {
+        this.delegate = new CborDelegateEncoder(cborMapper, delegate);
     }
 
     @Override

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientStackTraceTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientStackTraceTest.java
@@ -81,7 +81,7 @@ public final class JaxRsClientStackTraceTest extends TestBase {
     }
 
     private static MockResponse serializableError() throws JsonProcessingException {
-        String json = ObjectMappers.newServerObjectMapper()
+        String json = ObjectMappers.newServerJsonMapper()
                 .writeValueAsString(SerializableError.forException(new ServiceException(ErrorType.INTERNAL)));
         return new MockResponse()
                 .setResponseCode(500)

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/EmptyContainerDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/EmptyContainerDecoderTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HttpHeaders;
@@ -50,7 +50,7 @@ import org.junit.Test;
 
 public class EmptyContainerDecoderTest {
 
-    private static final ObjectMapper mapper = ObjectMappers.newClientObjectMapper();
+    private static final JsonMapper mapper = ObjectMappers.newClientJsonMapper();
     private static final Response HTTP_204 = Response.create(204, "No Content", Collections.emptyMap(), new byte[] {});
     private final Decoder delegate = mock(Decoder.class);
     private final EmptyContainerDecoder emptyContainerDecoder = new EmptyContainerDecoder(mapper, delegate);

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaTestServer.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/GuavaTestServer.java
@@ -45,7 +45,7 @@ public class GuavaTestServer extends Application<Configuration> {
     @Override
     public final void run(Configuration _config, final Environment env) throws Exception {
         env.jersey().register(ConjureJerseyFeature.INSTANCE);
-        env.jersey().register(new JacksonMessageBodyProvider(ObjectMappers.newServerObjectMapper()));
+        env.jersey().register(new JacksonMessageBodyProvider(ObjectMappers.newServerJsonMapper()));
         env.jersey().register(new TestResource());
     }
 

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8TestServer.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/Java8TestServer.java
@@ -53,7 +53,7 @@ public class Java8TestServer extends Application<Configuration> {
     @Override
     public final void run(Configuration _config, final Environment env) throws Exception {
         env.jersey().register(ConjureJerseyFeature.INSTANCE);
-        env.jersey().register(new JacksonMessageBodyProvider(ObjectMappers.newServerObjectMapper()));
+        env.jersey().register(new JacksonMessageBodyProvider(ObjectMappers.newServerJsonMapper()));
         env.jersey().register(new EmptyOptionalTo204ExceptionMapper());
         env.jersey().register(new TestResource());
     }

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/NeverReturnNullDecoderTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/feignimpl/NeverReturnNullDecoderTest.java
@@ -37,7 +37,7 @@ public final class NeverReturnNullDecoderTest extends TestBase {
 
     private final Map<String, Collection<String>> headers = new HashMap<>();
     private final Decoder textDelegateDecoder =
-            new NeverReturnNullDecoder(new JacksonDecoder(ObjectMappers.newClientObjectMapper()));
+            new NeverReturnNullDecoder(new JacksonDecoder(ObjectMappers.newClientJsonMapper()));
 
     @Test
     public void throws_nullpointerexception_when_body_is_null() {

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ConjureJerseyFeature.java
@@ -54,7 +54,7 @@ public enum ConjureJerseyFeature implements Feature {
         JacksonExceptionMappers.configure(context, exceptionListener);
 
         // Cbor handling
-        context.register(new JacksonCBORProvider(ObjectMappers.newCborServerObjectMapper()));
+        context.register(new JacksonCBORProvider(ObjectMappers.newServerCborMapper()));
 
         // Auth handling
         context.register(AuthHeaderParamConverterProvider.class);

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/ExceptionMappingTest.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import com.palantir.conjure.java.api.errors.ErrorType;
@@ -70,7 +70,7 @@ public final class ExceptionMappingTest {
     private static final int REMOTE_EXCEPTION_STATUS_CODE = 400;
     private static final int UNAUTHORIZED_STATUS_CODE = 401;
     private static final int PERMISSION_DENIED_STATUS_CODE = 403;
-    private static final ObjectMapper MAPPER = ObjectMappers.newServerObjectMapper();
+    private static final JsonMapper MAPPER = ObjectMappers.newServerJsonMapper();
 
     private WebTarget target;
 

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapperTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapperTest.java
@@ -18,8 +18,8 @@ package com.palantir.conjure.java.server.jersey;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.conjure.java.serialization.ObjectMappers;
@@ -36,8 +36,10 @@ public final class JsonExceptionMapperTest {
                 }
             };
 
-    private final ObjectMapper objectMapper =
-            ObjectMappers.newServerObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    private final JsonMapper objectMapper = ObjectMappers.newServerJsonMapper()
+            .rebuild()
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .build();
 
     @Test
     public void testExpectedSerializedError() throws Exception {

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapperTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapperTest.java
@@ -18,8 +18,8 @@ package com.palantir.conjure.java.server.jersey;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
@@ -35,8 +35,10 @@ public final class WebApplicationExceptionMapperTest {
 
     private final WebApplicationExceptionMapper mapper =
             new WebApplicationExceptionMapper(ConjureJerseyFeature.NoOpListener.INSTANCE);
-    private final ObjectMapper objectMapper =
-            ObjectMappers.newServerObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    private final JsonMapper objectMapper = ObjectMappers.newServerJsonMapper()
+            .rebuild()
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .build();
 
     @Test
     public void testExplicitlyHandledExceptions() throws Exception {

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/CborConverterFactory.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/CborConverterFactory.java
@@ -17,9 +17,9 @@
 package com.palantir.conjure.java.client.retrofit2;
 
 import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
 import com.google.common.net.HttpHeaders;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -37,11 +37,11 @@ public final class CborConverterFactory extends Converter.Factory {
     private static final MediaType CBOR_MIME_TYPE = MediaType.parse("application/cbor");
 
     private final Converter.Factory delegate;
-    private final ObjectMapper cborObjectMapper;
+    private final CBORMapper cborMapper;
 
-    CborConverterFactory(Converter.Factory delegate, ObjectMapper cborObjectMapper) {
+    CborConverterFactory(Converter.Factory delegate, CBORMapper cborMapper) {
         this.delegate = delegate;
-        this.cborObjectMapper = cborObjectMapper;
+        this.cborMapper = cborMapper;
     }
 
     @Override
@@ -49,8 +49,8 @@ public final class CborConverterFactory extends Converter.Factory {
         // given we don't know how to convert the response until we check the Content-Type, we construct a delegate
         // converter for when the response is not application/cbor.
         Converter<ResponseBody, ?> delegateConverter = delegate.responseBodyConverter(type, annotations, retrofit);
-        JavaType javaType = cborObjectMapper.getTypeFactory().constructType(type);
-        ObjectReader objectReader = cborObjectMapper.readerFor(javaType);
+        JavaType javaType = cborMapper.getTypeFactory().constructType(type);
+        ObjectReader objectReader = cborMapper.readerFor(javaType);
         return new CborResponseBodyConverter<>(objectReader, delegateConverter);
     }
 
@@ -58,7 +58,7 @@ public final class CborConverterFactory extends Converter.Factory {
     public Converter<?, RequestBody> requestBodyConverter(
             Type type, Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
         if (contentTypeIsCbor(methodAnnotations)) {
-            return new CborRequestBodyConverter<>(cborObjectMapper.writer());
+            return new CborRequestBodyConverter<>(cborMapper.writer());
         } else {
             return delegate.requestBodyConverter(type, parameterAnnotations, methodAnnotations, retrofit);
         }

--- a/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
+++ b/conjure-java-retrofit2-client/src/main/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientBuilder.java
@@ -16,7 +16,8 @@
 
 package com.palantir.conjure.java.client.retrofit2;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.okhttp.HostEventsSink;
@@ -28,8 +29,8 @@ import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 public final class Retrofit2ClientBuilder {
-    private static final ObjectMapper CBOR_OBJECT_MAPPER = ObjectMappers.newCborClientObjectMapper();
-    private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newClientObjectMapper();
+    private static final JsonMapper JSON_MAPPER = ObjectMappers.newClientJsonMapper();
+    private static final CBORMapper CBOR_MAPPER = ObjectMappers.newClientCborMapper();
 
     private ClientConfiguration config;
 
@@ -62,8 +63,8 @@ public final class Retrofit2ClientBuilder {
                 .addConverterFactory(OptionalResponseBodyConverterFactory.INSTANCE)
                 .addConverterFactory(new CborConverterFactory(
                         new NeverReturnNullConverterFactory(
-                                new CoerceNullValuesConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER))),
-                        CBOR_OBJECT_MAPPER))
+                                new CoerceNullValuesConverterFactory(JacksonConverterFactory.create(JSON_MAPPER))),
+                        CBOR_MAPPER))
                 .addConverterFactory(OptionalObjectToStringConverterFactory.INSTANCE)
                 // These get evaluated last, to convert the original Call into the response type expected by the client
                 .addCallAdapterFactory(new QosExceptionThrowingCallAdapterFactory(

--- a/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientApiTest.java
+++ b/conjure-java-retrofit2-client/src/test/java/com/palantir/conjure/java/client/retrofit2/Retrofit2ClientApiTest.java
@@ -240,7 +240,7 @@ public final class Retrofit2ClientApiTest extends TestBase {
     @Test
     public void testCborReturnValues() throws IOException {
         LocalDate date = LocalDate.of(2001, 2, 3);
-        byte[] bytes = ObjectMappers.newCborServerObjectMapper().writeValueAsBytes(Optional.of(date));
+        byte[] bytes = ObjectMappers.newServerCborMapper().writeValueAsBytes(Optional.of(date));
         try (Buffer buffer = new Buffer()) {
             buffer.write(bytes);
             server.enqueue(new MockResponse().setBody(buffer).addHeader("Content-Type", "application/cbor"));
@@ -256,7 +256,7 @@ public final class Retrofit2ClientApiTest extends TestBase {
         service.makeCborRequest(date).execute();
         RecordedRequest request = server.takeRequest();
         assertThat(request.getBody().readByteArray())
-                .isEqualTo(ObjectMappers.newCborClientObjectMapper().writeValueAsBytes(date));
+                .isEqualTo(ObjectMappers.newClientCborMapper().writeValueAsBytes(date));
     }
 
     @Test
@@ -295,7 +295,7 @@ public final class Retrofit2ClientApiTest extends TestBase {
         server.enqueue(new MockResponse()
                 .setResponseCode(500)
                 .setHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-                .setBody(ObjectMappers.newClientObjectMapper().writeValueAsString(error)));
+                .setBody(ObjectMappers.newClientJsonMapper().writeValueAsString(error)));
 
         assertThatThrownBy(() -> Futures.getUnchecked(futureSupplier.get()))
                 .isInstanceOf(UncheckedExecutionException.class)
@@ -344,7 +344,7 @@ public final class Retrofit2ClientApiTest extends TestBase {
         server.enqueue(new MockResponse()
                 .setResponseCode(500)
                 .setHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-                .setBody(ObjectMappers.newClientObjectMapper().writeValueAsString(ERROR)));
+                .setBody(ObjectMappers.newClientJsonMapper().writeValueAsString(ERROR)));
 
         Future<String> future = futureSupplier.get();
 
@@ -390,7 +390,7 @@ public final class Retrofit2ClientApiTest extends TestBase {
         server.enqueue(new MockResponse()
                 .setResponseCode(500)
                 .setHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-                .setBody(ObjectMappers.newClientObjectMapper().writeValueAsString(ERROR)));
+                .setBody(ObjectMappers.newClientJsonMapper().writeValueAsString(ERROR)));
 
         Call<String> call = service.getRelative();
 
@@ -408,7 +408,7 @@ public final class Retrofit2ClientApiTest extends TestBase {
         server.enqueue(new MockResponse()
                 .setResponseCode(500)
                 .setHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-                .setBody(ObjectMappers.newClientObjectMapper().writeValueAsString(ERROR)));
+                .setBody(ObjectMappers.newClientJsonMapper().writeValueAsString(ERROR)));
 
         CountDownLatch assertionsPassed = new CountDownLatch(1);
         Call<String> call = service.getRelative();

--- a/conjure-java-server-verifier/src/test/java/com/palantir/verification/server/Cases.java
+++ b/conjure-java-server-verifier/src/test/java/com/palantir/verification/server/Cases.java
@@ -16,8 +16,8 @@
 
 package com.palantir.verification.server;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.palantir.conjure.verification.client.EndpointName;
 import com.palantir.conjure.verification.client.IgnoredServerTestCases;
@@ -38,8 +38,9 @@ public final class Cases {
 
     private static ServerTestCases deserializeTestCases(File file) {
         try {
-            return new ObjectMapper()
-                    .registerModule(new Jdk8Module())
+            return JsonMapper.builder()
+                    .addModule(new Jdk8Module())
+                    .build()
                     .readValue(file, com.palantir.conjure.verification.client.TestCases.class)
                     .getServer();
         } catch (IOException e) {
@@ -50,8 +51,9 @@ public final class Cases {
 
     private static IgnoredServerTestCases deserializeIgnoredServerTestCases(File file) {
         try {
-            return new ObjectMapper(new YAMLFactory())
-                    .registerModule(new Jdk8Module())
+            return YAMLMapper.builder()
+                    .addModule(new Jdk8Module())
+                    .build()
                     .readValue(file, IgnoredTestCases.class)
                     .getServer();
         } catch (IOException e) {

--- a/conjure-java-server-verifier/src/test/java/com/palantir/verification/server/undertest/ServerUnderTestApplication.java
+++ b/conjure-java-server-verifier/src/test/java/com/palantir/verification/server/undertest/ServerUnderTestApplication.java
@@ -16,7 +16,7 @@
 
 package com.palantir.verification.server.undertest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;
 import com.google.common.reflect.AbstractInvocationHandler;
@@ -39,10 +39,12 @@ public final class ServerUnderTestApplication extends Application<Configuration>
 
     @Override
     public void initialize(Bootstrap<Configuration> bootstrap) {
-        ObjectMapper remotingObjectMapper = ObjectMappers.newServerObjectMapper()
+        JsonMapper remotingObjectMapper = ObjectMappers.newServerJsonMapper()
+                .rebuild()
                 // needs discoverable subtype resolver for DW polymorphic configuration mechanism
-                .setSubtypeResolver(new DiscoverableSubtypeResolver())
-                .registerModule(new FuzzyEnumModule());
+                .subtypeResolver(new DiscoverableSubtypeResolver())
+                .addModule(new FuzzyEnumModule())
+                .build();
         bootstrap.setObjectMapper(remotingObjectMapper);
     }
 

--- a/conjure-scala-jaxrs-client/build.gradle
+++ b/conjure-scala-jaxrs-client/build.gradle
@@ -3,6 +3,10 @@ apply plugin: 'com.palantir.revapi'
 
 dependencies {
     api project(':conjure-java-jaxrs-client')
+    api "com.fasterxml.jackson.core:jackson-databind"
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-smile"
+
     implementation project(':conjure-java-jackson-serialization')
     implementation 'com.fasterxml.jackson.module:jackson-module-scala_2.12'
 }

--- a/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/FeignJaxRsScalaClientBuilder.java
+++ b/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/FeignJaxRsScalaClientBuilder.java
@@ -17,13 +17,15 @@
 package com.palantir.conjure.java.client.jaxrs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.serialization.ScalaObjectMappers;
 
 public final class FeignJaxRsScalaClientBuilder extends AbstractFeignJaxRsClientBuilder {
 
-    private static final ObjectMapper JSON_OBJECT_MAPPER = ScalaObjectMappers.newClientObjectMapper();
-    private static final ObjectMapper CBOR_OBJECT_MAPPER = ScalaObjectMappers.newCborClientObjectMapper();
+    private static final JsonMapper JSON_MAPPER = ScalaObjectMappers.newClientJsonMapper();
+    private static final CBORMapper CBOR_MAPPER = ScalaObjectMappers.newClientCborMapper();
 
     FeignJaxRsScalaClientBuilder(ClientConfiguration config) {
         super(config);
@@ -31,11 +33,11 @@ public final class FeignJaxRsScalaClientBuilder extends AbstractFeignJaxRsClient
 
     @Override
     protected ObjectMapper getObjectMapper() {
-        return JSON_OBJECT_MAPPER;
+        return JSON_MAPPER;
     }
 
     @Override
     protected ObjectMapper getCborObjectMapper() {
-        return CBOR_OBJECT_MAPPER;
+        return CBOR_MAPPER;
     }
 }

--- a/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/serialization/ScalaObjectMappers.java
+++ b/conjure-scala-jaxrs-client/src/main/java/com/palantir/conjure/java/serialization/ScalaObjectMappers.java
@@ -19,6 +19,9 @@ package com.palantir.conjure.java.serialization;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
+import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
 import com.fasterxml.jackson.module.scala.DefaultScalaModule;
 import com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospector$;
 
@@ -26,31 +29,55 @@ public final class ScalaObjectMappers {
 
     private ScalaObjectMappers() {}
 
+    public static JsonMapper newClientJsonMapper() {
+        return withScalaSupport(ObjectMappers.newClientJsonMapper());
+    }
+
+    public static CBORMapper newClientCborMapper() {
+        return withScalaSupport(ObjectMappers.newClientCborMapper());
+    }
+
+    public static SmileMapper newClientSmileMapper() {
+        return withScalaSupport(ObjectMappers.newClientSmileMapper());
+    }
+
+    public static JsonMapper newServerJsonMapper() {
+        return withScalaSupport(ObjectMappers.newServerJsonMapper());
+    }
+
+    public static CBORMapper newServerCborMapper() {
+        return withScalaSupport(ObjectMappers.newServerCborMapper());
+    }
+
+    public static SmileMapper newServerSmileMapper() {
+        return withScalaSupport(ObjectMappers.newServerSmileMapper());
+    }
+
     public static ObjectMapper newClientObjectMapper() {
-        return withScalaSupport(ObjectMappers.newClientObjectMapper());
+        return newClientJsonMapper();
     }
 
     public static ObjectMapper newCborClientObjectMapper() {
-        return withScalaSupport(ObjectMappers.newCborClientObjectMapper());
+        return newClientCborMapper();
     }
 
     public static ObjectMapper newSmileClientObjectMapper() {
-        return withScalaSupport(ObjectMappers.newSmileClientObjectMapper());
+        return newClientSmileMapper();
     }
 
     public static ObjectMapper newServerObjectMapper() {
-        return withScalaSupport(ObjectMappers.newServerObjectMapper());
+        return newServerJsonMapper();
     }
 
     public static ObjectMapper newCborServerObjectMapper() {
-        return withScalaSupport(ObjectMappers.newCborServerObjectMapper());
+        return newServerCborMapper();
     }
 
     public static ObjectMapper newSmileServerObjectMapper() {
-        return withScalaSupport(ObjectMappers.newSmileServerObjectMapper());
+        return newServerSmileMapper();
     }
 
-    private static ObjectMapper withScalaSupport(ObjectMapper objectMapper) {
+    private static <T extends ObjectMapper> T withScalaSupport(T objectMapper) {
         objectMapper
                 .registerModule(new DefaultScalaModule())
                 .setAnnotationIntrospector(new AnnotationIntrospectorPair(

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/KeyStoresTests.java
@@ -19,7 +19,7 @@ package com.palantir.conjure.java.config.ssl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.palantir.conjure.java.serialization.ObjectMappers;
@@ -320,7 +320,7 @@ public final class KeyStoresTests {
 
     @Test
     public void testPemX509CertificateDeserializationFromString() throws IOException {
-        ObjectMapper mapper = ObjectMappers.newServerObjectMapper();
+        JsonMapper mapper = ObjectMappers.newServerJsonMapper();
         String cert = Files.asCharSource(TestConstants.SERVER_CERT_PEM_PATH.toFile(), StandardCharsets.UTF_8)
                 .read();
         byte[] json = mapper.writeValueAsBytes(cert);
@@ -329,7 +329,7 @@ public final class KeyStoresTests {
 
     @Test
     public void testPemX509CertificateDeserializationFromJsonObject() throws IOException {
-        ObjectMapper mapper = ObjectMappers.newServerObjectMapper();
+        JsonMapper mapper = ObjectMappers.newServerJsonMapper();
         String cert = Files.asCharSource(TestConstants.SERVER_CERT_PEM_PATH.toFile(), StandardCharsets.UTF_8)
                 .read();
         byte[] json = mapper.writeValueAsBytes(ImmutableMap.of("pemCertificate", cert));
@@ -338,7 +338,7 @@ public final class KeyStoresTests {
 
     @Test
     public void testPemX509CertificateRoundTripSerde() throws IOException {
-        ObjectMapper mapper = ObjectMappers.newServerObjectMapper();
+        JsonMapper mapper = ObjectMappers.newServerJsonMapper();
         PemX509Certificate expected = PemX509Certificate.of(
                 Files.asCharSource(TestConstants.SERVER_CERT_PEM_PATH.toFile(), StandardCharsets.UTF_8)
                         .read());

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/SerializationTests.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/SerializationTests.java
@@ -18,7 +18,7 @@ package com.palantir.conjure.java.config.ssl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import java.io.IOException;
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 public final class SerializationTests {
 
-    private static final ObjectMapper MAPPER = ObjectMappers.newClientObjectMapper();
+    private static final JsonMapper MAPPER = ObjectMappers.newClientJsonMapper();
 
     @Test
     public void testJsonSerDe() throws IOException {

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/SslConfigurationTest.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/SslConfigurationTest.java
@@ -42,11 +42,11 @@ public final class SslConfigurationTest {
                 + "\"key-store-path\":\"keystore.jks\",\"key-store-password\":\"password\","
                 + "\"key-store-type\":\"JKS\",\"key-store-key-alias\":\"alias\"}";
 
-        assertThat(ObjectMappers.newClientObjectMapper().writeValueAsString(serialized))
+        assertThat(ObjectMappers.newClientJsonMapper().writeValueAsString(serialized))
                 .isEqualTo(deserializedCamelCase);
-        assertThat(ObjectMappers.newClientObjectMapper().readValue(deserializedCamelCase, SslConfiguration.class))
+        assertThat(ObjectMappers.newClientJsonMapper().readValue(deserializedCamelCase, SslConfiguration.class))
                 .isEqualTo(serialized);
-        assertThat(ObjectMappers.newClientObjectMapper().readValue(deserializedKebabCase, SslConfiguration.class))
+        assertThat(ObjectMappers.newClientJsonMapper().readValue(deserializedKebabCase, SslConfiguration.class))
                 .isEqualTo(serialized);
     }
 
@@ -59,11 +59,11 @@ public final class SslConfigurationTest {
                 + "\"key-store-path\":null,\"key-store-password\":null,\"key-store-type\":\"JKS\","
                 + "\"key-store-key-alias\":null}";
 
-        assertThat(ObjectMappers.newClientObjectMapper().writeValueAsString(serialized))
+        assertThat(ObjectMappers.newClientJsonMapper().writeValueAsString(serialized))
                 .isEqualTo(deserializedCamelCase);
-        assertThat(ObjectMappers.newClientObjectMapper().readValue(deserializedCamelCase, SslConfiguration.class))
+        assertThat(ObjectMappers.newClientJsonMapper().readValue(deserializedCamelCase, SslConfiguration.class))
                 .isEqualTo(serialized);
-        assertThat(ObjectMappers.newClientObjectMapper().readValue(deserializedKebabCase, SslConfiguration.class))
+        assertThat(ObjectMappers.newClientJsonMapper().readValue(deserializedKebabCase, SslConfiguration.class))
                 .isEqualTo(serialized);
     }
 }

--- a/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemoteExceptionResponseHandler.java
+++ b/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/RemoteExceptionResponseHandler.java
@@ -16,7 +16,7 @@
 
 package com.palantir.conjure.java.okhttp;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.io.CharStreams;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
@@ -39,7 +39,7 @@ enum RemoteExceptionResponseHandler implements ResponseHandler<RemoteException> 
     INSTANCE;
 
     private static final SafeLogger log = SafeLoggerFactory.get(RemoteExceptionResponseHandler.class);
-    private static final ObjectMapper MAPPER = ObjectMappers.newClientObjectMapper();
+    private static final JsonMapper MAPPER = ObjectMappers.newClientJsonMapper();
 
     @Override
     public Optional<RemoteException> handle(Response response) {

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/OkHttpClientsTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
 import com.google.common.net.HostAndPort;
@@ -348,7 +348,7 @@ public final class OkHttpClientsTest extends TestBase {
                 .errorName("error name")
                 .build();
         MockResponse mockResponse = new MockResponse()
-                .setBody(new ObjectMapper().writeValueAsString(error))
+                .setBody(new JsonMapper().writeValueAsString(error))
                 .addHeader("Content-Type", "application/json")
                 .setResponseCode(400);
         server.enqueue(mockResponse);

--- a/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/RemoteExceptionResponseHandlerTest.java
+++ b/okhttp-clients/src/test/java/com/palantir/conjure/java/okhttp/RemoteExceptionResponseHandlerTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.errors.ErrorType;
@@ -52,7 +52,7 @@ public final class RemoteExceptionResponseHandlerTest {
     private static final String message = "hello";
     private static final int STATUS_500 = 500;
 
-    private static final ObjectMapper SERVER_MAPPER = ObjectMappers.newServerObjectMapper();
+    private static final JsonMapper SERVER_MAPPER = ObjectMappers.newServerJsonMapper();
 
     private static final Request request =
             new Request.Builder().url("http://url").build();


### PR DESCRIPTION
In Jackson 2.13.0, in preparation for Jackson 3.0, some `ObjectMapper` configuration methods have been deprecated in favor of using the `ObjectMapper` subtype builders.

Because the existing `ObjectMappers` methods return `ObjectMapper`, consumers cannot modify/extend these object mapper using the `rebuild` functionality. For example, Witchcraft uses these methods to build a configuration deserialization object mapper.

This PR adds `ObjectMappers` methods that return the `ObjectMapper` subtypes and construct the object mappers using builders. In future PRs, we should deprecate and ultimately remove the existing methods.

For more details see [this Jackson 3.0 blog post](https://cowtowncoder.medium.com/jackson-3-0-immutability-w-builders-d9c532860d88).