### PR TITLE
Disable Jackson field name interning

### DIFF
--- a/changelog/@unreleased/pr-2583.v2.yml
+++ b/changelog/@unreleased/pr-2583.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Interning introduces excessive contention
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2583


### PR DESCRIPTION
## Before this PR
Seeing synchronization contention in `com.fasterxml.jackson.core.util.InternCache.intern(String)` via JFR with services processing high volumes of SMILE encoded data, where we are reusing `ObjectMapper` I don't believe we are failing to close the `JsonParser`. See https://github.com/FasterXML/jackson-core/issues/946

![image](https://user-images.githubusercontent.com/54594/229831042-aa42895d-8780-43a1-983a-6d17a80ff538.png)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Interning introduces excessive contention
==COMMIT_MSG==

## Possible downsides?
This potentially increases allocations and GC work necessary for deserialization.

Long term we are probably better off pushing String deduplication to the Garbage Collector via `-XX:+UseStringDeduplication` per https://github.com/palantir/sls-packaging/issues/1378

Relevant context:

https://shipilev.net/jvm/anatomy-quarks/10-string-intern/

G1 and Shenandoah GC support string deduplication as of JDK 17

* https://openjdk.java.net/jeps/192
* https://bugs.openjdk.org/browse/JDK-8264718

Only enable on JDK 17+ due to fix https://bugs.openjdk.org/browse/JDK-8277981

JDK 18+ enable string deduplication for SerialGC, ParallalGC, and ZGC.
https://malloc.se/blog/zgc-jdk18
