### PR TITLE
CompatibleJaxRsContract exceptions retain causal exception

### DIFF
--- a/changelog/@unreleased/pr-2437.v2.yml
+++ b/changelog/@unreleased/pr-2437.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: CompatibleJaxRsContract exceptions retain causal exception
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2437

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/CompatibleJaxRsContract.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/CompatibleJaxRsContract.java
@@ -240,7 +240,7 @@ public final class CompatibleJaxRsContract extends Contract.BaseContract {
             return annotation.annotationType().getMethod("value").invoke(annotation);
         } catch (ReflectiveOperationException e) {
             throw new SafeIllegalStateException(
-                    "Failed to read annotation value", SafeArg.of("annotationType", annotation.annotationType()));
+                    "Failed to read annotation value", e, SafeArg.of("annotationType", annotation.annotationType()));
         }
     }
 


### PR DESCRIPTION
I noticed this while fixing up an issue with a graalvm native-image
build internally.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
CompatibleJaxRsContract exceptions retain causal exception
==COMMIT_MSG==