### PR TITLE
ServiceExceptionMapper log messages use placeholders

### DIFF
--- a/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
+++ b/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
@@ -42,15 +42,15 @@ final class ServiceExceptionMapper extends ListenableExceptionMapper<ServiceExce
         int httpStatus = exception.getErrorType().httpErrorCode();
         if (httpStatus / 100 == 4 /* client error */) {
             log.info(
-                    "Error handling request",
-                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
+                    "Error handling request. {}: {}",
                     SafeArg.of("errorName", exception.getErrorType().name()),
+                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
                     exception);
         } else {
             log.error(
-                    "Error handling request",
-                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
+                    "Error handling request. {}: {}",
                     SafeArg.of("errorName", exception.getErrorType().name()),
+                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
                     exception);
         }
 


### PR DESCRIPTION
## Before this PR
My logging framework does not have SLS logging so I don't get any log arguments
See https://github.com/palantir/conjure-java-runtime/issues/1582

## After this PR
ServiceExceptionMapper log messages use placeholders
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

