### PR TITLE
Improve ClientConfiguration creation performance by reusing already created trust managers

### DIFF
--- a/changelog/@unreleased/pr-2608.v2.yml
+++ b/changelog/@unreleased/pr-2608.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Extract creation of X509TrustManager for reutilization on client config
+    creation.
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2608

--- a/client-config/build.gradle
+++ b/client-config/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation "junit:junit"
     testImplementation 'com.google.guava:guava'
     testImplementation "org.assertj:assertj-core"
-    testImplementation "org.mockito:mockito-core"
+    testImplementation "org. mockito:mockito-core"
     testImplementation 'com.palantir.safe-logging:preconditions-assertj'
 
     annotationProcessor "org.immutables:value"

--- a/client-config/build.gradle
+++ b/client-config/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation "junit:junit"
     testImplementation 'com.google.guava:guava'
     testImplementation "org.assertj:assertj-core"
-    testImplementation "org. mockito:mockito-core"
+    testImplementation "org.mockito:mockito-core"
     testImplementation 'com.palantir.safe-logging:preconditions-assertj'
 
     annotationProcessor "org.immutables:value"

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -22,7 +22,6 @@ import com.google.common.net.HostAndPort;
 import com.palantir.conjure.java.api.config.service.ProxyConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.UserAgent;
