### PR TITLE
explicitly cast ctor args to unblock jackson 2.19

### DIFF
--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/BinaryBytesDeserializationModule.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/BinaryBytesDeserializationModule.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.serialization;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -41,7 +42,7 @@ public final class BinaryBytesDeserializationModule extends SimpleModule {
     private static final class BytesObjectDeserializer extends UntypedObjectDeserializer {
         BytesObjectDeserializer() {
             // Use the default behaviour for lists and maps
-            super(null, null);
+            super(null, (JavaType) null);
         }
 
         @Override


### PR DESCRIPTION
in jackson 2.19+, a constructor was added to UntypedObjectDeserializer making this super() call ambiguous; this should unblock it.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

