### PR TITLE
Use a TypeFactory backed by a Caffeine Cache

### DIFF
--- a/changelog/@unreleased/pr-2587.v2.yml
+++ b/changelog/@unreleased/pr-2587.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use a TypeFactory backed by a Caffeine Cache
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2587

--- a/conjure-java-jackson-serialization/build.gradle
+++ b/conjure-java-jackson-serialization/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     api "com.palantir.safe-logging:preconditions"
     implementation "com.palantir.safe-logging:logger"
     implementation 'com.palantir.tritium:tritium-registry'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     testImplementation "junit:junit"
     testImplementation "org.assertj:assertj-core"

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CaffeineCachingTypeFactory.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/CaffeineCachingTypeFactory.java
@@ -1,0 +1,145 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.serialization;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.type.TypeModifier;
+import com.fasterxml.jackson.databind.type.TypeParser;
+import com.fasterxml.jackson.databind.util.ArrayBuilders;
+import com.fasterxml.jackson.databind.util.LRUMap;
+import com.fasterxml.jackson.databind.util.LookupCache;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.primitives.Ints;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import javax.annotation.Nullable;
+
+final class CaffeineCachingTypeFactory extends TypeFactory {
+    private static final SafeLogger log = SafeLoggerFactory.get(CaffeineCachingTypeFactory.class);
+
+    CaffeineCachingTypeFactory() {
+        super(new CaffeineLookupCache());
+    }
+
+    CaffeineCachingTypeFactory(
+            CaffeineLookupCache typeCache,
+            TypeParser parser,
+            @Nullable TypeModifier[] modifiers,
+            ClassLoader classLoader) {
+        super(typeCache, parser, modifiers, classLoader);
+    }
+
+    private static CaffeineLookupCache asCaffeine(LookupCache<Object, JavaType> typeCache) {
+        if (typeCache instanceof CaffeineLookupCache) {
+            return (CaffeineLookupCache) typeCache;
+        } else if (typeCache == null || typeCache.size() == 0) {
+            // Use a caffeine cache instead of the provided empty cache
+            return new CaffeineLookupCache();
+        } else if (typeCache instanceof LRUMap) {
+            CaffeineLookupCache cache = new CaffeineLookupCache();
+            LRUMap<Object, JavaType> defaultJacksonCacheType = (LRUMap<Object, JavaType>) typeCache;
+            defaultJacksonCacheType.contents(cache::put);
+            return cache;
+        } else {
+            log.error(
+                    "Unknown LookupCache, using a new caffeine cache instead",
+                    SafeArg.of("cacheType", typeCache.getClass()));
+            return new CaffeineLookupCache();
+        }
+    }
+
+    @Override
+    public CaffeineCachingTypeFactory withModifier(TypeModifier mod) {
+        // Updating modifiers clears the cache
+        return new CaffeineCachingTypeFactory(
+                new CaffeineLookupCache(), _parser, computeModifiers(_modifiers, mod), _classLoader);
+    }
+
+    @Nullable
+    private static TypeModifier[] computeModifiers(TypeModifier[] existing, TypeModifier newModifier) {
+        // Semantics are based on the jackson-databind `withModifier` implementation.
+        if (newModifier == null) {
+            return null;
+        }
+        if (existing == null || existing.length == 0) {
+            return new TypeModifier[] {newModifier};
+        }
+        return ArrayBuilders.insertInListNoDup(existing, newModifier);
+    }
+
+    @Override
+    public CaffeineCachingTypeFactory withClassLoader(ClassLoader classLoader) {
+        return new CaffeineCachingTypeFactory(asCaffeine(_typeCache), _parser, _modifiers, classLoader);
+    }
+
+    @Override
+    public CaffeineCachingTypeFactory withCache(LRUMap<Object, JavaType> cache) {
+        return withCache((LookupCache<Object, JavaType>) cache);
+    }
+
+    @Override
+    public CaffeineCachingTypeFactory withCache(LookupCache<Object, JavaType> cache) {
+        return new CaffeineCachingTypeFactory(asCaffeine(cache), _parser, _modifiers, _classLoader);
+    }
+
+    private static final class CaffeineLookupCache implements LookupCache<Object, JavaType> {
+        private final Cache<Object, JavaType> cache;
+
+        CaffeineLookupCache() {
+            this.cache = Caffeine.newBuilder()
+                    // max-size 1000 up from 200 default as of 2.14.2
+                    .maximumSize(1000)
+                    // initial-size 128 up from 16 default as of 2.14.2
+                    .initialCapacity(128)
+                    .build();
+        }
+
+        @Override
+        public int size() {
+            return Ints.saturatedCast(cache.estimatedSize());
+        }
+
+        @Override
+        @Nullable
+        public JavaType get(Object key) {
+            return cache.getIfPresent(key);
+        }
+
+        @Override
+        public JavaType put(Object key, JavaType value) {
+            return cache.asMap().put(key, value);
+        }
+
+        @Override
+        public JavaType putIfAbsent(Object key, JavaType value) {
+            return cache.asMap().putIfAbsent(key, value);
+        }
+
+        @Override
+        public void clear() {
+            cache.invalidateAll();
+        }
+
+        @Override
+        public String toString() {
+            return "CaffeineLookupCache{" + cache + '}';
+        }
+    }
+}

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -170,7 +170,8 @@ public final class ObjectMappers {
      * </ul>
      */
     public static <M extends ObjectMapper, B extends MapperBuilder<M, B>> B withDefaultModules(B builder) {
-        return builder.addModule(new GuavaModule())
+        return builder.typeFactory(new CaffeineCachingTypeFactory())
+                .addModule(new GuavaModule())
                 .addModule(new ShimJdk7Module())
                 .addModule(new Jdk8Module().configureAbsentsAsNulls(true))
                 .addModules(ObjectMapperOptimizations.createModules())
@@ -204,6 +205,7 @@ public final class ObjectMappers {
      * </ul>
      */
     public static ObjectMapper withDefaultModules(ObjectMapper mapper) {
+        mapper.setTypeFactory(new CaffeineCachingTypeFactory());
         return mapper.registerModule(new GuavaModule())
                 .registerModule(new ShimJdk7Module())
                 .registerModule(new Jdk8Module().configureAbsentsAsNulls(true))

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/ObjectMappersTest.java
@@ -402,13 +402,33 @@ public final class ObjectMappersTest {
     }
 
     @Test
+    public void testTypeFactoryCache() {
+        testTypeFactory(ObjectMappers.newServerObjectMapper());
+        testTypeFactory(ObjectMappers.newClientObjectMapper());
+        testTypeFactory(ObjectMappers.newServerJsonMapper());
+        testTypeFactory(ObjectMappers.newClientJsonMapper());
+        testTypeFactory(ObjectMappers.newSmileServerObjectMapper());
+        testTypeFactory(ObjectMappers.newSmileClientObjectMapper());
+        testTypeFactory(ObjectMappers.newServerSmileMapper());
+        testTypeFactory(ObjectMappers.newClientSmileMapper());
+        testTypeFactory(ObjectMappers.newCborServerObjectMapper());
+        testTypeFactory(ObjectMappers.newCborClientObjectMapper());
+        testTypeFactory(ObjectMappers.newServerCborMapper());
+        testTypeFactory(ObjectMappers.newClientCborMapper());
+    }
+
+    private void testTypeFactory(ObjectMapper mapper) {
+        assertThat(mapper.getTypeFactory()).isInstanceOf(CaffeineCachingTypeFactory.class);
+    }
+
+    @Test
     public void testMapKeysAreNotInterned() throws IOException {
         testMapKeysAreNotInterned(ObjectMappers.newServerJsonMapper());
         testMapKeysAreNotInterned(ObjectMappers.newServerCborMapper());
         testMapKeysAreNotInterned(ObjectMappers.newServerSmileMapper());
     }
 
-    public void testMapKeysAreNotInterned(ObjectMapper mapper) throws IOException {
+    private void testMapKeysAreNotInterned(ObjectMapper mapper) throws IOException {
         Map<String, String> expected = Collections.singletonMap(
                 UUID.randomUUID().toString(), UUID.randomUUID().toString());
         byte[] serialized = mapper.writeValueAsBytes(expected);


### PR DESCRIPTION
This is meant to avoid contention observed in the Jackson LRUMap while we investigate and build a reproducer to submit upstream.

==COMMIT_MSG==
Use a TypeFactory backed by a Caffeine Cache
==COMMIT_MSG==

Note that in addition to using a caffeine cache, we set the bounds larger than the default jackson values.
At first glance it appears that we're moving from the default singleton TypeFactory to a new factory per-mapper, however this wasn't the case to begin with due to modules (guava) adding a `TypeModifier` which produces a new factory+cache entirely.
Also note that the SerializerCache and DeserailizerCache use the same LRUMap cache as TypeFactory, which I haven't found an easy way to modify. It's possible that places with contention on TypeFactory will shift contention to ser/de factories (although I suspect this is less likely as more types are visited by the TypeFactory than have serializers or deserializers).

## Possible downsides?
More to maintain on our end, we don't have a way to validate this configuration.
