### PR TITLE
Increase string-length observability thresholds

### DIFF
--- a/changelog/@unreleased/pr-2574.v2.yml
+++ b/changelog/@unreleased/pr-2574.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Increase string-length observability thresholds
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2574

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -323,8 +323,8 @@ public final class ObjectMappersTest {
         registry.forEachMetric((name, _value) -> registry.remove(name));
         Histogram stringLength = JsonParserMetrics.of(registry).stringLength(JsonFactory.FORMAT_NAME_JSON);
         assertThat(stringLength.getSnapshot().size()).isZero();
-        // Length must exceed the minimum threshold for metrics (64 characters)
-        String expected = "Hello, World!".repeat(10);
+        // Length must exceed the minimum threshold for metrics
+        String expected = "Hello, World!".repeat(100000);
         String value = ObjectMappers.newServerJsonMapper().readValue("\"" + expected + "\"", String.class);
         assertThat(value).isEqualTo(expected);
         assertThat(stringLength.getSnapshot().size()).isOne();
@@ -352,7 +352,7 @@ public final class ObjectMappersTest {
         Histogram stringLength = JsonParserMetrics.of(registry).stringLength(SmileFactory.FORMAT_NAME_SMILE);
         assertThat(stringLength.getSnapshot().size()).isZero();
         // Length must exceed the minimum threshold for metrics (64 characters)
-        String expected = "Hello, World!".repeat(10);
+        String expected = "Hello, World!".repeat(100000);
         String value = ObjectMappers.newServerSmileMapper()
                 .readValue(ObjectMappers.newClientSmileMapper().writeValueAsBytes(expected), String.class);
         assertThat(value).isEqualTo(expected);

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -351,7 +351,7 @@ public final class ObjectMappersTest {
         registry.forEachMetric((name, _value) -> registry.remove(name));
         Histogram stringLength = JsonParserMetrics.of(registry).stringLength(SmileFactory.FORMAT_NAME_SMILE);
         assertThat(stringLength.getSnapshot().size()).isZero();
-        // Length must exceed the minimum threshold for metrics (64 characters)
+        // Length must exceed the minimum threshold for metrics
         String expected = "Hello, World!".repeat(100000);
         String value = ObjectMappers.newServerSmileMapper()
                 .readValue(ObjectMappers.newClientSmileMapper().writeValueAsBytes(expected), String.class);


### PR DESCRIPTION
This is meant to increase the signal to noise ratio of the data we collect in a couple ways:
We collect stack trace information when values are within 20% of the upcoming limit in Jackson (4mb), helping us focus our efforts on places that are most likely to be impacted.
We increase the minimum threshold to update our histogram in order to vastly reduce interactions with the metric because it uses a recency-biased random sampling reservoir which holds ~1k samples at a time. With a high rate of interactions, it's likely that we will fail to sample the largest value's we observe (which I've found in practice as logged warnings have length values which exceed reported metrics).

==COMMIT_MSG==
Increase string-length observability thresholds
==COMMIT_MSG==

