### PR TITLE
Add `withConjureErrorParameterFormat` option to `WithClientOptions`

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -79,3 +79,8 @@ acceptedBreaks:
     - code: "java.class.removed"
       old: "enum com.palantir.conjure.java.server.jersey.ErrorCause"
       justification: "ErrorCause is never used by consumers"
+  "8.22.0":
+    com.palantir.conjure.java.runtime:client-config:
+    - code: "java.method.addedToInterface"
+      new: "method T com.palantir.conjure.java.clients.ConjureClients.WithClientOptions<T>::withConjureErrorParameterSerializationFormat(com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat)"
+      justification: "Allowing clients to request error parameter serialization format"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -82,5 +82,6 @@ acceptedBreaks:
   "8.22.0":
     com.palantir.conjure.java.runtime:client-config:
     - code: "java.method.addedToInterface"
-      new: "method T com.palantir.conjure.java.clients.ConjureClients.WithClientOptions<T>::withConjureErrorParameterSerializationFormat(com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat)"
-      justification: "Allowing clients to request error parameter serialization format"
+      new: "method T com.palantir.conjure.java.clients.ConjureClients.WithClientOptions<T>::withConjureErrorParameterFormat(com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat)"
+      justification: "Adding method to allow clients to request error parameter serialization\
+        \ format"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -79,13 +79,9 @@ acceptedBreaks:
     - code: "java.class.removed"
       old: "enum com.palantir.conjure.java.server.jersey.ErrorCause"
       justification: "ErrorCause is never used by consumers"
-  "8.24.0-rc1":
+  "8.24.0":
     com.palantir.conjure.java.runtime:client-config:
     - code: "java.method.addedToInterface"
       new: "method T com.palantir.conjure.java.clients.ConjureClients.WithClientOptions<T>::withConjureErrorParameterFormat(com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat)"
-      justification: "Adding method to allow clients to request error parameter serialization\
-        \ format"
-    - code: "java.method.removed"
-      old: "method T com.palantir.conjure.java.clients.ConjureClients.WithClientOptions<T>::withConjureErrorParameterSerializationFormat(com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat)"
       justification: "Adding method to allow clients to request error parameter serialization\
         \ format"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -79,9 +79,13 @@ acceptedBreaks:
     - code: "java.class.removed"
       old: "enum com.palantir.conjure.java.server.jersey.ErrorCause"
       justification: "ErrorCause is never used by consumers"
-  "8.22.0":
+  "8.24.0-rc1":
     com.palantir.conjure.java.runtime:client-config:
     - code: "java.method.addedToInterface"
       new: "method T com.palantir.conjure.java.clients.ConjureClients.WithClientOptions<T>::withConjureErrorParameterFormat(com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat)"
+      justification: "Adding method to allow clients to request error parameter serialization\
+        \ format"
+    - code: "java.method.removed"
+      old: "method T com.palantir.conjure.java.clients.ConjureClients.WithClientOptions<T>::withConjureErrorParameterSerializationFormat(com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat)"
       justification: "Adding method to allow clients to request error parameter serialization\
         \ format"

--- a/client-config/build.gradle
+++ b/client-config/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.revapi.revapi-gradle-plugin'
 
 dependencies {
     api 'com.palantir.conjure.java.api:service-config'
+    api 'com.palantir.conjure.java.api:errors'
     api 'com.palantir.tritium:tritium-registry'
     api 'com.google.errorprone:error_prone_annotations'
     api 'com.palantir.refreshable:refreshable'

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -127,8 +127,6 @@ public interface ClientConfiguration {
     /** Per-host failures are recorded using this interface. */
     Optional<HostEventsSink> hostEventsSink();
 
-    Optional<Boolean> supportsConjureErrorDeserializationAsJson();
-
     @Value.Check
     default void check() {
         if (meshProxy().isPresent()) {

--- a/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfiguration.java
@@ -127,6 +127,8 @@ public interface ClientConfiguration {
     /** Per-host failures are recorded using this interface. */
     Optional<HostEventsSink> hostEventsSink();
 
+    Optional<Boolean> supportsConjureErrorDeserializationAsJson();
+
     @Value.Check
     default void check() {
         if (meshProxy().isPresent()) {

--- a/client-config/src/main/java/com/palantir/conjure/java/clients/ConjureClients.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/clients/ConjureClients.java
@@ -90,7 +90,7 @@ public final class ConjureClients {
         /** Per-host success/failure information will be recorded to this sink. */
         T withHostEventsSink(HostEventsSink hostEventsSink);
 
-        T withConjureErrorParameterSerializationFormat(ConjureErrorParameterFormat format);
+        T withConjureErrorParameterFormat(ConjureErrorParameterFormat format);
     }
 
     public interface ToReloadingFactory<U> {

--- a/client-config/src/main/java/com/palantir/conjure/java/clients/ConjureClients.java
+++ b/client-config/src/main/java/com/palantir/conjure/java/clients/ConjureClients.java
@@ -20,6 +20,7 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.conjure.java.api.config.service.ServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
+import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.client.config.HostEventsSink;
 import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
@@ -88,6 +89,8 @@ public final class ConjureClients {
 
         /** Per-host success/failure information will be recorded to this sink. */
         T withHostEventsSink(HostEventsSink hostEventsSink);
+
+        T withConjureErrorParameterSerializationFormat(ConjureErrorParameterFormat format);
     }
 
     public interface ToReloadingFactory<U> {


### PR DESCRIPTION
## Before this PR
I'd like to enable clients to set the desired error parameter format. We currently don't have a method on Dialogue's `ReloadingFactory` to do so.


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG== 
Add `withConjureErrorParameterFormat` option to `WithClientOptions`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

