### PR TITLE
Optimize query parameter key=value parsing

### DIFF
--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
@@ -73,7 +73,6 @@ final class DialogueFeignClient implements feign.Client {
     private static final Splitter PATH_SPLITTER = Splitter.on('/');
     private static final Splitter QUERY_SPLITTER = Splitter.on('&').omitEmptyStrings();
     private static final char QUERY_KEY_VALUE_SEPARATOR = '=';
-    private static final Splitter QUERY_KEY_VALUE_SPLITTER = Splitter.on(QUERY_KEY_VALUE_SEPARATOR);
 
     private final ConjureRuntime runtime;
     private final Channel channel;
@@ -419,23 +418,18 @@ final class DialogueFeignClient implements feign.Client {
             if (queryParamsStart != -1) {
                 String querySegments = trailing.substring(queryParamsStart + 1);
                 for (String querySegment : QUERY_SPLITTER.split(querySegments)) {
-                    boolean isValid = false;
                     int equalsIndex = querySegment.indexOf(QUERY_KEY_VALUE_SEPARATOR);
-                    if (equalsIndex > -1) {
+                    if (equalsIndex > 0) {
                         String key = querySegment.substring(0, equalsIndex);
-                        int valueStart = equalsIndex + 1;
-                        if (querySegment.indexOf(QUERY_KEY_VALUE_SEPARATOR, valueStart) == -1) {
-                            isValid = true;
-                            url.queryParam(urlDecode(key), urlDecode(querySegment.substring(valueStart)));
-                        }
-                    }
-
-                    if (!isValid) {
-                        List<String> keyValuePair = QUERY_KEY_VALUE_SPLITTER.splitToList(querySegment);
+                        String value = querySegment.substring(equalsIndex + 1);
+                        url.queryParam(urlDecode(key), urlDecode(value));
+                    } else {
                         throw new SafeIllegalStateException(
                                 "Expected two parameters",
-                                SafeArg.of("parameters", keyValuePair.size()),
-                                UnsafeArg.of("values", keyValuePair));
+                                SafeArg.of(
+                                        "parameters",
+                                        querySegment.split(String.valueOf(QUERY_KEY_VALUE_SEPARATOR)).length),
+                                UnsafeArg.of("values", querySegment));
                     }
                 }
             }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
@@ -419,15 +419,18 @@ final class DialogueFeignClient implements feign.Client {
             if (queryParamsStart != -1) {
                 String querySegments = trailing.substring(queryParamsStart + 1);
                 for (String querySegment : QUERY_SPLITTER.split(querySegments)) {
+                    boolean isValid = false;
                     int equalsIndex = querySegment.indexOf(QUERY_KEY_VALUE_SEPARATOR);
                     if (equalsIndex > -1) {
                         String key = querySegment.substring(0, equalsIndex);
                         int valueStart = equalsIndex + 1;
                         if (querySegment.indexOf(QUERY_KEY_VALUE_SEPARATOR, valueStart) == -1) {
-                            String value = querySegment.substring(valueStart);
-                            url.queryParam(urlDecode(key), urlDecode(value));
+                            isValid = true;
+                            url.queryParam(urlDecode(key), urlDecode(querySegment.substring(valueStart)));
                         }
-                    } else {
+                    }
+
+                    if (!isValid) {
                         List<String> keyValuePair = QUERY_KEY_VALUE_SPLITTER.splitToList(querySegment);
                         throw new SafeIllegalStateException(
                                 "Expected two parameters",

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
@@ -426,9 +426,7 @@ final class DialogueFeignClient implements feign.Client {
                     } else {
                         throw new SafeIllegalStateException(
                                 "Expected two parameters",
-                                SafeArg.of(
-                                        "parameters",
-                                        querySegment.split(String.valueOf(QUERY_KEY_VALUE_SEPARATOR)).length),
+                                SafeArg.of("parameters", equalsIndex == -1 ? 0 : 1),
                                 UnsafeArg.of("values", querySegment));
                     }
                 }

--- a/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
+++ b/conjure-java-jaxrs-client/src/main/java/com/palantir/conjure/java/client/jaxrs/DialogueFeignClient.java
@@ -72,7 +72,8 @@ final class DialogueFeignClient implements feign.Client {
     private static final String REQUEST_URL_PATH_PARAM = "request-url";
     private static final Splitter PATH_SPLITTER = Splitter.on('/');
     private static final Splitter QUERY_SPLITTER = Splitter.on('&').omitEmptyStrings();
-    private static final Splitter QUERY_VALUE_SPLITTER = Splitter.on('=');
+    private static final char QUERY_KEY_VALUE_SEPARATOR = '=';
+    private static final Splitter QUERY_KEY_VALUE_SPLITTER = Splitter.on(QUERY_KEY_VALUE_SEPARATOR);
 
     private final ConjureRuntime runtime;
     private final Channel channel;
@@ -386,6 +387,7 @@ final class DialogueFeignClient implements feign.Client {
         }
 
         @Override
+        @SuppressWarnings("CyclomaticComplexity")
         public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
             List<String> requestUrls = params.get(REQUEST_URL_PATH_PARAM);
             Preconditions.checkState(
@@ -417,14 +419,21 @@ final class DialogueFeignClient implements feign.Client {
             if (queryParamsStart != -1) {
                 String querySegments = trailing.substring(queryParamsStart + 1);
                 for (String querySegment : QUERY_SPLITTER.split(querySegments)) {
-                    List<String> keyValuePair = QUERY_VALUE_SPLITTER.splitToList(querySegment);
-                    if (keyValuePair.size() != 2) {
+                    int equalsIndex = querySegment.indexOf(QUERY_KEY_VALUE_SEPARATOR);
+                    if (equalsIndex > -1) {
+                        String key = querySegment.substring(0, equalsIndex);
+                        int valueStart = equalsIndex + 1;
+                        if (querySegment.indexOf(QUERY_KEY_VALUE_SEPARATOR, valueStart) == -1) {
+                            String value = querySegment.substring(valueStart);
+                            url.queryParam(urlDecode(key), urlDecode(value));
+                        }
+                    } else {
+                        List<String> keyValuePair = QUERY_KEY_VALUE_SPLITTER.splitToList(querySegment);
                         throw new SafeIllegalStateException(
                                 "Expected two parameters",
                                 SafeArg.of("parameters", keyValuePair.size()),
                                 UnsafeArg.of("values", keyValuePair));
                     }
-                    url.queryParam(urlDecode(keyValuePair.get(0)), urlDecode(keyValuePair.get(1)));
                 }
             }
         }

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
@@ -105,7 +105,7 @@ public final class JaxRsClientDialogueEndpointTest {
     public void testQueryParameters() {
         Channel channel = stubNoContentResponseChannel();
         StubService service = JaxRsClient.create(StubService.class, channel, runtime);
-        service.collectionOfQueryParams(List.of("", "=", "test=value"));
+        service.collectionOfQueryParams(List.of("", "=", "value", "test=value"));
 
         ArgumentCaptor<Endpoint> endpointCaptor = ArgumentCaptor.forClass(Endpoint.class);
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
@@ -114,11 +114,12 @@ public final class JaxRsClientDialogueEndpointTest {
                 .hasSize(1)
                 .extractingByKey("request-url")
                 .asInstanceOf(collection(String.class))
-                .containsExactly("dialogue://feign/foo/params?query=&query=%3D&query=test%3Dvalue");
+                .containsExactly("dialogue://feign/foo/params?query=&query=%3D&query=value&query=test%3Dvalue");
         Endpoint endpoint = endpointCaptor.getValue();
         UrlBuilder urlBuilder = mock(UrlBuilder.class);
         endpoint.renderPath(
-                ImmutableListMultimap.of("request-url", "dialogue://feign/foo/params?query=&query==&query=test=value"),
+                ImmutableListMultimap.of(
+                        "request-url", "dialogue://feign/foo/params?query=&query==&query=value&query=test=value"),
                 urlBuilder);
         verify(urlBuilder).queryParam("query", "");
         verify(urlBuilder).queryParam("query", "=");
@@ -141,13 +142,19 @@ public final class JaxRsClientDialogueEndpointTest {
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasLogMessage("Expected two parameters")
                 .args()
-                .containsExactlyInAnyOrder(SafeArg.of("parameters", 0), UnsafeArg.of("values", "="));
+                .containsExactlyInAnyOrder(SafeArg.of("parameters", 1), UnsafeArg.of("values", "="));
+        assertThatLoggableExceptionThrownBy(() -> endpoint.renderPath(
+                        ImmutableListMultimap.of("request-url", "dialogue://feign/foo/params?=value"), urlBuilder))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasLogMessage("Expected two parameters")
+                .args()
+                .containsExactlyInAnyOrder(SafeArg.of("parameters", 1), UnsafeArg.of("values", "=value"));
         assertThatLoggableExceptionThrownBy(() -> endpoint.renderPath(
                         ImmutableListMultimap.of("request-url", "dialogue://feign/foo/params?query"), urlBuilder))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasLogMessage("Expected two parameters")
                 .args()
-                .containsExactlyInAnyOrder(SafeArg.of("parameters", 1), UnsafeArg.of("values", "query"));
+                .containsExactlyInAnyOrder(SafeArg.of("parameters", 0), UnsafeArg.of("values", "query"));
         verify(urlBuilder, never()).queryParam(any(), any());
     }
 

--- a/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
+++ b/conjure-java-jaxrs-client/src/test/java/com/palantir/conjure/java/client/jaxrs/JaxRsClientDialogueEndpointTest.java
@@ -16,10 +16,13 @@
 
 package com.palantir.conjure.java.client.jaxrs;
 
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.collection;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,6 +38,9 @@ import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Response;
 import com.palantir.dialogue.UrlBuilder;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -93,6 +99,56 @@ public final class JaxRsClientDialogueEndpointTest {
         verify(urlBuilder).queryParam("query", "");
         verify(urlBuilder).queryParam("query", "a b");
         verify(urlBuilder).queryParam("query", "a+b");
+    }
+
+    @Test
+    public void testQueryParameters() {
+        Channel channel = stubNoContentResponseChannel();
+        StubService service = JaxRsClient.create(StubService.class, channel, runtime);
+        service.collectionOfQueryParams(List.of("", "=", "test=value"));
+
+        ArgumentCaptor<Endpoint> endpointCaptor = ArgumentCaptor.forClass(Endpoint.class);
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(channel).execute(endpointCaptor.capture(), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().pathParameters().asMap())
+                .hasSize(1)
+                .extractingByKey("request-url")
+                .asInstanceOf(collection(String.class))
+                .containsExactly("dialogue://feign/foo/params?query=&query=%3D&query=test%3Dvalue");
+        Endpoint endpoint = endpointCaptor.getValue();
+        UrlBuilder urlBuilder = mock(UrlBuilder.class);
+        endpoint.renderPath(
+                ImmutableListMultimap.of("request-url", "dialogue://feign/foo/params?query=&query==&query=test=value"),
+                urlBuilder);
+        verify(urlBuilder).queryParam("query", "");
+        verify(urlBuilder).queryParam("query", "=");
+        verify(urlBuilder).queryParam("query", "test=value");
+    }
+
+    @Test
+    public void testInvalidQueryParameters() {
+        Channel channel = stubNoContentResponseChannel();
+        StubService service = JaxRsClient.create(StubService.class, channel, runtime);
+        service.collectionOfQueryParams(List.of());
+
+        ArgumentCaptor<Endpoint> endpointCaptor = ArgumentCaptor.forClass(Endpoint.class);
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(channel).execute(endpointCaptor.capture(), requestCaptor.capture());
+        Endpoint endpoint = endpointCaptor.getValue();
+        UrlBuilder urlBuilder = mock(UrlBuilder.class);
+        assertThatLoggableExceptionThrownBy(() -> endpoint.renderPath(
+                        ImmutableListMultimap.of("request-url", "dialogue://feign/foo/params?="), urlBuilder))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasLogMessage("Expected two parameters")
+                .args()
+                .containsExactlyInAnyOrder(SafeArg.of("parameters", 0), UnsafeArg.of("values", "="));
+        assertThatLoggableExceptionThrownBy(() -> endpoint.renderPath(
+                        ImmutableListMultimap.of("request-url", "dialogue://feign/foo/params?query"), urlBuilder))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasLogMessage("Expected two parameters")
+                .args()
+                .containsExactlyInAnyOrder(SafeArg.of("parameters", 1), UnsafeArg.of("values", "query"));
+        verify(urlBuilder, never()).queryParam(any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Before this PR

In services that make high throughput RPCs with small responses (think similar clients of timestamps, locks, authorization results, etc. as https://github.com/palantir/conjure-java-runtime/pull/3114 ), `String#charAt` & `com.google.common.base.Splitter#splitToList` pop up as hot methods & allocators due to `DialogueFeignClient.FeignEndpoint#renderPath` query parameter `key=value` parsing.

<img width="1307" height="439" alt="image" src="https://github.com/user-attachments/assets/a233e592-c506-4de1-88fe-3bc759eaffe8" />


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use vectorized `indexOf` to improve query parameter parsing and reduce allocation overhead.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