-import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.conjure.java.config.ssl.SslUtils;
 import com.palantir.logsafe.UnsafeArg;

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -24,6 +24,7 @@ import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
+import com.palantir.conjure.java.config.ssl.SslUtils;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.logger.SafeLogger;
@@ -83,7 +84,7 @@ public final class ClientConfigurations {
         SSLSocketFactory sslSocketFactory =
                 SslSocketFactories.createSslContext(trustManagers, keyManagers).getSocketFactory();
 
-        X509TrustManager trustManager = extractX509TrustManager(trustManagers, config.security());
+        X509TrustManager trustManager = SslUtils.extractX509TrustManager(trustManagers, config.security());
 
         return ClientConfiguration.builder()
                 .sslSocketFactory(sslSocketFactory)
@@ -205,19 +206,6 @@ public final class ClientConfigurations {
     static InetSocketAddress createInetSocketAddress(String uriString) {
         URI uri = URI.create(uriString);
         return InetSocketAddress.createUnresolved(uri.getHost(), uri.getPort());
-    }
-
-    private static X509TrustManager extractX509TrustManager(TrustManager[] trustManagers, SslConfiguration config) {
-        TrustManager trustManager = trustManagers[0];
-        if (trustManager instanceof X509TrustManager) {
-            return (X509TrustManager) trustManager;
-        } else {
-            throw new RuntimeException(String.format(
-                    "First TrustManager associated with SslConfiguration was expected to be a %s, but was a %s: %s",
-                    X509TrustManager.class.getSimpleName(),
-                    trustManager.getClass().getSimpleName(),
-                    config.trustStorePath()));
-        }
     }
 
     private static Optional<HostAndPort> meshProxy(Optional<ProxyConfiguration> proxy) {

--- a/keystores/build.gradle
+++ b/keystores/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     testImplementation "org.conscrypt:conscrypt-openjdk-uber"
     testImplementation "org.assertj:assertj-core"
     testImplementation "org.junit.jupiter:junit-jupiter"
+    testImplementation "org.mockito:mockito-core"
 
     annotationProcessor "org.immutables:value"
     compileOnly 'org.immutables:value::annotations'

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/SslSocketFactories.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/SslSocketFactories.java
@@ -211,28 +211,13 @@ public final class SslSocketFactories {
      * {@link javax.net.ssl.X509TrustManager}.
      */
     public static X509TrustManager createX509TrustManager(SslConfiguration config) {
-        TrustManager trustManager = createTrustManagers(config)[0];
-        if (trustManager instanceof X509TrustManager) {
-            return (X509TrustManager) trustManager;
-        } else {
-            throw new RuntimeException(String.format(
-                    "First TrustManager associated with SslConfiguration was expected to be a %s, but was a %s: %s",
-                    X509TrustManager.class.getSimpleName(),
-                    trustManager.getClass().getSimpleName(),
-                    config.trustStorePath()));
-        }
+        TrustManager[] trustManagers = createTrustManagers(config);
+        return SslUtils.extractX509TrustManager(trustManagers, config);
     }
 
     public static X509TrustManager createX509TrustManager(Map<String, PemX509Certificate> certificatesByAlias) {
-        TrustManager trustManager = createTrustManagers(certificatesByAlias)[0];
-        if (trustManager instanceof X509TrustManager) {
-            return (X509TrustManager) trustManager;
-        } else {
-            throw new RuntimeException(String.format(
-                    "First TrustManager associated with certificates was expected to be a %s, but was a %s",
-                    X509TrustManager.class.getSimpleName(),
-                    trustManager.getClass().getSimpleName()));
-        }
+        TrustManager[] trustManagers = createTrustManagers(certificatesByAlias);
+        return SslUtils.extractX509TrustManager(trustManagers);
     }
 
     /**

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/SslSocketFactories.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/SslSocketFactories.java
@@ -140,7 +140,7 @@ public final class SslSocketFactories {
         return createSslContext(trustManagers, new KeyManager[] {}, provider);
     }
 
-    private static SSLContext createSslContext(TrustManager[] trustManagers, KeyManager[] keyManagers) {
+    public static SSLContext createSslContext(TrustManager[] trustManagers, KeyManager[] keyManagers) {
         try {
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(keyManagers, trustManagers, null);

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/SslUtils.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/SslUtils.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.config.ssl;
+
+import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+public class SslUtils {
+    private SslUtils() {}
+
+    /**
+     * Returns the first {@link TrustManager} initialized from the given configuration.
+     * If created via an {@link SslConfiguration} this is always an {@link javax.net.ssl.X509TrustManager}.
+     */
+    public static X509TrustManager extractX509TrustManager(TrustManager[] trustManagers, SslConfiguration config) {
+        TrustManager trustManager = trustManagers[0];
+        if (trustManager instanceof X509TrustManager) {
+            return (X509TrustManager) trustManager;
+        } else {
+            throw new RuntimeException(String.format(
+                    "First TrustManager associated with SslConfiguration was expected to be a %s, but was a %s: %s",
+                    X509TrustManager.class.getSimpleName(),
+                    trustManager.getClass().getSimpleName(),
+                    config.trustStorePath()));
+        }
+    }
+
+    public static X509TrustManager extractX509TrustManager(TrustManager[] trustManagers) {
+        TrustManager trustManager = trustManagers[0];
+        if (trustManager instanceof X509TrustManager) {
+            return (X509TrustManager) trustManager;
+        } else {
+            throw new RuntimeException(String.format(
+                    "First TrustManager associated with SslConfiguration was expected to be a %s, but was a %s",
+                    X509TrustManager.class.getSimpleName(),
+                    trustManager.getClass().getSimpleName()));
+        }
+    }
+}

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/SslSocketFactoriesTests.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/SslSocketFactoriesTests.java
@@ -30,8 +30,10 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.security.Provider;
 import java.util.Map;
+import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
 import org.conscrypt.Conscrypt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -384,5 +386,19 @@ public final class SslSocketFactoriesTests {
         SSLSocketFactory defaultFactory = SslSocketFactories.createSslSocketFactory(sslConfig);
         assertThat(Conscrypt.isConscrypt(conscryptFactory)).isTrue();
         assertThat(Conscrypt.isConscrypt(defaultFactory)).isFalse();
+    }
+
+    @Test
+    public void testCreateSslContext_completesWithProvidedManagers() {
+        SslConfiguration sslConfig = SslConfiguration.builder()
+                .trustStorePath(TestConstants.CA_TRUST_STORE_PATH)
+                .trustStoreType(TestConstants.CA_TRUST_STORE_TYPE)
+                .build();
+
+        TrustManager[] trustManagers = SslSocketFactories.createTrustManagers(sslConfig);
+        KeyManager[] keyManagers = SslSocketFactories.createKeyManagers(sslConfig);
+
+        assertThat(SslSocketFactories.createSslContext(trustManagers, keyManagers))
+                .isNotNull();
     }
 }

--- a/keystores/src/test/java/com/palantir/conjure/java/config/ssl/SslUtilsTest.java
+++ b/keystores/src/test/java/com/palantir/conjure/java/config/ssl/SslUtilsTest.java
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.config.ssl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import org.junit.jupiter.api.Test;
+
+class SslUtilsTest {
+
+    @Test
+    public void testExtractX509TrustManager_extractsFirstManagerIf509() {
+        SslConfiguration sslConfig = SslConfiguration.builder()
+                .trustStorePath(TestConstants.CA_TRUST_STORE_PATH)
+                .trustStoreType(TestConstants.CA_TRUST_STORE_TYPE)
+                .build();
+
+        X509TrustManager x509TrustManager = mock(X509TrustManager.class);
+
+        TrustManager[] trustManagers = new TrustManager[] {x509TrustManager};
+
+        X509TrustManager extractedManager = SslUtils.extractX509TrustManager(trustManagers, sslConfig);
+
+        assertThat(extractedManager).isEqualTo(x509TrustManager);
+    }
+
+    @Test
+    public void testExtractX509TrustManager_throwsIfFirstManagerNotX509() {
+        SslConfiguration sslConfig = SslConfiguration.builder()
+                .trustStorePath(TestConstants.CA_TRUST_STORE_PATH)
+                .trustStoreType(TestConstants.CA_TRUST_STORE_TYPE)
+                .build();
+
+        TrustManager nonX509TrustManager = new DummyTrustManager();
+        TrustManager[] trustManagers = new TrustManager[] {nonX509TrustManager};
+
+        assertThatThrownBy(() -> SslUtils.extractX509TrustManager(trustManagers, sslConfig))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("First TrustManager associated with SslConfiguration was expected to be a X509TrustManager,"
+                        + " but was a DummyTrustManager: src/test/resources/testCA/testCA.jks");
+    }
+
+    private static final class DummyTrustManager implements TrustManager {}
+}


### PR DESCRIPTION
## Before this PR
In the creation of the client configuration from the service configuration we currently first create a SSLSocketFactory and later a X509TrustManager. 

This is redundant work since the [creation of the SSLSocketFactory](https://github.com/palantir/conjure-java-runtime/blob/d4ece2245a9a61f013b0e37c01c9cb2e3897651b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/SslSocketFactories.java#L51) already has to [instantiate all the necessary TrustManagers](https://github.com/palantir/conjure-java-runtime/blob/d4ece2245a9a61f013b0e37c01c9cb2e3897651b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/SslSocketFactories.java#L98-L102).

Since the creation of the managers involves an I/O call, removing the second creation creates a verifiable performance improvement. 

## After this PR
==COMMIT_MSG==
Extract creation of X509TrustManager for reutilization on client config creation.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

