### PR TITLE
Expose deprecated cipher info

### DIFF
--- a/changelog/@unreleased/pr-2272.v2.yml
+++ b/changelog/@unreleased/pr-2272.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Expose deprecated cipher info
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2272

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
@@ -18,7 +18,6 @@ package com.palantir.conjure.java.client.config;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.errorprone.annotations.InlineMe;
 import java.util.Set;
 
 public final class CipherSuites {
@@ -63,9 +62,6 @@ public final class CipherSuites {
      * @deprecated No longer necessary, GCM ciphers provide the most throughput on modern JVMs.
      */
     @Deprecated
-    @InlineMe(
-            replacement = "CipherSuites.allCipherSuites()",
-            imports = "com.palantir.conjure.java.client.config.CipherSuites")
     public static String[] fastCipherSuites() {
         return allCipherSuites();
     }
@@ -76,9 +72,6 @@ public final class CipherSuites {
      * @deprecated should not be used, this is an artifact from java-8 when gcm ciphers performed poorly.
      */
     @Deprecated
-    @InlineMe(
-            replacement = "CipherSuites.allCipherSuites()",
-            imports = "com.palantir.conjure.java.client.config.CipherSuites")
     public static String[] gcmCipherSuites() {
         return ALL_CIPHER_SUITES.stream()
                 .filter(cipherString -> cipherString.contains("_GCM_"))

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/CipherSuites.java
@@ -17,37 +17,41 @@
 package com.palantir.conjure.java.client.config;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.InlineMe;
+import java.util.Set;
 
 public final class CipherSuites {
 
-    private static final ImmutableList<String> OTHER_CIPHER_SUITES = ImmutableList.of(
-            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-            "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
-            "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
-            "TLS_RSA_WITH_AES_128_CBC_SHA256",
-            "TLS_RSA_WITH_AES_256_CBC_SHA256",
-            "TLS_CHACHA20_POLY1305_SHA256",
-            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256");
-
-    private static final ImmutableList<String> GCM_CIPHER_SUITES = ImmutableList.of(
+    private static final ImmutableList<String> CIPHERS = ImmutableList.of(
             "TLS_AES_256_GCM_SHA384",
             "TLS_AES_128_GCM_SHA256",
             "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            // required to include for http/2: https://http2.github.io/http2-spec/#rfc.section.9.2.2
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_CHACHA20_POLY1305_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256");
+
+    private static final ImmutableSet<String> DEPRECATED_CIPHERS = ImmutableSet.of(
             "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
             "TLS_RSA_WITH_AES_256_GCM_SHA384",
             "TLS_RSA_WITH_AES_128_GCM_SHA256",
-            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
-            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256");
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_RSA_WITH_AES_256_CBC_SHA256");
 
     private static final ImmutableList<String> ALL_CIPHER_SUITES = ImmutableList.<String>builder()
-            .addAll(GCM_CIPHER_SUITES)
-            .addAll(OTHER_CIPHER_SUITES)
+            .addAll(CIPHERS)
+            .addAll(DEPRECATED_CIPHERS)
             .build();
 
     /**
@@ -59,18 +63,36 @@ public final class CipherSuites {
      * @deprecated No longer necessary, GCM ciphers provide the most throughput on modern JVMs.
      */
     @Deprecated
+    @InlineMe(
+            replacement = "CipherSuites.allCipherSuites()",
+            imports = "com.palantir.conjure.java.client.config.CipherSuites")
     public static String[] fastCipherSuites() {
         return allCipherSuites();
     }
 
-    /** Known safe GCM cipher suites. */
+    /**
+     * GCM cipher suites.
+     *
+     * @deprecated should not be used, this is an artifact from java-8 when gcm ciphers performed poorly.
+     */
+    @Deprecated
+    @InlineMe(
+            replacement = "CipherSuites.allCipherSuites()",
+            imports = "com.palantir.conjure.java.client.config.CipherSuites")
     public static String[] gcmCipherSuites() {
-        return GCM_CIPHER_SUITES.toArray(new String[0]);
+        return ALL_CIPHER_SUITES.stream()
+                .filter(cipherString -> cipherString.contains("_GCM_"))
+                .toArray(String[]::new);
     }
 
     /** Union of {@link #fastCipherSuites()} and {@link #gcmCipherSuites()}. */
     public static String[] allCipherSuites() {
         return ALL_CIPHER_SUITES.toArray(new String[0]);
+    }
+
+    /** Returns ciphers which are currently supported, but are deprecated for removal in a future release. */
+    public static Set<String> deprecatedCiphers() {
+        return DEPRECATED_CIPHERS;
     }
 
     private CipherSuites() {}


### PR DESCRIPTION
Dialogue will use this data to produce client-side metrics
when a deprecated cipher is negotiated.

==COMMIT_MSG==
Expose deprecated cipher info
==COMMIT_MSG==

