### PR TITLE
SslSocketFactories avoids duplicate effort creating TLS components

### DIFF
--- a/changelog/@unreleased/pr-2609.v2.yml
+++ b/changelog/@unreleased/pr-2609.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: SslSocketFactories avoids duplicate effort creating TLS components
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2609

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -23,6 +23,7 @@ import com.palantir.conjure.java.api.config.service.ProxyConfiguration;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
+import com.palantir.conjure.java.config.ssl.TrustContext;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.logger.SafeLogger;
@@ -75,9 +76,10 @@ public final class ClientConfigurations {
      * empty/absent configuration with the defaults specified as constants in this class.
      */
     public static ClientConfiguration of(ServiceConfiguration config) {
+        TrustContext trustContext = SslSocketFactories.createTrustContext(config.security());
         return ClientConfiguration.builder()
-                .sslSocketFactory(SslSocketFactories.createSslSocketFactory(config.security()))
-                .trustManager(SslSocketFactories.createX509TrustManager(config.security()))
+                .sslSocketFactory(trustContext.sslSocketFactory())
+                .trustManager(trustContext.x509TrustManager())
                 .uris(config.uris())
                 .connectTimeout(config.connectTimeout().orElse(DEFAULT_CONNECT_TIMEOUT))
                 .readTimeout(config.readTimeout().orElse(DEFAULT_READ_TIMEOUT))


### PR DESCRIPTION
Concretely, this simplifies creation of TrustContext and creating ClientConfiguration from a ServiceConfiguration to load the TrustManagerFactory from disk a single time rather than once for the X509TrustManager and a second time for the SSLContext to create an SSLSocketFactory.

Additionally, we provide public utility functionality such that consumers may also avoid duplicating efforts with slight code changes, without reimplementing the logic to create SSLContext instances themselves.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
SslSocketFactories avoids duplicate effort creating TLS components
==COMMIT_MSG==