### PR TITLE
Remove Dependency on Jackson Afterburner

### DIFF
--- a/changelog/@unreleased/pr-2879.v2.yml
+++ b/changelog/@unreleased/pr-2879.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove Dependency on Jackson Afterburner
+  links:
+  - https://github.com/palantir/conjure-java-runtime/pull/2879

--- a/conjure-java-jackson-optimizations/build.gradle
+++ b/conjure-java-jackson-optimizations/build.gradle
@@ -3,5 +3,4 @@ apply plugin: 'com.palantir.revapi'
 
 dependencies {
     api "com.fasterxml.jackson.core:jackson-databind"
-    implementation "com.fasterxml.jackson.module:jackson-module-afterburner"
 }

--- a/conjure-java-jackson-optimizations/src/main/java/com/palantir/conjure/java/jackson/optimizations/ObjectMapperOptimizations.java
+++ b/conjure-java-jackson-optimizations/src/main/java/com/palantir/conjure/java/jackson/optimizations/ObjectMapperOptimizations.java
@@ -32,6 +32,5 @@ public final class ObjectMapperOptimizations {
         return List.of();
     }
 
-    private ObjectMapperOptimizations() {
-    }
+    private ObjectMapperOptimizations() {}
 }

--- a/conjure-java-jackson-optimizations/src/main/java/com/palantir/conjure/java/jackson/optimizations/ObjectMapperOptimizations.java
+++ b/conjure-java-jackson-optimizations/src/main/java/com/palantir/conjure/java/jackson/optimizations/ObjectMapperOptimizations.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.jackson.optimizations;
 
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import java.util.List;
 
 /**
@@ -26,31 +25,13 @@ import java.util.List;
  */
 public final class ObjectMapperOptimizations {
 
-    private static final boolean NO_OPTIMIZATIONS =
-            // These optimizations are not used within graalvm because they leverage dynamic class creation The
-            // nativeimage check should not be refactored into a utility method which may reduce our ability to
-            // tree-shake.
-            System.getProperty("org.graalvm.nativeimage.imagecode") != null
-                    // This may be globally configured with a system property
-                    || readProperty(
-                            "com.palantir.conjure.java.jackson.optimizations.disabled", shouldDisableByDefault());
-
-    @SuppressWarnings("AfterburnerJavaIncompatibility")
     public static List<? extends com.fasterxml.jackson.databind.Module> createModules() {
-        return NO_OPTIMIZATIONS ? List.of() : List.<com.fasterxml.jackson.databind.Module>of(new AfterburnerModule());
+        // At one point this conditionally returned List.of(new AfterburnerModule), however afterburner is not
+        // supported on any supported LTS Java release anymore, and the Blackbird alternative incurs a memory
+        // leak (https://github.com/FasterXML/jackson-modules-base/issues/147).
+        return List.of();
     }
 
-    private ObjectMapperOptimizations() {}
-
-    /**
-     * We disable afterburner optimizations by default on java 16+ where internal access is
-     * restricted by https://openjdk.java.net/jeps/396 and https://openjdk.java.net/jeps/403.
-     */
-    private static boolean shouldDisableByDefault() {
-        return Runtime.version().feature() >= 16;
-    }
-
-    private static boolean readProperty(String property, boolean defaultValue) {
-        return Boolean.parseBoolean(System.getProperty(property, Boolean.toString(defaultValue)));
+    private ObjectMapperOptimizations() {
     }
 }

--- a/versions.lock
+++ b/versions.lock
@@ -1,8 +1,8 @@
 # Run ./gradlew writeVersionsLock to regenerate this file
 com.fasterxml:classmate:1.5.1 (1 constraints: 9a122a13)
 com.fasterxml.jackson.core:jackson-annotations:2.15.3 (11 constraints: a5cb8531)
-com.fasterxml.jackson.core:jackson-core:2.15.3 (15 constraints: 6f3b8e5f)
-com.fasterxml.jackson.core:jackson-databind:2.15.3 (19 constraints: 657bcd19)
+com.fasterxml.jackson.core:jackson-core:2.15.3 (14 constraints: ec23b668)
+com.fasterxml.jackson.core:jackson-databind:2.15.3 (18 constraints: e263a4e3)
 com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.15.3 (2 constraints: 3220a606)
 com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.15.3 (1 constraints: 3c05423b)
 com.fasterxml.jackson.datatype:jackson-datatype-guava:2.15.3 (1 constraints: 3c05423b)
@@ -11,7 +11,6 @@ com.fasterxml.jackson.datatype:jackson-datatype-joda:2.15.3 (1 constraints: 3c05
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3 (1 constraints: 3c05423b)
 com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base:2.15.3 (1 constraints: f71afd42)
 com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-cbor-provider:2.15.3 (1 constraints: 3c05423b)
-com.fasterxml.jackson.module:jackson-module-afterburner:2.15.3 (1 constraints: 3c05423b)
 com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.15.3 (2 constraints: e4300fb4)
 com.fasterxml.jackson.module:jackson-module-scala_2.12:2.15.3 (1 constraints: 3c05423b)
 com.github.ben-manes.caffeine:caffeine:3.1.8 (3 constraints: f223e4a4)


### PR DESCRIPTION
Afterburner is not used on supported JDKs, there's no reason to include the dependency.

==COMMIT_MSG==
Remove Dependency on Jackson Afterburner
==COMMIT_MSG==

## Possible downsides?
Slight possibility that code running on jdk-11 may observe a very slight performance regression. In practice we haven't seen much difference between registering afterburner and not.

