### PR TITLE
ObjectMappers.withDefaultModules(ObjectMapper) does not replace existing TypeFactories

### DIFF
--- a/changelog/@unreleased/pr-2597.v2.yml
+++ b/changelog/@unreleased/pr-2597.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: ObjectMappers.withDefaultModules(ObjectMapper) does not replace existing
+    TypeFactories with state from registered modules
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2597

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/NonCachingTypeFactory.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/NonCachingTypeFactory.java
@@ -32,11 +32,29 @@ import javax.annotation.Nullable;
  */
 final class NonCachingTypeFactory extends TypeFactory {
 
-    NonCachingTypeFactory() {
+    /**
+     * Attempt to produce a {@link NonCachingTypeFactory} based on the given {@link TypeFactory}.
+     * If the provided TypeFactory is non-default, this may not be possible to do safely
+     * and the original will be returned.
+     */
+    static TypeFactory from(TypeFactory original) {
+        if (original instanceof NonCachingTypeFactory) {
+            return original;
+        }
+        if (original == TypeFactory.defaultInstance()) {
+            return new NonCachingTypeFactory();
+        }
+        // As a fallback we update the existing factory with a non-caching cache implementation. Unfortunately this
+        // is not likely to survive any module registration which adds a TypeModifier, but it's the best we can do.
+        // If we return a new instance which doesn't preserve existing TypeModifiers, deserialization may fail.
+        return original.withCache(NoCacheLookupCache.INSTANCE);
+    }
+
+    private NonCachingTypeFactory() {
         super(NoCacheLookupCache.INSTANCE);
     }
 
-    NonCachingTypeFactory(TypeParser parser, @Nullable TypeModifier[] modifiers, ClassLoader classLoader) {
+    private NonCachingTypeFactory(TypeParser parser, @Nullable TypeModifier[] modifiers, ClassLoader classLoader) {
         super(NoCacheLookupCache.INSTANCE, parser, modifiers, classLoader);
     }
 

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -170,7 +170,7 @@ public final class ObjectMappers {
      * </ul>
      */
     public static <M extends ObjectMapper, B extends MapperBuilder<M, B>> B withDefaultModules(B builder) {
-        return builder.typeFactory(new NonCachingTypeFactory())
+        return builder.typeFactory(NonCachingTypeFactory.from(builder.build().getTypeFactory()))
                 .addModule(new GuavaModule())
                 .addModule(new ShimJdk7Module())
                 .addModule(new Jdk8Module().configureAbsentsAsNulls(true))
@@ -205,7 +205,7 @@ public final class ObjectMappers {
      * </ul>
      */
     public static ObjectMapper withDefaultModules(ObjectMapper mapper) {
-        return mapper.setTypeFactory(new NonCachingTypeFactory())
+        return mapper.setTypeFactory(NonCachingTypeFactory.from(mapper.getTypeFactory()))
                 .registerModule(new GuavaModule())
                 .registerModule(new ShimJdk7Module())
                 .registerModule(new Jdk8Module().configureAbsentsAsNulls(true))


### PR DESCRIPTION
Setting the TypeFactory does not cause the new TypeFactory to be updated with existing TypeModifier instances, even if modules are re-registered (due to IGNORE_DUPLICATE_MODULE_REGISTRATIONS). We can identify cases where the default TypeFactory instance is used, and handle those correctly, leaving edge cases using existing TypeFactory instances.

==COMMIT_MSG==
ObjectMappers.withDefaultModules(ObjectMapper) does not replace existing TypeFactories with state from registered modules
==COMMIT_MSG==

This resolves an issue impacting components which call `withDefaultModules(mapper)` on mappers that have been created and configured elsewhere prior to being passed to this method.

