### PR TITLE
Reduce the default conjure connect timeout to 5 seconds (from 10)

### DIFF
--- a/changelog/@unreleased/pr-2777.v2.yml
+++ b/changelog/@unreleased/pr-2777.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce the default conjure connect timeout to 5 seconds (from 10)
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2777

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java
@@ -50,7 +50,7 @@ public final class ClientConfigurations {
     private static final SafeLogger log = SafeLoggerFactory.get(ClientConfigurations.class);
 
     // Defaults for parameters that are optional in ServiceConfiguration.
-    private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
     private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration DEFAULT_BACKOFF_SLOT_SIZE = Duration.ofMillis(250);

--- a/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
+++ b/client-config/src/test/java/com/palantir/conjure/java/client/config/ClientConfigurationsTest.java
@@ -54,7 +54,7 @@ public final class ClientConfigurationsTest {
         assertThat(actual.sslSocketFactory()).isNotNull();
         assertThat(actual.trustManager()).isNotNull();
         assertThat(actual.uris()).containsExactlyElementsOf(uris);
-        assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(5));
         assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(5));
         assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(5));
         assertThat(actual.enableGcmCipherSuites()).isTrue();
@@ -73,7 +73,7 @@ public final class ClientConfigurationsTest {
         assertThat(actual.sslSocketFactory()).isEqualTo(sslFactory);
         assertThat(actual.trustManager()).isEqualTo(trustManager);
         assertThat(actual.uris()).containsExactlyElementsOf(uris);
-        assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(actual.connectTimeout()).isEqualTo(Duration.ofSeconds(5));
         assertThat(actual.readTimeout()).isEqualTo(Duration.ofMinutes(5));
         assertThat(actual.writeTimeout()).isEqualTo(Duration.ofMinutes(5));
         assertThat(actual.enableGcmCipherSuites()).isTrue();


### PR DESCRIPTION
## Before this PR
10 second default connect timeout.

## After this PR
==COMMIT_MSG==
Reduce the default conjure connect timeout to 5 seconds (from 10)
==COMMIT_MSG==

## Possible downsides?
Oh goodness yes! If clients are interacting with tremendously latent servers which are expected to take longer than 5 seconds to connect, attempts to connect may fail. However, our metrics make it clear that is not something to expect, and happens rarely+intermittently enough that failing early + retrying will provide a better user experience. In the off-chance that longer times are expected, clients may be configured with larger connect-timeout values. Ultimately it would be ideal if we reduced connect timeout values below 1 seconds.