### PR TITLE
Make DefaultCas public to allow building custom truststores

### DIFF
--- a/keystores/src/main/java/com/palantir/conjure/java/config/ssl/DefaultCas.java
+++ b/keystores/src/main/java/com/palantir/conjure/java/config/ssl/DefaultCas.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-final class DefaultCas {
+public final class DefaultCas {
 
     private static final SafeLogger log = SafeLoggerFactory.get(DefaultCas.class);
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
DefaultCas is package-private which does not allow building custom truststores that trust default cas
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==
DefaultCas class is public to allow clients to build custom truststores


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

