### PR TITLE
Avoid forcing dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,27 +47,6 @@ allprojects {
     repositories {
         mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
     }
-
-    configurations.all {
-        resolutionStrategy {
-            preferProjectModules()
-        }
-
-        resolutionStrategy.eachDependency { details ->
-            if (details.requested.group == 'com.google.errorprone' && details.requested.name == 'error_prone_annotations') {
-                details.useTarget group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.7.1'
-                details.because "The error_prone_annotations dependency must be low to avoid forcing consumers to use newer releases"
-            }
-            if (details.requested.group == 'com.github.ben-manes.caffeine' && details.requested.name == 'caffeine' && details.requested.version == '3.1.7') {
-                details.useTarget group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.6'
-                details.because "https://github.com/ben-manes/caffeine/issues/1111"
-            }
-            if (details.requested.group.startsWith('com.fasterxml.jackson') && (details.requested.version == '2.16.0' || details.requested.version == '2.16.1')) {
-                details.useTarget group: details.requested.group, name: details.requested.name, version: '2.15.3'
-                details.because 'https://github.com/FasterXML/jackson-databind/pull/4230'
-            }
-        }
-    }
 }
 
 subprojects {

--- a/conjure-java-client-verifier/build.gradle
+++ b/conjure-java-client-verifier/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     testImplementation project(':conjure-java-jaxrs-client')
     testImplementation project(':conjure-java-jackson-serialization')
     testImplementation project(':keystores')
-    testImplementation project(':okhttp-clients')
     testImplementation "org.slf4j:slf4j-api"
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
@@ -17,4 +16,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
+
+    testRuntimeOnly 'jakarta.ws.rs:jakarta.ws.rs-api'
 }

--- a/conjure-java-jackson-serialization/build.gradle
+++ b/conjure-java-jackson-serialization/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'com.palantir.tritium:tritium-registry'
     implementation 'io.dropwizard.metrics:metrics-core'
 
+    testImplementation 'com.fasterxml.jackson.core:jackson-annotations'
     testImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
     testImplementation "org.assertj:assertj-core"
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/conjure-java-jersey-jakarta-server/build.gradle
+++ b/conjure-java-jersey-jakarta-server/build.gradle
@@ -41,12 +41,3 @@ dependencies {
     implementation 'com.palantir.safe-logging:logger'
 
 }
-
-configurations.all {
-    resolutionStrategy {
-        // Conflicts with javax.inject:javax.inject:1
-        // This is safe to remove, the purpose of the repackaged version is to implement OSGI, which we don't use
-        // Source: https://stackoverflow.com/a/25218230/274699
-        exclude group: 'org.glassfish.hk2.external', module: 'jakarta.inject'
-    }
-}

--- a/conjure-java-jersey-server/build.gradle
+++ b/conjure-java-jersey-server/build.gradle
@@ -55,15 +55,6 @@ dependencies {
     }
 }
 
-configurations.all {
-    resolutionStrategy {
-        // Conflicts with javax.inject:javax.inject:1
-        // This is safe to remove, the purpose of the repackaged version is to implement OSGI, which we don't use
-        // Source: https://stackoverflow.com/a/25218230/274699
-        exclude group: 'org.glassfish.hk2.external', module: 'jakarta.inject'
-    }
-}
-
 checkImplicitDependencies {
     ignore 'com.palantir.conjure.java.runtime', 'conjure-java-jersey-jakarta-server'
 }

--- a/conjure-java-server-verifier/build.gradle
+++ b/conjure-java-server-verifier/build.gradle
@@ -8,10 +8,11 @@ dependencies {
     testImplementation project(':conjure-java-jaxrs-client')
     testImplementation project(':conjure-java-jersey-jakarta-server')
     testImplementation project(':keystores')
-    testImplementation project(':okhttp-clients')
     testImplementation project(':undertow-jakarta-testing')
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
+    testImplementation 'com.palantir.conjure.java:conjure-lib'
+    testImplementation 'jakarta.ws.rs:jakarta.ws.rs-api'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-params'

--- a/gradle/verifier.gradle
+++ b/gradle/verifier.gradle
@@ -27,8 +27,6 @@ dependencies {
     generatedJerseyImplementation 'jakarta.ws.rs:jakarta.ws.rs-api'
     generatedJerseyImplementation sourceSets.generatedObjects.output
 
-    testImplementation 'com.palantir.conjure.java:conjure-lib'
-    testImplementation 'jakarta.ws.rs:jakarta.ws.rs-api'
     testImplementation sourceSets.generatedObjects.output
     testImplementation sourceSets.generatedJersey.output
 }
@@ -102,5 +100,3 @@ test.dependsOn unpackVerifier, copyTestCases
 
 checkstyleGeneratedObjects.enabled = false
 checkstyleGeneratedJersey.enabled = false
-
-checkUnusedDependenciesTest.enabled = false

--- a/versions.lock
+++ b/versions.lock
@@ -28,11 +28,11 @@ com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.20.0 (
 
 com.fasterxml.jackson.module:jackson-module-scala_2.12:2.20.0 (1 constraints: 3605333b)
 
-com.github.ben-manes.caffeine:caffeine:3.2.3 (3 constraints: e42397a2)
+com.github.ben-manes.caffeine:caffeine:3.2.2 (3 constraints: e3233da2)
 
 com.google.code.findbugs:jsr305:3.0.2 (7 constraints: 5f6b7728)
 
-com.google.errorprone:error_prone_annotations:2.7.1 (18 constraints: bd186fb8)
+com.google.errorprone:error_prone_annotations:2.41.0 (18 constraints: ba1866af)
 
 com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
 

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,6 @@
 com.fasterxml.jackson.*:* = 2.20.0
 com.fasterxml.jackson.core:jackson-annotations = 2.20
-com.github.ben-manes.caffeine:caffeine = 3.2.3
+com.github.ben-manes.caffeine:caffeine = 3.2.2
 com.google.code.findbugs:jsr305 = 3.0.2
 com.google.guava:guava = 33.5.0-jre
 com.netflix.concurrency-limits:* = 0.2.2


### PR DESCRIPTION
The `error_prone_annotations` version is forced in this repo, which allowed Caffeine to upgrade in https://github.com/palantir/conjure-java-runtime/pull/3275. But this then fails to upgrade in consumers which have not migrated to Java 21.

```
  bad class file: /home/circleci/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotation/2.43.0/f6b6825247bb18f81208b9911b200b9d71d29e71/error_prone_annotation-2.43.0.jar(/com/google/errorprone/BugPattern.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
```

Forcing downgrading dependencies is dangerous, since there might be code depending on a newer version that will fail at runtime.

In practice, all of our consumer were using newer versions of these dependencies because they are pulled in elsewhere.