### PR TITLE
Metrics to determine when a feign client dangerously buffers data

### DIFF
--- a/changelog/@unreleased/pr-2304.v2.yml
+++ b/changelog/@unreleased/pr-2304.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Metrics to determine when a feign client dangerously buffers data
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2304

--- a/conjure-java-jaxrs-client/build.gradle
+++ b/conjure-java-jaxrs-client/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.revapi'
+apply plugin: 'com.palantir.metric-schema'
 
 dependencies {
     api project(":extras:refresh-utils")
@@ -18,6 +19,8 @@ dependencies {
     implementation "com.palantir.dialogue:dialogue-core"
     implementation "com.palantir.dialogue:dialogue-serde"
     implementation 'com.palantir.safe-logging:logger'
+
+    implementation 'com.palantir.tritium:tritium-registry'
 
     implementation project(":conjure-java-jackson-serialization")
     implementation "com.google.guava:guava"

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/JaxRsClient.java
@@ -72,6 +72,7 @@ public final class JaxRsClient {
         Preconditions.checkNotNull(serviceClass, "JAX-RS interface is required");
         Preconditions.checkNotNull(runtime, "ConjureRuntime is required");
         return FeignJaxRsClientBuilder.create(
+                "JaxRsClient-" + serviceClass.getSimpleName(),
                 serviceClass,
                 channel,
                 runtime,

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/InputStreamDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/InputStreamDelegateDecoder.java
@@ -16,6 +16,10 @@
 
 package com.palantir.conjure.java.client.jaxrs.feignimpl;
 
+import com.codahale.metrics.Meter;
+import com.palantir.conjure.java.client.jaxrs.feignimpl.FeignClientMetrics.DangerousBuffering_Direction;
+import com.palantir.logsafe.Safe;
+import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import feign.FeignException;
 import feign.Response;
 import feign.Util;
@@ -28,9 +32,20 @@ import java.lang.reflect.Type;
 /** If the return type is InputStream, return it, otherwise delegate to provided decoder. */
 public final class InputStreamDelegateDecoder implements Decoder {
     private final Decoder delegate;
+    private final Meter dangerousBufferingMeter;
 
     public InputStreamDelegateDecoder(Decoder delegate) {
+        this("unknown", delegate);
+    }
+
+    @SuppressWarnings("deprecation") // No access to a TaggedMetricRegistry without breaking API
+    public InputStreamDelegateDecoder(@Safe String clientNameForLogging, Decoder delegate) {
         this.delegate = delegate;
+        this.dangerousBufferingMeter = FeignClientMetrics.of(SharedTaggedMetricRegistries.getSingleton())
+                .dangerousBuffering()
+                .client(clientNameForLogging)
+                .direction(DangerousBuffering_Direction.RESPONSE)
+                .build();
     }
 
     @Override
@@ -38,6 +53,7 @@ public final class InputStreamDelegateDecoder implements Decoder {
         if (type.equals(InputStream.class)) {
             byte[] body =
                     response.body() != null ? Util.toByteArray(response.body().asInputStream()) : new byte[0];
+            dangerousBufferingMeter.mark(Math.max(1, body.length));
             return new ByteArrayInputStream(body);
         } else {
             return delegate.decode(response, type);

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureInputStreamDelegateDecoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureInputStreamDelegateDecoder.java
@@ -31,7 +31,7 @@ public final class ConjureInputStreamDelegateDecoder implements Decoder {
     private final Decoder delegate;
 
     public ConjureInputStreamDelegateDecoder(Decoder delegate) {
-        this.delegate = new InputStreamDelegateDecoder(delegate);
+        this.delegate = new InputStreamDelegateDecoder("unknown", delegate);
     }
 
     @Override

--- a/conjure-java-jaxrs-client/src/main/java/feign/ConjureInputStreamDelegateEncoder.java
+++ b/conjure-java-jaxrs-client/src/main/java/feign/ConjureInputStreamDelegateEncoder.java
@@ -31,7 +31,7 @@ public final class ConjureInputStreamDelegateEncoder implements Encoder {
     private final Encoder delegate;
 
     public ConjureInputStreamDelegateEncoder(Encoder delegate) {
-        this.delegate = new InputStreamDelegateEncoder(delegate);
+        this.delegate = new InputStreamDelegateEncoder("unknown", delegate);
     }
 
     @Override

--- a/conjure-java-jaxrs-client/src/main/metrics/dangerous-buffering.yml
+++ b/conjure-java-jaxrs-client/src/main/metrics/dangerous-buffering.yml
@@ -13,7 +13,8 @@ namespaces:
           - name: direction
             values: [request, response]
         docs: |
-          Meter incremented each time a feign client is used to send or receive streamed binary data. Feign should
-          never be used in this way because it fully buffers the request and response internally, resulting in heavy
-          heap pressure. Dialogue clients are preferred as they do not cause such heap churn, and allow streaming
-          beyond two gigabytes of data.
+          Meter incremented each time a feign client is used to send or receive streamed binary data by the number of 
+          bytes sent or received (minimum one such that empty streams are recorded).
+          Feign should never be used in this way because it fully buffers the request and response internally,
+          resulting in heavy heap pressure. Dialogue clients are preferred as they do not cause such heap churn,
+          and allow streaming beyond two gigabytes of data.

--- a/conjure-java-jaxrs-client/src/main/metrics/dangerous-buffering.yml
+++ b/conjure-java-jaxrs-client/src/main/metrics/dangerous-buffering.yml
@@ -1,0 +1,19 @@
+options:
+  javaPackage: com.palantir.conjure.java.client.jaxrs.feignimpl
+  javaVisibility: packagePrivate
+namespaces:
+  feign.client:
+    docs: Metrics produced by Feign clients
+    metrics:
+      dangerous.buffering:
+        type: meter
+        tags:
+          - name: client
+            docs: Name of the client which dangerously buffered data.
+          - name: direction
+            values: [request, response]
+        docs: |
+          Meter incremented each time a feign client is used to send or receive streamed binary data. Feign should
+          never be used in this way because it fully buffers the request and response internally, resulting in heavy
+          heap pressure. Dialogue clients are preferred as they do not cause such heap churn, and allow streaming
+          beyond two gigabytes of data.


### PR DESCRIPTION
We are phasing out feign clients, this allows us to detect the
most critical clients to migrate to dialogue.

==COMMIT_MSG==
Metrics to determine when a feign client dangerously buffers data
==COMMIT_MSG==
