### PR TITLE
Opt out of canonicalization in Conjure JsonFactories

### DIFF
--- a/changelog/@unreleased/pr-2603.v2.yml
+++ b/changelog/@unreleased/pr-2603.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Opt out of canonicalization in Conjure JsonFactories
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2603

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/ObjectMappers.java
@@ -245,6 +245,10 @@ public final class ObjectMappers {
     private static <F extends JsonFactory, B extends TSFBuilder<F, B>> B withDefaults(B builder) {
         return ReflectiveStreamReadConstraints.withDefaultConstraints(builder
                 // Interning introduces excessive contention https://github.com/FasterXML/jackson-core/issues/946
-                .disable(JsonFactory.Feature.INTERN_FIELD_NAMES));
+                .disable(JsonFactory.Feature.INTERN_FIELD_NAMES)
+                // Canonicalization can be helpful to avoid string re-allocation, however we expect unbounded
+                // key space due to use of maps keyed by random identifiers, which cause heavy heap churn.
+                // See this discussion: https://github.com/FasterXML/jackson-benchmarks/pull/6
+                .disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES));
     }
 }


### PR DESCRIPTION
We expect unlimited keyspace due to maps keyed by random IDs which are usually UUID-based. This interacts poorly with string canonicalization components in Jackson in ways that cause heavy heap churn. See the discussion here for the details:
https://github.com/FasterXML/jackson-benchmarks/pull/6

==COMMIT_MSG==
Opt out of canonicalization in Conjure JsonFactories
==COMMIT_MSG==

## Possible downsides?
The primary risk is that without canonicalization, we allocate reused strings much more heavily. Strings used to match setter methods should be very short lived and should not escape the parsing thread, so the JIT may be able to do terribly clever things to help us out.

Note: it may be possible to canonicalize contextually in jackson 3, which would give us the best of both worlds!
