### PR TITLE
Expand the supported cipher suite list

### DIFF
--- a/changelog/@unreleased/pr-2258.v2.yml
+++ b/changelog/@unreleased/pr-2258.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Expand the supported cipher suite list to include `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`,
+    `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`, `TLS_DHE_RSA_WITH_AES_256_GCM_SHA384`,
+    `TLS_DHE_RSA_WITH_AES_128_GCM_SHA256`
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2258

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
@@ -34,12 +34,16 @@ public final class CipherSuites {
     private static final ImmutableList<String> GCM_CIPHER_SUITES = ImmutableList.of(
             "TLS_AES_256_GCM_SHA384",
             "TLS_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
             "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
             "TLS_RSA_WITH_AES_256_GCM_SHA384",
-            "TLS_RSA_WITH_AES_128_GCM_SHA256");
+            "TLS_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256");
 
     private static final ImmutableList<String> ALL_CIPHER_SUITES = ImmutableList.<String>builder()
             .addAll(GCM_CIPHER_SUITES)


### PR DESCRIPTION
Includes the following new suites:
- `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
- `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
- `TLS_DHE_RSA_WITH_AES_256_GCM_SHA384`
- `TLS_DHE_RSA_WITH_AES_128_GCM_SHA256`

==COMMIT_MSG==
Expand the supported cipher suite list to include `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`, `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`, `TLS_DHE_RSA_WITH_AES_256_GCM_SHA384`, `TLS_DHE_RSA_WITH_AES_128_GCM_SHA256`
==COMMIT_MSG==

