### PR TITLE
InstrumentedJsonFactory sets the expected 'JSON' format name

### DIFF
--- a/changelog/@unreleased/pr-2570.v2.yml
+++ b/changelog/@unreleased/pr-2570.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: InstrumentedJsonFactory sets the expected 'JSON' format name
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2570

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/InstrumentedJsonFactory.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/InstrumentedJsonFactory.java
@@ -83,6 +83,11 @@ final class InstrumentedJsonFactory extends JsonFactory {
     }
 
     @Override
+    public String getFormatName() {
+        return FORMAT_NAME_JSON;
+    }
+
+    @Override
     protected JsonParser _createParser(InputStream in, IOContext ctxt) throws IOException {
         return wrap(super._createParser(in, ctxt));
     }

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -372,6 +372,30 @@ public final class ObjectMappersTest {
         assertThat(stringLength.getSnapshot().size()).isZero();
     }
 
+    @Test
+    public void testJsonFormatName() {
+        assertThat(ObjectMappers.newServerJsonMapper().getFactory().getFormatName())
+                .isEqualTo("JSON");
+        assertThat(ObjectMappers.newClientJsonMapper().getFactory().getFormatName())
+                .isEqualTo("JSON");
+    }
+
+    @Test
+    public void testCborFormatName() {
+        assertThat(ObjectMappers.newServerCborMapper().getFactory().getFormatName())
+                .isEqualTo("CBOR");
+        assertThat(ObjectMappers.newClientCborMapper().getFactory().getFormatName())
+                .isEqualTo("CBOR");
+    }
+
+    @Test
+    public void testSmileFormatName() {
+        assertThat(ObjectMappers.newServerSmileMapper().getFactory().getFormatName())
+                .isEqualTo("Smile");
+        assertThat(ObjectMappers.newClientSmileMapper().getFactory().getFormatName())
+                .isEqualTo("Smile");
+    }
+
     private static String ser(Object object) throws IOException {
         return MAPPER.writeValueAsString(object);
     }


### PR DESCRIPTION
This resolves a hiccup for consumers which depend on the value of `getFormatName()`
==COMMIT_MSG==
InstrumentedJsonFactory sets the expected 'JSON' format name
==COMMIT_MSG==
