### PR TITLE
Fix #2179 Exception mappers interpolate the errorInstanceId and errorName parameters

### DIFF
--- a/changelog/@unreleased/pr-2186.v2.yml
+++ b/changelog/@unreleased/pr-2186.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Exception mappers interpolate the errorInstanceId and errorName parameters
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2186

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/JsonExceptionMapper.java
@@ -57,15 +57,15 @@ abstract class JsonExceptionMapper<T extends Throwable> extends ListenableExcept
 
         if (errorType.httpErrorCode() / 100 == 4 /* client error */) {
             log.info(
-                    "Error handling request",
-                    SafeArg.of("errorInstanceId", errorInstanceId),
+                    "Error handling request. {}: {}",
                     SafeArg.of("errorName", errorType.name()),
+                    SafeArg.of("errorInstanceId", errorInstanceId),
                     exception);
         } else {
             log.error(
-                    "Error handling request",
-                    SafeArg.of("errorInstanceId", errorInstanceId),
+                    "Error handling request. {}: {}",
                     SafeArg.of("errorName", errorType.name()),
+                    SafeArg.of("errorInstanceId", errorInstanceId),
                     exception);
         }
 


### PR DESCRIPTION
## Before this PR

#2179

==COMMIT_MSG==
Exception mappers interpolate the errorInstanceId and errorName parameters
==COMMIT_MSG==

