### PR TITLE
Cache Feign endpoints

### DIFF
--- a/conjure-java-jaxrs-client/build.gradle
+++ b/conjure-java-jaxrs-client/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     implementation 'com.palantir.tritium:tritium-registry'
     implementation 'io.dropwizard.metrics:metrics-core'
 
+    annotationProcessor "org.immutables:value"
+    compileOnly 'org.immutables:value::annotations'
+
     implementation project(":conjure-java-jackson-serialization")
     implementation "com.google.guava:guava"
     implementation "com.github.ben-manes.caffeine:caffeine"

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/MethodHeaderEnrichmentContract.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/feignimpl/MethodHeaderEnrichmentContract.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.client.jaxrs.feignimpl;
+
+import feign.Contract;
+import feign.MethodMetadata;
+import java.lang.reflect.Method;
+
+/**
+ * Contract to capture the method name and pass it to a feign client.
+ *
+ * This should be considered internal API and should not be depended upon.
+ */
+public final class MethodHeaderEnrichmentContract extends AbstractDelegatingContract {
+
+    public static final String METHOD_HEADER = "dialogue-method";
+
+    public MethodHeaderEnrichmentContract(Contract delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected void processMetadata(Class<?> _targetType, Method method, MethodMetadata metadata) {
+        metadata.template().header(METHOD_HEADER, method.toString());
+    }
+}

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
 import com.palantir.dialogue.Channel;
@@ -87,7 +86,7 @@ public final class JaxRsClientDialogueEndpointTest {
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(channel).execute(endpointCaptor.capture(), requestCaptor.capture());
         UrlBuilder urlBuilder = mock(UrlBuilder.class);
-        endpointCaptor.getValue().renderPath(ImmutableMap.of(), urlBuilder);
+        endpointCaptor.getValue().renderPath(requestCaptor.getValue().pathParameters(), urlBuilder);
         verify(urlBuilder).queryParam("query", "a");
         verify(urlBuilder).queryParam("query", "/");
         verify(urlBuilder).queryParam("query", "");
@@ -167,7 +166,7 @@ public final class JaxRsClientDialogueEndpointTest {
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(channel).execute(endpointCaptor.capture(), requestCaptor.capture());
         UrlBuilder urlBuilder = mock(UrlBuilder.class);
-        endpointCaptor.getValue().renderPath(ImmutableMap.of(), urlBuilder);
+        endpointCaptor.getValue().renderPath(requestCaptor.getValue().pathParameters(), urlBuilder);
         verify(urlBuilder).pathSegment("foo"); // context path
         verify(urlBuilder).pathSegment("static0");
         verify(urlBuilder).pathSegment("dynamic0");
@@ -186,7 +185,7 @@ public final class JaxRsClientDialogueEndpointTest {
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(channel).execute(endpointCaptor.capture(), requestCaptor.capture());
         UrlBuilder urlBuilder = mock(UrlBuilder.class);
-        endpointCaptor.getValue().renderPath(ImmutableMap.of(), urlBuilder);
+        endpointCaptor.getValue().renderPath(requestCaptor.getValue().pathParameters(), urlBuilder);
         verify(urlBuilder).pathSegment("foo"); // context path
         verify(urlBuilder).pathSegment("static0");
         verify(urlBuilder).pathSegment("dynamic0");
@@ -205,7 +204,7 @@ public final class JaxRsClientDialogueEndpointTest {
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(channel).execute(endpointCaptor.capture(), requestCaptor.capture());
         UrlBuilder urlBuilder = mock(UrlBuilder.class);
-        endpointCaptor.getValue().renderPath(ImmutableMap.of(), urlBuilder);
+        endpointCaptor.getValue().renderPath(requestCaptor.getValue().pathParameters(), urlBuilder);
         verify(urlBuilder).pathSegment("foo"); // context path
         verify(urlBuilder).pathSegment("begin");
         verify(urlBuilder).pathSegment("");
@@ -222,12 +221,12 @@ public final class JaxRsClientDialogueEndpointTest {
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(channel).execute(endpointCaptor.capture(), requestCaptor.capture());
         UrlBuilder urlBuilder = mock(UrlBuilder.class);
-        endpointCaptor.getValue().renderPath(ImmutableMap.of(), urlBuilder);
+        endpointCaptor.getValue().renderPath(requestCaptor.getValue().pathParameters(), urlBuilder);
         verify(urlBuilder).pathSegment("foo"); // context path
         verify(urlBuilder).pathSegment("/"); // encoded into %2F by DefaultUrlBuilder
     }
 
-    static Channel stubNoContentResponseChannel() {
+    private static Channel stubNoContentResponseChannel() {
         Channel channel = mock(Channel.class);
         Response response = mock(Response.class);
         when(response.body()).thenReturn(new ByteArrayInputStream(new byte[0]));

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
@@ -110,10 +110,10 @@ public final class JaxRsClientDialogueEndpointTest {
         Request request = requestCaptor.getValue();
         assertThat(request.body()).isPresent();
         assertThat(request.body().get().contentType()).isEqualTo("text/plain");
+        assertThat(request.body().get().contentLength()).hasValue(13);
         assertThat(request.headerParams().asMap())
                 .containsExactly(
-                        new AbstractMap.SimpleImmutableEntry<>("Accept", ImmutableList.of("application/json")),
-                        new AbstractMap.SimpleImmutableEntry<>("Content-Length", ImmutableList.of("13")));
+                        new AbstractMap.SimpleImmutableEntry<>("Accept", ImmutableList.of("application/json")));
     }
 
     @Test
@@ -133,9 +133,9 @@ public final class JaxRsClientDialogueEndpointTest {
         Request request = requestCaptor.getValue();
         assertThat(request.body()).isPresent();
         assertThat(request.body().get().contentType()).isEqualTo("application/json");
+        assertThat(request.body().get().contentLength()).hasValue(15);
 
-        assertThat(request.headerParams().asMap())
-                .containsExactly(new AbstractMap.SimpleImmutableEntry<>("Content-Length", ImmutableList.of("15")));
+        assertThat(request.headerParams().asMap()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
The ultimate goal of this PR is to allow us to revert https://github.com/palantir/dialogue/pull/1414, or to at least add an exemption for `FeignEndpoint`.

The only part of the `feign.Request` that we use in the `Endpoint` implementation is the request URL. Because we don't use Dialogue path templates and path parameters here, we can (ab)use the Dialogue path parameters to pass the request URL.

Although this may seem a little strange at first glance, it's not entirely unlike the static/dynamic split between path templates and path parameters - it's just as if the entire path template is a single path parameter.