### PR TITLE
Report metrics when unusually large strings are parsed

### DIFF
--- a/changelog/@unreleased/pr-2569.v2.yml
+++ b/changelog/@unreleased/pr-2569.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Report metrics when unusually large strings are parsed using JSON mappers
+    created using Conjure ObjectMappers factory methods.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2569

--- a/conjure-java-jackson-serialization/build.gradle
+++ b/conjure-java-jackson-serialization/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.revapi'
+apply plugin: 'com.palantir.metric-schema'
 
 dependencies {
     implementation project(":conjure-java-jackson-optimizations")
@@ -11,6 +12,8 @@ dependencies {
     api "com.fasterxml.jackson.datatype:jackson-datatype-joda"
     api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     api "com.palantir.safe-logging:preconditions"
+    implementation "com.palantir.safe-logging:logger"
+    implementation 'com.palantir.tritium:tritium-registry'
 
     testImplementation "junit:junit"
     testImplementation "org.assertj:assertj-core"

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/InstrumentedJsonFactory.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/InstrumentedJsonFactory.java
@@ -1,0 +1,710 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.serialization;
+
+import com.codahale.metrics.Histogram;
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.FormatSchema;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonStreamContext;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.StreamReadCapability;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.TSFBuilder;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.async.NonBlockingInputFeeder;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.util.JacksonFeatureSet;
+import com.fasterxml.jackson.core.util.RequestPayload;
+import com.google.common.util.concurrent.RateLimiter;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.io.DataInput;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Iterator;
+import javax.annotation.Nullable;
+
+final class InstrumentedJsonFactory extends JsonFactory {
+
+    // Log at most once per second
+    private static final RateLimiter LOGGING_RATE_LIMITER = RateLimiter.create(1);
+    private static final SafeLogger log = SafeLoggerFactory.get(InstrumentedJsonFactory.class);
+    private final Histogram parsedStringLength;
+    private final Throwable creationStackTrace;
+
+    // Using the shared metric registry singleton to avoid API churn in methods that use this instrumentation.
+    @SuppressWarnings("deprecation")
+    InstrumentedJsonFactory() {
+        this(SharedTaggedMetricRegistries.getSingleton());
+    }
+
+    InstrumentedJsonFactory(TaggedMetricRegistry registry) {
+        this.parsedStringLength = JsonParserMetrics.of(registry).stringLength();
+        this.creationStackTrace = new SafeRuntimeException("InstrumentedJsonFactory created here");
+    }
+
+    private InstrumentedJsonFactory(
+            JsonFactoryBuilder builder, Histogram parsedStringLength, Throwable creationStackTrace) {
+        super(builder);
+        this.parsedStringLength = parsedStringLength;
+        this.creationStackTrace = creationStackTrace;
+    }
+
+    private InstrumentedJsonFactory(
+            JsonFactory src, @Nullable ObjectCodec codec, Histogram parsedStringLength, Throwable creationStackTrace) {
+        super(src, codec);
+        this.parsedStringLength = parsedStringLength;
+        this.creationStackTrace = creationStackTrace;
+    }
+
+    @Override
+    public TSFBuilder<?, ?> rebuild() {
+        return new JsonFactoryBuilder(this) {
+            @Override
+            public JsonFactory build() {
+                return new InstrumentedJsonFactory(this, parsedStringLength, creationStackTrace);
+            }
+        };
+    }
+
+    @Override
+    public JsonFactory copy() {
+        return new InstrumentedJsonFactory(this, null, parsedStringLength, creationStackTrace);
+    }
+
+    @Override
+    protected JsonParser _createParser(InputStream in, IOContext ctxt) throws IOException {
+        return wrap(super._createParser(in, ctxt));
+    }
+
+    @Override
+    protected JsonParser _createParser(Reader reader, IOContext ctxt) throws IOException {
+        return wrap(super._createParser(reader, ctxt));
+    }
+
+    @Override
+    protected JsonParser _createParser(char[] data, int offset, int len, IOContext ctxt, boolean recyclable)
+            throws IOException {
+        return wrap(super._createParser(data, offset, len, ctxt, recyclable));
+    }
+
+    @Override
+    protected JsonParser _createParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException {
+        return wrap(super._createParser(data, offset, len, ctxt));
+    }
+
+    @Override
+    protected JsonParser _createParser(DataInput input, IOContext ctxt) throws IOException {
+        return wrap(super._createParser(input, ctxt));
+    }
+
+    private JsonParser wrap(JsonParser input) {
+        if (input == null || input instanceof InstrumentedJsonParser) {
+            return input;
+        }
+        return new InstrumentedJsonParser(input, parsedStringLength, creationStackTrace);
+    }
+
+    private static final class InstrumentedJsonParser extends JsonParser {
+        private final JsonParser delegate;
+        private final Histogram parsedStringLength;
+        private final Throwable factoryCreationStackTrace;
+
+        InstrumentedJsonParser(JsonParser delegate, Histogram parsedStringLength, Throwable factoryCreationStackTrace) {
+            this.delegate = delegate;
+            this.parsedStringLength = parsedStringLength;
+            this.factoryCreationStackTrace = factoryCreationStackTrace;
+        }
+
+        private String recordStringLength(String value) {
+            if (value != null) {
+                int length = value.length();
+                parsedStringLength.update(length);
+                if (length > 1_000_000 && LOGGING_RATE_LIMITER.tryAcquire()) {
+                    log.info(
+                            "Detected an unusually large JSON string value",
+                            SafeArg.of("length", length),
+                            new SafeRuntimeException("Pared here", factoryCreationStackTrace));
+                }
+            }
+            return value;
+        }
+
+        @Override
+        public ObjectCodec getCodec() {
+            return delegate.getCodec();
+        }
+
+        @Override
+        public void setCodec(ObjectCodec oc) {
+            delegate.setCodec(oc);
+        }
+
+        @Override
+        public Object getInputSource() {
+            return delegate.getInputSource();
+        }
+
+        @Override
+        public void setRequestPayloadOnError(RequestPayload payload) {
+            delegate.setRequestPayloadOnError(payload);
+        }
+
+        @Override
+        public void setRequestPayloadOnError(byte[] payload, String charset) {
+            delegate.setRequestPayloadOnError(payload, charset);
+        }
+
+        @Override
+        public void setRequestPayloadOnError(String payload) {
+            delegate.setRequestPayloadOnError(payload);
+        }
+
+        @Override
+        public void setSchema(FormatSchema schema) {
+            delegate.setSchema(schema);
+        }
+
+        @Override
+        public FormatSchema getSchema() {
+            return delegate.getSchema();
+        }
+
+        @Override
+        public boolean canUseSchema(FormatSchema schema) {
+            return delegate.canUseSchema(schema);
+        }
+
+        @Override
+        public boolean requiresCustomCodec() {
+            return delegate.requiresCustomCodec();
+        }
+
+        @Override
+        public boolean canParseAsync() {
+            return delegate.canParseAsync();
+        }
+
+        @Override
+        public NonBlockingInputFeeder getNonBlockingInputFeeder() {
+            return delegate.getNonBlockingInputFeeder();
+        }
+
+        @Override
+        public JacksonFeatureSet<StreamReadCapability> getReadCapabilities() {
+            return delegate.getReadCapabilities();
+        }
+
+        @Override
+        public Version version() {
+            return delegate.version();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return delegate.isClosed();
+        }
+
+        @Override
+        public JsonStreamContext getParsingContext() {
+            return delegate.getParsingContext();
+        }
+
+        @Override
+        public JsonLocation currentLocation() {
+            return delegate.currentLocation();
+        }
+
+        @Override
+        public JsonLocation currentTokenLocation() {
+            return delegate.currentTokenLocation();
+        }
+
+        @Override
+        public JsonLocation getCurrentLocation() {
+            return delegate.getCurrentLocation();
+        }
+
+        @Override
+        public JsonLocation getTokenLocation() {
+            return delegate.getTokenLocation();
+        }
+
+        @Override
+        public Object currentValue() {
+            return delegate.currentValue();
+        }
+
+        @Override
+        public void assignCurrentValue(Object value) {
+            delegate.assignCurrentValue(value);
+        }
+
+        @Override
+        public Object getCurrentValue() {
+            return delegate.getCurrentValue();
+        }
+
+        @Override
+        public void setCurrentValue(Object value) {
+            delegate.setCurrentValue(value);
+        }
+
+        @Override
+        public int releaseBuffered(OutputStream out) throws IOException {
+            return delegate.releaseBuffered(out);
+        }
+
+        @Override
+        public int releaseBuffered(Writer writer) throws IOException {
+            return delegate.releaseBuffered(writer);
+        }
+
+        @Override
+        public JsonParser enable(Feature feature) {
+            delegate.enable(feature);
+            return this;
+        }
+
+        @Override
+        public JsonParser disable(Feature feature) {
+            delegate.disable(feature);
+            return this;
+        }
+
+        @Override
+        public JsonParser configure(Feature feature, boolean state) {
+            delegate.configure(feature, state);
+            return this;
+        }
+
+        @Override
+        public boolean isEnabled(Feature feature) {
+            return delegate.isEnabled(feature);
+        }
+
+        @Override
+        public boolean isEnabled(StreamReadFeature feature) {
+            return delegate.isEnabled(feature);
+        }
+
+        @Override
+        public int getFeatureMask() {
+            return delegate.getFeatureMask();
+        }
+
+        @Override
+        @Deprecated
+        public JsonParser setFeatureMask(int mask) {
+            delegate.setFeatureMask(mask);
+            return this;
+        }
+
+        @Override
+        public JsonParser overrideStdFeatures(int values, int mask) {
+            delegate.overrideStdFeatures(values, mask);
+            return this;
+        }
+
+        @Override
+        public int getFormatFeatures() {
+            return delegate.getFormatFeatures();
+        }
+
+        @Override
+        public JsonParser overrideFormatFeatures(int values, int mask) {
+            delegate.overrideFormatFeatures(values, mask);
+            return this;
+        }
+
+        @Override
+        public JsonToken nextToken() throws IOException {
+            return delegate.nextToken();
+        }
+
+        @Override
+        public JsonToken nextValue() throws IOException {
+            return delegate.nextValue();
+        }
+
+        @Override
+        public boolean nextFieldName(SerializableString str) throws IOException {
+            return delegate.nextFieldName(str);
+        }
+
+        @Override
+        public String nextFieldName() throws IOException {
+            return delegate.nextFieldName();
+        }
+
+        @Override
+        public String nextTextValue() throws IOException {
+            return recordStringLength(delegate.nextTextValue());
+        }
+
+        @Override
+        public int nextIntValue(int defaultValue) throws IOException {
+            return delegate.nextIntValue(defaultValue);
+        }
+
+        @Override
+        public long nextLongValue(long defaultValue) throws IOException {
+            return delegate.nextLongValue(defaultValue);
+        }
+
+        @Override
+        public Boolean nextBooleanValue() throws IOException {
+            return delegate.nextBooleanValue();
+        }
+
+        @Override
+        public JsonParser skipChildren() throws IOException {
+            delegate.skipChildren();
+            return this;
+        }
+
+        @Override
+        public void finishToken() throws IOException {
+            delegate.finishToken();
+        }
+
+        @Override
+        public JsonToken currentToken() {
+            return delegate.currentToken();
+        }
+
+        @Override
+        public int currentTokenId() {
+            return delegate.currentTokenId();
+        }
+
+        @Override
+        public JsonToken getCurrentToken() {
+            return delegate.getCurrentToken();
+        }
+
+        @Override
+        @Deprecated
+        public int getCurrentTokenId() {
+            return delegate.getCurrentTokenId();
+        }
+
+        @Override
+        public boolean hasCurrentToken() {
+            return delegate.hasCurrentToken();
+        }
+
+        @Override
+        public boolean hasTokenId(int id) {
+            return delegate.hasTokenId(id);
+        }
+
+        @Override
+        public boolean hasToken(JsonToken token) {
+            return delegate.hasToken(token);
+        }
+
+        @Override
+        public boolean isExpectedStartArrayToken() {
+            return delegate.isExpectedStartArrayToken();
+        }
+
+        @Override
+        public boolean isExpectedStartObjectToken() {
+            return delegate.isExpectedStartObjectToken();
+        }
+
+        @Override
+        public boolean isExpectedNumberIntToken() {
+            return delegate.isExpectedNumberIntToken();
+        }
+
+        @Override
+        public boolean isNaN() throws IOException {
+            return delegate.isNaN();
+        }
+
+        @Override
+        public void clearCurrentToken() {
+            delegate.clearCurrentToken();
+        }
+
+        @Override
+        public JsonToken getLastClearedToken() {
+            return delegate.getLastClearedToken();
+        }
+
+        @Override
+        public void overrideCurrentName(String name) {
+            delegate.overrideCurrentName(name);
+        }
+
+        @Override
+        public String getCurrentName() throws IOException {
+            return delegate.getCurrentName();
+        }
+
+        @Override
+        public String currentName() throws IOException {
+            return delegate.currentName();
+        }
+
+        @Override
+        public String getText() throws IOException {
+            return recordStringLength(delegate.getText());
+        }
+
+        @Override
+        public int getText(Writer writer) throws IOException, UnsupportedOperationException {
+            return delegate.getText(writer);
+        }
+
+        @Override
+        public char[] getTextCharacters() throws IOException {
+            return delegate.getTextCharacters();
+        }
+
+        @Override
+        public int getTextLength() throws IOException {
+            return delegate.getTextLength();
+        }
+
+        @Override
+        public int getTextOffset() throws IOException {
+            return delegate.getTextOffset();
+        }
+
+        @Override
+        public boolean hasTextCharacters() {
+            return delegate.hasTextCharacters();
+        }
+
+        @Override
+        public Number getNumberValue() throws IOException {
+            return delegate.getNumberValue();
+        }
+
+        @Override
+        public Number getNumberValueExact() throws IOException {
+            return delegate.getNumberValueExact();
+        }
+
+        @Override
+        public NumberType getNumberType() throws IOException {
+            return delegate.getNumberType();
+        }
+
+        @Override
+        public byte getByteValue() throws IOException {
+            return delegate.getByteValue();
+        }
+
+        @Override
+        public short getShortValue() throws IOException {
+            return delegate.getShortValue();
+        }
+
+        @Override
+        public int getIntValue() throws IOException {
+            return delegate.getIntValue();
+        }
+
+        @Override
+        public long getLongValue() throws IOException {
+            return delegate.getLongValue();
+        }
+
+        @Override
+        public BigInteger getBigIntegerValue() throws IOException {
+            return delegate.getBigIntegerValue();
+        }
+
+        @Override
+        public float getFloatValue() throws IOException {
+            return delegate.getFloatValue();
+        }
+
+        @Override
+        public double getDoubleValue() throws IOException {
+            return delegate.getDoubleValue();
+        }
+
+        @Override
+        public BigDecimal getDecimalValue() throws IOException {
+            return delegate.getDecimalValue();
+        }
+
+        @Override
+        public boolean getBooleanValue() throws IOException {
+            return delegate.getBooleanValue();
+        }
+
+        @Override
+        public Object getEmbeddedObject() throws IOException {
+            return delegate.getEmbeddedObject();
+        }
+
+        @Override
+        public byte[] getBinaryValue(Base64Variant bv) throws IOException {
+            return delegate.getBinaryValue(bv);
+        }
+
+        @Override
+        public byte[] getBinaryValue() throws IOException {
+            return delegate.getBinaryValue();
+        }
+
+        @Override
+        public int readBinaryValue(OutputStream out) throws IOException {
+            return delegate.readBinaryValue(out);
+        }
+
+        @Override
+        public int readBinaryValue(Base64Variant bv, OutputStream out) throws IOException {
+            return delegate.readBinaryValue(bv, out);
+        }
+
+        @Override
+        public int getValueAsInt() throws IOException {
+            return delegate.getValueAsInt();
+        }
+
+        @Override
+        public int getValueAsInt(int def) throws IOException {
+            return delegate.getValueAsInt(def);
+        }
+
+        @Override
+        public long getValueAsLong() throws IOException {
+            return delegate.getValueAsLong();
+        }
+
+        @Override
+        public long getValueAsLong(long def) throws IOException {
+            return delegate.getValueAsLong(def);
+        }
+
+        @Override
+        public double getValueAsDouble() throws IOException {
+            return delegate.getValueAsDouble();
+        }
+
+        @Override
+        public double getValueAsDouble(double def) throws IOException {
+            return delegate.getValueAsDouble(def);
+        }
+
+        @Override
+        public boolean getValueAsBoolean() throws IOException {
+            return delegate.getValueAsBoolean();
+        }
+
+        @Override
+        public boolean getValueAsBoolean(boolean def) throws IOException {
+            return delegate.getValueAsBoolean(def);
+        }
+
+        @Override
+        public String getValueAsString() throws IOException {
+            return recordStringLength(delegate.getValueAsString());
+        }
+
+        @Override
+        public String getValueAsString(String def) throws IOException {
+            return recordStringLength(delegate.getValueAsString(def));
+        }
+
+        @Override
+        public boolean canReadObjectId() {
+            return delegate.canReadObjectId();
+        }
+
+        @Override
+        public boolean canReadTypeId() {
+            return delegate.canReadTypeId();
+        }
+
+        @Override
+        public Object getObjectId() throws IOException {
+            return delegate.getObjectId();
+        }
+
+        @Override
+        public Object getTypeId() throws IOException {
+            return delegate.getTypeId();
+        }
+
+        @Override
+        public <T> T readValueAs(Class<T> valueType) throws IOException {
+            return delegate.readValueAs(valueType);
+        }
+
+        @Override
+        @SuppressWarnings("TypeParameterUnusedInFormals")
+        public <T> T readValueAs(TypeReference<?> valueTypeRef) throws IOException {
+            return delegate.readValueAs(valueTypeRef);
+        }
+
+        @Override
+        public <T> Iterator<T> readValuesAs(Class<T> valueType) throws IOException {
+            return delegate.readValuesAs(valueType);
+        }
+
+        @Override
+        public <T> Iterator<T> readValuesAs(TypeReference<T> valueTypeRef) throws IOException {
+            return delegate.readValuesAs(valueTypeRef);
+        }
+
+        @Override
+        @SuppressWarnings("TypeParameterUnusedInFormals")
+        public <T extends TreeNode> T readValueAsTree() throws IOException {
+            return delegate.readValueAsTree();
+        }
+
+        @Override
+        public ObjectCodec _codec() {
+            ObjectCodec codec = delegate.getCodec();
+            if (codec == null) {
+                throw new SafeIllegalStateException("No ObjectCodec defined for parser, needed for deserialization");
+            }
+            return codec;
+        }
+    }
+}

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/InstrumentedSmileFactory.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/InstrumentedSmileFactory.java
@@ -1,0 +1,234 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.serialization;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer;
+import com.fasterxml.jackson.dataformat.smile.SmileConstants;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import com.fasterxml.jackson.dataformat.smile.SmileFactoryBuilder;
+import com.fasterxml.jackson.dataformat.smile.SmileParser;
+import com.fasterxml.jackson.dataformat.smile.SmileParserBootstrapper;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.annotation.Nullable;
+
+final class InstrumentedSmileFactory extends SmileFactory {
+
+    private final ParserInstrumentation instrumentation;
+
+    InstrumentedSmileFactory() {
+        instrumentation = new ParserInstrumentation();
+    }
+
+    private InstrumentedSmileFactory(SmileFactoryBuilder builder) {
+        this(builder, new ParserInstrumentation());
+    }
+
+    private InstrumentedSmileFactory(SmileFactoryBuilder builder, ParserInstrumentation instrumentation) {
+        super(builder);
+        this.instrumentation = instrumentation;
+    }
+
+    private InstrumentedSmileFactory(
+            SmileFactory src, @Nullable ObjectCodec codec, ParserInstrumentation instrumentation) {
+        super(src, codec);
+        this.instrumentation = instrumentation;
+    }
+
+    public static SmileFactoryBuilder builder() {
+        return new SmileFactoryBuilder() {
+            @Override
+            public SmileFactory build() {
+                return new InstrumentedSmileFactory(this);
+            }
+        };
+    }
+
+    @Override
+    public SmileFactoryBuilder rebuild() {
+        return new SmileFactoryBuilder(this) {
+            @Override
+            public SmileFactory build() {
+                return new InstrumentedSmileFactory(this, instrumentation);
+            }
+        };
+    }
+
+    @Override
+    public SmileFactory copy() {
+        return new InstrumentedSmileFactory(this, null, instrumentation);
+    }
+
+    @Override
+    protected SmileParser _createParser(InputStream in, IOContext ctxt) throws IOException {
+        SmileParserBootstrapper bootstrapper = new InstrumentedSmileParserBootstrapper(ctxt, in, instrumentation);
+        return bootstrapper.constructParser(
+                _factoryFeatures, _parserFeatures, _smileParserFeatures, _objectCodec, _byteSymbolCanonicalizer);
+    }
+
+    @Override
+    protected SmileParser _createParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException {
+        return new InstrumentedSmileParserBootstrapper(ctxt, data, offset, len, instrumentation)
+                .constructParser(
+                        _factoryFeatures,
+                        _parserFeatures,
+                        _smileParserFeatures,
+                        _objectCodec,
+                        _byteSymbolCanonicalizer);
+    }
+
+    private static final class InstrumentedSmileParserBootstrapper extends SmileParserBootstrapper {
+
+        private final ParserInstrumentation instrumentation;
+
+        InstrumentedSmileParserBootstrapper(IOContext ctxt, InputStream in, ParserInstrumentation instrumentation) {
+            super(ctxt, in);
+            this.instrumentation = instrumentation;
+        }
+
+        InstrumentedSmileParserBootstrapper(
+                IOContext ctxt,
+                byte[] inputBuffer,
+                int inputStart,
+                int inputLen,
+                ParserInstrumentation instrumentation) {
+            super(ctxt, inputBuffer, inputStart, inputLen);
+            this.instrumentation = instrumentation;
+        }
+
+        /**
+         * This method is copied from the superclass, updated to instantiate an instrumented smile factory
+         * instead of the default.
+         * Original implementation is
+         * <a href="https://github.com/FasterXML/jackson-dataformats-binary/blob/527fbb6a42358d92d493285f35a4387c482a3aaa/smile/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileParserBootstrapper.java#L89-L138">here</a>
+         * using the Apache 2.0 license.
+         */
+        @Override
+        public InstrumentedSmileParser constructParser(
+                int factoryFeatures,
+                int generalParserFeatures,
+                int smileFeatures,
+                ObjectCodec codec,
+                ByteQuadsCanonicalizer rootByteSymbols)
+                throws IOException, JsonParseException {
+            // 13-Mar-2021, tatu: [dataformats-binary#252] Create canonicalizing OR
+            //    placeholder, depending on settings
+            ByteQuadsCanonicalizer can = rootByteSymbols.makeChildOrPlaceholder(factoryFeatures);
+            // We just need a single byte, really, to know if it starts with header
+            int end = _inputEnd;
+            if ((_inputPtr < end) && (_in != null)) {
+                int count = _in.read(_inputBuffer, end, _inputBuffer.length - end);
+                if (count > 0) {
+                    _inputEnd += count;
+                }
+            }
+
+            InstrumentedSmileParser smileParser = new InstrumentedSmileParser(
+                    _context,
+                    generalParserFeatures,
+                    smileFeatures,
+                    codec,
+                    can,
+                    _in,
+                    _inputBuffer,
+                    _inputPtr,
+                    _inputEnd,
+                    _bufferRecyclable,
+                    instrumentation);
+            boolean hadSig = false;
+
+            if (_inputPtr >= _inputEnd) { // only the case for empty doc
+                // 11-Oct-2012, tatu: Actually, let's allow empty documents even if
+                //   header signature would otherwise be needed. This is useful for
+                //   JAX-RS provider, empty PUT/POST payloads.
+                return smileParser;
+            }
+            final byte firstByte = _inputBuffer[_inputPtr];
+            if (firstByte == SmileConstants.HEADER_BYTE_1) {
+                // need to ensure it gets properly handled so caller won't see the signature
+                hadSig = smileParser.handleSignature(true, true);
+            }
+
+            if (!hadSig && SmileParser.Feature.REQUIRE_HEADER.enabledIn(smileFeatures)) {
+                // Ok, first, let's see if it looks like plain JSON...
+                String msg;
+
+                if (firstByte == '{' || firstByte == '[') {
+                    msg = "Input does not start with Smile format header (first byte = 0x"
+                            + Integer.toHexString(firstByte & 0xFF) + ") -- rather, it starts with '"
+                            + ((char) firstByte)
+                            + "' (plain JSON input?) -- can not parse";
+                } else {
+                    msg = "Input does not start with Smile format header (first byte = 0x"
+                            + Integer.toHexString(firstByte & 0xFF)
+                            + ") and parser has REQUIRE_HEADER enabled: can not parse";
+                }
+                throw new JsonParseException(smileParser, msg);
+            }
+            return smileParser;
+        }
+    }
+
+    private static final class InstrumentedSmileParser extends SmileParser {
+        private final ParserInstrumentation instrumentation;
+
+        InstrumentedSmileParser(
+                IOContext ctxt,
+                int parserFeatures,
+                int smileFeatures,
+                ObjectCodec codec,
+                ByteQuadsCanonicalizer sym,
+                InputStream in,
+                byte[] inputBuffer,
+                int start,
+                int end,
+                boolean bufferRecyclable,
+                ParserInstrumentation instrumentation) {
+            super(ctxt, parserFeatures, smileFeatures, codec, sym, in, inputBuffer, start, end, bufferRecyclable);
+            this.instrumentation = instrumentation;
+        }
+
+        @Override
+        public String nextTextValue() throws IOException {
+            return instrumentation.recordStringLength(super.nextTextValue());
+        }
+
+        @Override
+        public String getText() throws IOException {
+            return instrumentation.recordStringLength(super.getText());
+        }
+
+        @Override
+        public String getValueAsString() throws IOException {
+            return instrumentation.recordStringLength(super.getValueAsString());
+        }
+
+        @Override
+        public String getValueAsString(String def) throws IOException {
+            return instrumentation.recordStringLength(super.getValueAsString(def));
+        }
+
+        @Override
+        public boolean handleSignature(boolean consumeFirstByte, boolean throwException) throws IOException {
+            // overridden to expose access to the boostrapper
+            return super.handleSignature(consumeFirstByte, throwException);
+        }
+    }
+}

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -36,10 +36,6 @@ public final class ObjectMappers {
 
     private ObjectMappers() {}
 
-    private static final SmileFactory SMILE_FACTORY = SmileFactory.builder()
-            .disable(SmileGenerator.Feature.ENCODE_BINARY_AS_7BIT)
-            .build();
-
     /**
      * Returns a default ObjectMapper with settings adjusted for use in clients.
      *
@@ -81,7 +77,7 @@ public final class ObjectMappers {
      * </ul>
      */
     public static SmileMapper newClientSmileMapper() {
-        return withDefaultModules(SmileMapper.builder(SMILE_FACTORY))
+        return withDefaultModules(SmileMapper.builder(smileFactory()))
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .build();
     }
@@ -127,7 +123,7 @@ public final class ObjectMappers {
      * </ul>
      */
     public static SmileMapper newServerSmileMapper() {
-        return withDefaultModules(SmileMapper.builder(SMILE_FACTORY))
+        return withDefaultModules(SmileMapper.builder(smileFactory()))
                 .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .build();
     }
@@ -222,5 +218,11 @@ public final class ObjectMappers {
                 .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
                 .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
                 .disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT);
+    }
+
+    private static SmileFactory smileFactory() {
+        return InstrumentedSmileFactory.builder()
+                .disable(SmileGenerator.Feature.ENCODE_BINARY_AS_7BIT)
+                .build();
     }
 }

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -50,7 +50,7 @@ public final class ObjectMappers {
      * </ul>
      */
     public static JsonMapper newClientJsonMapper() {
-        return withDefaultModules(JsonMapper.builder())
+        return withDefaultModules(JsonMapper.builder(new InstrumentedJsonFactory()))
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .build();
     }
@@ -96,7 +96,7 @@ public final class ObjectMappers {
      * </ul>
      */
     public static JsonMapper newServerJsonMapper() {
-        return withDefaultModules(JsonMapper.builder())
+        return withDefaultModules(JsonMapper.builder(new InstrumentedJsonFactory()))
                 .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .build();
     }

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ParserInstrumentation.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ParserInstrumentation.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.serialization;
+
+import com.codahale.metrics.Histogram;
+import com.google.common.util.concurrent.RateLimiter;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
+
+/** Internal utility to record instrumentation from JSON parsers. */
+final class ParserInstrumentation {
+    // Log at most once per second
+    private static final RateLimiter LOGGING_RATE_LIMITER = RateLimiter.create(1);
+    private static final SafeLogger log = SafeLoggerFactory.get(ParserInstrumentation.class);
+
+    private final Throwable creationStackTrace;
+    private final Histogram parsedStringLength;
+
+    // Using the shared metric registry singleton to avoid API churn in methods that use this instrumentation.
+    @SuppressWarnings("deprecation")
+    ParserInstrumentation() {
+        creationStackTrace = new SafeRuntimeException("Stream factory created here");
+        parsedStringLength = JsonParserMetrics.of(SharedTaggedMetricRegistries.getSingleton())
+                .stringLength();
+    }
+
+    /** Returns the input, recording length of the value. */
+    String recordStringLength(String value) {
+        if (value != null) {
+            int length = value.length();
+            // Avoid updating a histogram in the common case (small values) because this path will be exceedingly
+            // hot.
+            if (length > 64) {
+                recordNontrivialStringLength(length);
+            }
+        }
+        return value;
+    }
+
+    private void recordNontrivialStringLength(int length) {
+        parsedStringLength.update(length);
+        if (length > 1_000_000 && LOGGING_RATE_LIMITER.tryAcquire()) {
+            log.info(
+                    "Detected an unusually large JSON string value",
+                    SafeArg.of("length", length),
+                    new SafeRuntimeException("Parsed here", creationStackTrace));
+        }
+    }
+}

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ParserInstrumentation.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ParserInstrumentation.java
@@ -57,7 +57,7 @@ final class ParserInstrumentation {
     private void recordNontrivialStringLength(int length) {
         parsedStringLength.update(length);
         if (length > 1_000_000 && LOGGING_RATE_LIMITER.tryAcquire()) {
-            log.info(
+            log.warn(
                     "Detected an unusually large JSON string value",
                     SafeArg.of("length", length),
                     new SafeRuntimeException("Parsed here", creationStackTrace));

--- a/conjure-java-jackson-serialization/src/main/metrics/jackson-registry-metrics.yml
+++ b/conjure-java-jackson-serialization/src/main/metrics/jackson-registry-metrics.yml
@@ -1,0 +1,10 @@
+options:
+  javaPackage: com.palantir.conjure.java.serialization
+  javaVisibility: packagePrivate
+namespaces:
+  json.parser:
+    docs: Metrics produced instrumented Jackson components.
+    metrics:
+      string.length:
+        type: histogram
+        docs: Histogram describing the length of strings parsed from input.

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.serialization;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.codahale.metrics.Histogram;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,6 +28,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -309,6 +312,20 @@ public final class ObjectMappersTest {
         assertThatThrownBy(() -> MAPPER.readValue("" + Long.MAX_VALUE, OptionalInt.class))
                 .isInstanceOf(InputCoercionException.class)
                 .hasMessageContaining("out of range of int");
+    }
+
+    @Test
+    public void testStringMetrics() throws IOException {
+        TaggedMetricRegistry registry = SharedTaggedMetricRegistries.getSingleton();
+        // Unregister all metrics
+        registry.forEachMetric((name, _value) -> registry.remove(name));
+        Histogram stringLength = JsonParserMetrics.of(registry).stringLength();
+        assertThat(stringLength.getSnapshot().size()).isZero();
+        String expected = "Hello, World!";
+        String value = ObjectMappers.newServerJsonMapper().readValue("\"" + expected + "\"", String.class);
+        assertThat(value).isEqualTo(expected);
+        assertThat(stringLength.getSnapshot().size()).isOne();
+        assertThat(stringLength.getSnapshot().getMax()).isEqualTo(expected.length());
     }
 
     private static String ser(Object object) throws IOException {


### PR DESCRIPTION
==COMMIT_MSG==
Report metrics when unusually large strings are parsed
==COMMIT_MSG==

Unfortunately this only covers JSON at the moment, and only JSON parsed using mappers from Conjure factory methods. I'd like to capture data from the smile mappers as well, but I don't want to block beginning to capture data on that.
