### PR TITLE
Changes Necessary to Fix 8.0 Conjure Update

### DIFF
--- a/conjure-java-client-verifier/build.gradle
+++ b/conjure-java-client-verifier/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     verifier "com.palantir.conjure.verification:verification-server::${osClassifier}@tgz"
 
     testImplementation project(':conjure-java-jaxrs-client')
-    testImplementation project(':conjure-java-retrofit2-client')
     testImplementation project(':conjure-java-jackson-serialization')
     testImplementation project(':keystores')
     testImplementation "org.slf4j:slf4j-api"

--- a/conjure-java-client-verifier/src/test/java/com/palantir/verification/AutoDeserializeTest.java
+++ b/conjure-java-client-verifier/src/test/java/com/palantir/verification/AutoDeserializeTest.java
@@ -18,11 +18,8 @@ package com.palantir.verification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.verification.server.AutoDeserializeConfirmService;
 import com.palantir.conjure.verification.server.AutoDeserializeService;
-import com.palantir.conjure.verification.server.AutoDeserializeServiceRetrofit;
 import com.palantir.conjure.verification.server.EndpointName;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -30,7 +27,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
-import okhttp3.ResponseBody;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -47,8 +43,6 @@ public class AutoDeserializeTest {
     private static final Logger log = LoggerFactory.getLogger(AutoDeserializeTest.class);
     private static final AutoDeserializeService testServiceJersey =
             VerificationClients.autoDeserializeServiceJersey(server);
-    private static final AutoDeserializeServiceRetrofit testServiceRetrofit =
-            VerificationClients.autoDeserializeServiceRetrofit(server);
     private static final AutoDeserializeConfirmService confirmService = VerificationClients.confirmService(server);
 
     private static Collection<Arguments> data() {
@@ -72,40 +66,6 @@ public class AutoDeserializeTest {
                             positiveAndNegativeTestCases.getNegative().get(i))));
         });
         return objects;
-    }
-
-    @ParameterizedTest(name = "{0}({3}) -> should succeed {2}")
-    @MethodSource("data")
-    @SuppressWarnings("IllegalThrows")
-    public void runTestCaseRetrofit(EndpointName endpointName, int index, boolean shouldSucceed, String jsonString)
-            throws Error, NoSuchMethodException {
-        boolean shouldIgnore = Cases.shouldIgnoreRetrofit(endpointName, jsonString);
-        Method method = testServiceRetrofit.getClass().getMethod(endpointName.get(), int.class);
-        System.out.printf(
-                "[%s%s test case %s]: %s(%s), expected client to %s%n",
-                shouldIgnore ? "ignored " : "",
-                shouldSucceed ? "positive" : "negative",
-                index,
-                endpointName,
-                jsonString,
-                shouldSucceed ? "succeed" : "fail");
-
-        Optional<Error> expectationFailure = shouldSucceed
-                ? expectSuccessRetrofit(method, endpointName, index)
-                : expectFailureRetrofit(method, index);
-
-        if (shouldIgnore) {
-            assertThat(expectationFailure)
-                    .describedAs(
-                            "The test passed but the test case was ignored - remove this from ignored-test-cases.yml")
-                    .isNotEmpty();
-        }
-
-        Assumptions.assumeFalse(shouldIgnore);
-
-        if (expectationFailure.isPresent()) {
-            throw expectationFailure.get();
-        }
     }
 
     @ParameterizedTest(name = "{0}({3}) -> should succeed {2}")
@@ -138,32 +98,6 @@ public class AutoDeserializeTest {
 
         if (expectationFailure.isPresent()) {
             throw expectationFailure.get();
-        }
-    }
-
-    private Optional<Error> expectSuccessRetrofit(Method method, EndpointName endpointName, int index) {
-        try {
-            Object result = Futures.getUnchecked((ListenableFuture<?>) method.invoke(testServiceRetrofit, index));
-            log.info("Received result for endpoint {} and index {}: {}", endpointName, index, result);
-            Object clientResponse = result;
-            if (result instanceof ResponseBody) {
-                ResponseBody body = (ResponseBody) result;
-                clientResponse = body.bytes();
-            }
-            confirmService.confirm(endpointName, index, clientResponse);
-            return Optional.empty();
-        } catch (Exception e) {
-            return Optional.of(new AssertionError("Expected call to succeed, but caught exception", e));
-        }
-    }
-
-    private Optional<Error> expectFailureRetrofit(Method method, int index) {
-        try {
-            Object result = Futures.getUnchecked((ListenableFuture<?>) method.invoke(testServiceRetrofit, index));
-            return Optional.of(new AssertionError(
-                    String.format("Result should have caused an exception but deserialized to: %s", result)));
-        } catch (Exception e) {
-            return Optional.empty(); // we expected the method to throw, and it did, so this expectation was satisfied
         }
     }
 

--- a/conjure-java-client-verifier/src/test/java/com/palantir/verification/VerificationClients.java
+++ b/conjure-java-client-verifier/src/test/java/com/palantir/verification/VerificationClients.java
@@ -17,11 +17,9 @@
 package com.palantir.verification;
 
 import com.palantir.conjure.java.client.jaxrs.JaxRsClient;
