### PR TITLE
Jakarta ServiceExceptionMapper log messages use placeholders

### DIFF
--- a/conjure-java-jersey-jakarta-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
+++ b/conjure-java-jersey-jakarta-server/src/main/java/com/palantir/conjure/java/server/jersey/ServiceExceptionMapper.java
@@ -42,15 +42,15 @@ final class ServiceExceptionMapper extends ListenableExceptionMapper<ServiceExce
         int httpStatus = exception.getErrorType().httpErrorCode();
         if (httpStatus / 100 == 4 /* client error */) {
             log.info(
-                    "Error handling request",
-                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
+                    "Error handling request. {}: {}",
                     SafeArg.of("errorName", exception.getErrorType().name()),
+                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
                     exception);
         } else {
             log.error(
-                    "Error handling request",
-                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
+                    "Error handling request. {}: {}",
                     SafeArg.of("errorName", exception.getErrorType().name()),
+                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
                     exception);
         }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Follow up to https://github.com/palantir/conjure-java-runtime/pull/3102

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Jakarta ServiceExceptionMapper log messages use placeholders
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

