### PR TITLE
Replace deprecated mappingException

### DIFF
--- a/changelog/@unreleased/pr-2714.v2.yml
+++ b/changelog/@unreleased/pr-2714.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Replace deprecated mappingException
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2714

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/PathDeserializer.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/PathDeserializer.java
@@ -37,11 +37,15 @@ package com.palantir.conjure.java.serialization;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
-import com.palantir.logsafe.exceptions.SafeIoException;
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 public final class PathDeserializer extends StdScalarDeserializer<Path> {
     private static final long serialVersionUID = 1;
@@ -59,7 +63,26 @@ public final class PathDeserializer extends StdScalarDeserializer<Path> {
             }
             // 16-Oct-2015: should we perhaps allow JSON Arrays (of Strings) as well?
         }
-        throw new SafeIoException(
-                "Could not deserialize path", ctxt.wrongTokenException(parser, Path.class, token, null));
+        throw new SafeJsonMappingException(
+                "Could not deserialize path", parser, ctxt.wrongTokenException(parser, Path.class, token, null));
+    }
+
+    private static final class SafeJsonMappingException extends JsonMappingException implements SafeLoggable {
+        private final String logMessage;
+
+        SafeJsonMappingException(@CompileTimeConstant String message, JsonParser parser, JsonMappingException cause) {
+            super(parser, message, cause);
+            this.logMessage = message;
+        }
+
+        @Override
+        public String getLogMessage() {
+            return logMessage;
+        }
+
+        @Override
+        public List<Arg<?>> getArgs() {
+            return List.of();
+        }
     }
 }

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/PathDeserializer.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/PathDeserializer.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+import com.palantir.logsafe.exceptions.SafeIoException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -58,6 +59,7 @@ public final class PathDeserializer extends StdScalarDeserializer<Path> {
             }
             // 16-Oct-2015: should we perhaps allow JSON Arrays (of Strings) as well?
         }
-        throw ctxt.mappingException(Path.class, token);
+        throw new SafeIoException(
+                "Could not deserialize path", ctxt.wrongTokenException(parser, Path.class, token, null));
     }
 }


### PR DESCRIPTION
## Before this PR
Jackson deprecated `DeserializationContext#mappingException` and removes it in 2.16, leading to compilation failure in https://github.com/palantir/conjure-java-runtime/pull/2712 .

## After this PR
==COMMIT_MSG==
Replace deprecated mappingException
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

