### PR TITLE
Optimize DialogueFeignClient small response reader

### DIFF
--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
@@ -50,7 +50,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
+import java.io.StringReader;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -143,11 +143,7 @@ final class DialogueFeignClient implements feign.Client {
     }
 
     private static String urlDecode(String input) {
-        try {
-            return URLDecoder.decode(input, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new SafeUncheckedIoException("Failed to decode path segment", e, UnsafeArg.of("encoded", input));
-        }
+        return URLDecoder.decode(input, StandardCharsets.UTF_8);
     }
 
     private static Optional<RequestBody> requestBody(Request request) {
@@ -239,6 +235,17 @@ final class DialogueFeignClient implements feign.Client {
 
         @Override
         public Reader asReader() {
+            Integer maybeLength = length();
+            if (maybeLength != null && maybeLength < 8192) {
+                // Avoid InputStreamReader / HeapByteBuffer overhead for small (less than 8KiB) inputs,
+                // see https://github.com/FasterXML/jackson-core/pull/1081
+                try (InputStream inputStream = asInputStream()) {
+                    return new StringReader(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+                } catch (IOException e) {
+                    throw new SafeUncheckedIoException(
+                            "Failed to read response body", e, SafeArg.of("length", maybeLength));
+                }
+            }
             return new InputStreamReader(asInputStream(), StandardCharsets.UTF_8);
         }
 

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
@@ -248,7 +248,7 @@ final class DialogueFeignClient implements feign.Client {
                     byte[] bytes = new byte[toRead];
                     try {
                         int read = inputStream.readNBytes(bytes, 0, toRead);
-                        if (read == length) {
+                        if (read <= length) {
                             // fully read input
                             inputStream.close();
                             return new StringReader(new String(bytes, 0, read, StandardCharsets.UTF_8));

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
@@ -50,6 +50,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.io.SequenceInputStream;
 import java.io.StringReader;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -235,18 +236,32 @@ final class DialogueFeignClient implements feign.Client {
 
         @Override
         public Reader asReader() {
+            InputStream inputStream = asInputStream();
             Integer maybeLength = length();
-            if (maybeLength != null && maybeLength < 8192) {
-                // Avoid InputStreamReader / HeapByteBuffer overhead for small (less than 8KiB) inputs,
-                // see https://github.com/FasterXML/jackson-core/pull/1081
-                try (InputStream inputStream = asInputStream()) {
-                    return new StringReader(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
-                } catch (IOException e) {
-                    throw new SafeUncheckedIoException(
-                            "Failed to read response body", e, SafeArg.of("length", maybeLength));
+            if (maybeLength != null) {
+                int length = maybeLength;
+                if (length < 8192) {
+                    // Avoid InputStreamReader / HeapByteBuffer overhead for small (less than 8KiB) inputs,
+                    // see https://github.com/FasterXML/jackson-core/pull/1081
+                    // try to read an extra byte to determine if more bytes were provided than actual content-length
+                    int toRead = length + 1;
+                    byte[] bytes = new byte[toRead];
+                    try {
+                        int read = inputStream.readNBytes(bytes, 0, toRead);
+                        if (read == length) {
+                            // fully read input
+                            inputStream.close();
+                            return new StringReader(new String(bytes, 0, read, StandardCharsets.UTF_8));
+                        }
+                        // input was larger than provided content length, fallback to stream path
+                        inputStream = new SequenceInputStream(new ByteArrayInputStream(bytes), inputStream);
+                    } catch (IOException e) {
+                        throw new SafeUncheckedIoException(
+                                "Failed to read response body", e, SafeArg.of("length", maybeLength));
+                    }
                 }
             }
-            return new InputStreamReader(asInputStream(), StandardCharsets.UTF_8);
+            return new InputStreamReader(inputStream, StandardCharsets.UTF_8);
         }
 
         @Override


### PR DESCRIPTION
## Before this PR

Small responses <= 8KiB would always allocate 8KiB `ByteBuffer` as `InputStreamReader` creates a `StreamDecoder` that allocates a fixed 8192 byte `ByteBuffer`. This allocation becomes a scalability bottleneck for high throughput RPCs with small responses (think something returning timestamps, locks, authorization results, etc.)

See https://github.com/openjdk/jdk/blob/4c03e5938df0a9cb10c2379af81163795dd3a086/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java#L248

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Avoid `InputStreamReader` / `HeapByteBuffer` overhead for small (less than 8KiB) inputs, see https://github.com/FasterXML/jackson-core/pull/1081 and https://github.com/FasterXML/jackson-benchmarks/pull/9#issuecomment-1685036954 for benchmarks showing between 2x and 10x speedup handling deserialization of small values.

==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

