### PR TITLE
Always load certificates from the same jar as the code

### DIFF
--- a/changelog/@unreleased/pr-2721.v2.yml
+++ b/changelog/@unreleased/pr-2721.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Always load certificates from the same jar as the code
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2721

--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/DefaultCas.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/DefaultCas.java
@@ -41,7 +41,7 @@ final class DefaultCas {
     /**
      * This is managed by an excavator.
      */
-    private static final String CA_CERTIFICATES_CRT = "ca-certificates.crt";
+    private static final String CA_CERTIFICATES_CRT = "/ca-certificates.crt";
 
     private static final Supplier<Map<String, X509Certificate>> TRUSTED_CERTIFICATES =
             Suppliers.memoize(DefaultCas::getTrustedCertificates);
@@ -53,8 +53,8 @@ final class DefaultCas {
     private static Map<String, X509Certificate> getTrustedCertificates() {
         ImmutableMap.Builder<String, X509Certificate> certificateMap = ImmutableMap.builder();
         try {
-            List<X509Certificate> caCertificates = KeyStores.readX509Certificates(
-                            new ByteArrayInputStream(Resources.toByteArray(Resources.getResource(CA_CERTIFICATES_CRT))))
+            List<X509Certificate> caCertificates = KeyStores.readX509Certificates(new ByteArrayInputStream(
+                            Resources.toByteArray(Resources.getResource(DefaultCas.class, CA_CERTIFICATES_CRT))))
                     .stream()
                     .map(cert -> (X509Certificate) cert)
                     .collect(Collectors.toList());


### PR DESCRIPTION
## Before this PR
We occasionally hit errors like this while initializing clients in threads with context class loaders:

```
Caused by: java.lang.IllegalArgumentException: resource ca-certificates.crt not found.
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:218)
        at com.google.common.io.Resources.getResource(Resources.java:196)
        at com.palantir.conjure.java.config.ssl.DefaultCas.getTrustedCertificates(DefaultCas.java:57)
```

## After this PR
Always load the certificates from the same jar as the code.

## Possible downsides?
None that I'm aware of.