-import com.palantir.conjure.java.client.retrofit2.Retrofit2Client;
 import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
 import com.palantir.conjure.verification.server.AutoDeserializeConfirmService;
 import com.palantir.conjure.verification.server.AutoDeserializeService;
-import com.palantir.conjure.verification.server.AutoDeserializeServiceRetrofit;
 import com.palantir.conjure.verification.server.SingleHeaderService;
 import com.palantir.conjure.verification.server.SinglePathParamService;
 import com.palantir.conjure.verification.server.SingleQueryParamService;
@@ -32,14 +30,6 @@ public final class VerificationClients {
     public static AutoDeserializeService autoDeserializeServiceJersey(VerificationServerRule server) {
         return JaxRsClient.create(
                 AutoDeserializeService.class,
-                server.getClientConfiguration().userAgent().orElseThrow(IllegalArgumentException::new),
-                new HostMetricsRegistry(),
-                server.getClientConfiguration());
-    }
-
-    public static AutoDeserializeServiceRetrofit autoDeserializeServiceRetrofit(VerificationServerRule server) {
-        return Retrofit2Client.create(
-                AutoDeserializeServiceRetrofit.class,
                 server.getClientConfiguration().userAgent().orElseThrow(IllegalArgumentException::new),
                 new HostMetricsRegistry(),
                 server.getClientConfiguration());

--- a/gradle/verifier.gradle
+++ b/gradle/verifier.gradle
@@ -9,7 +9,6 @@ ext {
 sourceSets {
     generatedObjects
     generatedJersey
-    generatedRetrofit
 }
 
 configurations {
@@ -27,16 +26,11 @@ dependencies {
     generatedJerseyImplementation 'com.palantir.conjure.java:conjure-lib'
     generatedJerseyImplementation 'jakarta.ws.rs:jakarta.ws.rs-api'
     generatedJerseyImplementation sourceSets.generatedObjects.output
-    generatedRetrofitImplementation 'com.google.guava:guava'
-    generatedRetrofitImplementation 'com.palantir.conjure.java:conjure-lib'
-    generatedRetrofitImplementation 'com.squareup.retrofit2:retrofit'
-    generatedRetrofitImplementation sourceSets.generatedObjects.output
 
     testImplementation 'com.palantir.conjure.java:conjure-lib'
     testImplementation 'jakarta.ws.rs:jakarta.ws.rs-api'
     testImplementation sourceSets.generatedObjects.output
     testImplementation sourceSets.generatedJersey.output
-    testImplementation sourceSets.generatedRetrofit.output
 }
 
 tasks.withType(JavaCompile).matching { it.name == "compileTestJava" }.configureEach {
@@ -47,14 +41,11 @@ idea {
     module {
         sourceDirs += sourceSets.generatedObjects.java.srcDirs
         sourceDirs += sourceSets.generatedJersey.java.srcDirs
-        sourceDirs += sourceSets.generatedRetrofit.java.srcDirs
         generatedSourceDirs += sourceSets.generatedObjects.java.srcDirs
         generatedSourceDirs += sourceSets.generatedJersey.java.srcDirs
-        generatedSourceDirs += sourceSets.generatedRetrofit.java.srcDirs
         scopes.COMPILE.plus += [
             configurations.generatedObjectsCompileClasspath,
-            configurations.generatedJerseyCompileClasspath,
-            configurations.generatedRetrofitCompileClasspath]
+            configurations.generatedJerseyCompileClasspath]
     }
 }
 
@@ -102,25 +93,14 @@ task conjureJavaJersey(type: Exec, dependsOn: unpackGenerator) {
     doFirst { delete "src/generatedJersey/java/*" }
 }
 
-task conjureJavaRetrofit(type: Exec, dependsOn: unpackGenerator) {
-    executable "${-> unpackGenerator.getExecutable()}"
-    args 'generate',  "${-> configurations.verificationApi.singleFile}", 'src/generatedRetrofit/java', '--retrofit', '--retrofitListenableFutures'
-
-    inputs.file "${-> configurations.verificationApi.singleFile}"
-    outputs.dir "src/generatedRetrofit/java"
-    doFirst { delete "src/generatedRetrofit/java/*" }
-}
-
 // ensure compiling the sourceSet automatically run these tasks
 compileGeneratedObjectsJava.dependsOn conjureJavaObjects
 compileGeneratedJerseyJava.dependsOn conjureJavaJersey
-compileGeneratedRetrofitJava.dependsOn conjureJavaRetrofit
 
-tasks.idea.dependsOn conjureJavaObjects, conjureJavaJersey, conjureJavaRetrofit, unpackVerifier, copyTestCases
+tasks.idea.dependsOn conjureJavaObjects, conjureJavaJersey, unpackVerifier, copyTestCases
 test.dependsOn unpackVerifier, copyTestCases
 
 checkstyleGeneratedObjects.enabled = false
 checkstyleGeneratedJersey.enabled = false
-checkstyleGeneratedRetrofit.enabled = false
 
 checkUnusedDependenciesTest.enabled = false


### PR DESCRIPTION
Fixes #2735, but will mean that `conjure-java-retrofit2-client` is untested, and while we intend to remove that it seems that the lesser evil is blocking the 8.x upgrade IMO.