### PR TITLE
WebApplicationExceptionMapper treats redirection as informational

### DIFF
--- a/changelog/@unreleased/pr-2316.v2.yml
+++ b/changelog/@unreleased/pr-2316.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: WebApplicationExceptionMapper treats redirection as informational
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2316

--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapper.java
@@ -52,10 +52,10 @@ final class WebApplicationExceptionMapper extends ListenableExceptionMapper<WebA
     public Response toResponseInner(WebApplicationException exception) {
         String errorInstanceId = UUID.randomUUID().toString();
 
-        if (exception.getResponse().getStatus() / 100 == 4 /* client error */) {
-            log.info("Error handling request", SafeArg.of("errorInstanceId", errorInstanceId), exception);
-        } else {
+        if (exception.getResponse().getStatusInfo().getFamily() == Response.Status.Family.SERVER_ERROR) {
             log.error("Error handling request", SafeArg.of("errorInstanceId", errorInstanceId), exception);
+        } else {
+            log.info("Error handling request", SafeArg.of("errorInstanceId", errorInstanceId), exception);
         }
 
         if (exception instanceof NotAuthorizedException) {

--- a/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapperTest.java
+++ b/conjure-java-jersey-server/src/test/java/com/palantir/conjure/java/server/jersey/WebApplicationExceptionMapperTest.java
@@ -25,6 +25,7 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.RedirectionException;
 import javax.ws.rs.ServiceUnavailableException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -101,6 +102,19 @@ public final class WebApplicationExceptionMapperTest {
         assertThat(entity).contains("\"errorCode\" : \"javax.ws.rs.ServiceUnavailableException\"");
         assertThat(entity).contains("\"errorName\" : \"ServiceUnavailableException\"");
         assertThat(response.getStatus()).isEqualTo(503);
+        assertThat(entity).doesNotContain("secret");
+    }
+
+    @Test
+    public void handle304NotModified() throws Exception {
+        Response response = mapper.toResponse(
+                new RedirectionException(Response.notModified("test-etag").build()));
+        String entity = objectMapper.writeValueAsString(response.getEntity());
+        assertThat(entity).contains("\"errorCode\" : \"javax.ws.rs.RedirectionException\"");
+        assertThat(entity).contains("\"errorName\" : \"RedirectionException\"");
+        assertThat(entity).contains("\"errorInstanceId\" : ");
+        assertThat(response.getStatus()).isEqualTo(304);
+        assertThat(response.getHeaderString("ETag")).isNull();
         assertThat(entity).doesNotContain("secret");
     }
 }


### PR DESCRIPTION
## Before this PR
RedirectionExceptions were being logged at `ERROR`, especially HTTP 304 Not Modified

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
WebApplicationExceptionMapper treats redirection as informational
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

