### PR TITLE
Bump gradle-git-version from 0.15.0 to 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         classpath 'com.palantir.gradle.revapi:gradle-revapi:1.7.0'
         classpath 'com.netflix.nebula:gradle-dependency-lock-plugin:7.0.1'
         classpath 'com.palantir.baseline:gradle-baseline-java:5.6.0'
-        classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.15.0'
+        classpath 'com.palantir.gradle.gitversion:gradle-git-version:3.0.0'
         classpath 'com.palantir.metricschema:gradle-metric-schema:0.16.0'
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:2.11.0'


### PR DESCRIPTION
## Before this PR
Running `./gradlew classes testClasses` on my local checkout fails with `org.eclipse.jgit.errors.CorruptObjectException: DIRC checksum mismatch` because newer versions of the git binary produce checkouts that older versions of jgit do not support.  All repos using gradle-git-version will need this bump.

## After this PR
==COMMIT_MSG==
Bump gradle-git-version from 0.15.0 to 3.0.0
==COMMIT_MSG==