### PR TITLE
Fail if annotated server resource is used as a client

### DIFF
--- a/changelog/@unreleased/pr-2324.v2.yml
+++ b/changelog/@unreleased/pr-2324.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fail if annotated server resource is used as a client
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2324

--- a/conjure-java-jaxrs-client/build.gradle
+++ b/conjure-java-jaxrs-client/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     }
     api "com.palantir.dialogue:dialogue-target"
 
+    implementation project(":conjure-java-annotations")
     implementation "com.palantir.dialogue:dialogue-apache-hc5-client"
     implementation "com.palantir.dialogue:dialogue-core"
     implementation "com.palantir.dialogue:dialogue-serde"

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientAnnotationVerificationTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientAnnotationVerificationTest.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import org.junit.Test;
+
+public final class JaxRsClientAnnotationVerificationTest extends TestBase {
+
+    @Test
+    public void can_create_client_with_no_annotations() {
+        createClient(TestService.class);
+    }
+
+    @Test
+    public void can_create_client_with_client_annotation() {
+        createClient(OnlyClientAnnotation.class);
+    }
+
+    @Test
+    public void can_create_client_with_client_and_server_annotation() {
+        createClient(ClientAndServerAnnotation.class);
+    }
+
+    @Test
+    public void fails_creating_client_with_only_server_annotation() {
+        assertThatThrownBy(() -> createClient(OnlyServerAnnotation.class))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Service class should not be used as a client");
+    }
+
+    @com.palantir.conjure.java.annotations.JaxRsClient
+    interface OnlyClientAnnotation extends TestService {}
+
+    @com.palantir.conjure.java.annotations.JaxRsServer
+    interface OnlyServerAnnotation extends TestService {}
+
+    @com.palantir.conjure.java.annotations.JaxRsServer
+    @com.palantir.conjure.java.annotations.JaxRsClient
+    interface ClientAndServerAnnotation extends TestService {}
+
+    private void createClient(Class<?> serviceClass) {
+        JaxRsClient.create(serviceClass, AGENT, new HostMetricsRegistry(), createTestConfig("http://localhost:4321"));
+    }
+}


### PR DESCRIPTION
## Before this PR
FLUP on https://github.com/palantir/conjure-java-runtime/pull/2320 where we added the marker annotations.

## After this PR

Fail if a JaxRs class is only annotated with `@JaxRsServer` but is used to create a client. Note that we still succeed if no annotation is given or if the class is annotated with both `@JaxRsServer` and `@JaxRsClient`.

==COMMIT_MSG==
Fail if annotated server resource is used as a client
==COMMIT_MSG==

## Possible downsides?
I wonder if this should be an error-prone check instead to fail at compile rather then runtime?
We might want to add something similar to verify client interfaces are not used as servers.