### PR TITLE
Add JacksonWarmup to pre-settle JIT

### DIFF
--- a/conjure-java-jackson-serialization/build.gradle
+++ b/conjure-java-jackson-serialization/build.gradle
@@ -29,3 +29,9 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
 }
+
+tasks.named('test', Test) {
+    // Forward the opt-in flag for JacksonWarmupReproducerTest so it can be enabled with
+    // `./gradlew :conjure-java-jackson-serialization:test -Djackson.warmup.reproducer=true`.
+    systemProperty 'jackson.warmup.reproducer', System.getProperty('jackson.warmup.reproducer', 'false')
+}

--- a/conjure-java-jackson-serialization/build.gradle
+++ b/conjure-java-jackson-serialization/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     api "com.fasterxml.jackson.datatype:jackson-datatype-joda"
     api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     api "com.palantir.safe-logging:preconditions"
+
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.google.code.findbugs:jsr305'
     implementation 'com.google.guava:guava'

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/JacksonWarmup.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/JacksonWarmup.java
@@ -24,6 +24,9 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,17 +38,31 @@ import java.util.stream.Stream;
  * (typed vs untyped serializer) with full type-profile coverage before customer traffic perturbs it.
  *
  * <p>Without this warmup, a hot host that gets restarted and then receives a perturbing workload can re-enter
- * {@code unstable_if} deopt thrash on the JSON serialization path. The bytecode site is
- * {@code if (_typeSerializer == null)} in {@code BeanPropertyWriter.serializeAsField}: properties feeding
- * monomorphic serializers take one branch while properties feeding polymorphic serializers (Conjure unions,
- * {@code @JsonTypeInfo} types) take the other. The JIT speculates one branch, hits the other, deopts, recompiles,
- * and repeats - manifesting as kernel/system CPU from safepoints, code-cache invalidation, and recompilation.
+ * {@code unstable_if} deopt thrash on the JSON serialization path. The bytecode site is the
+ * {@code if (_typeSerializer == null)} check in {@code BeanPropertyWriter.serializeAsField}
+ * (<a href="https://github.com/FasterXML/jackson-databind/blob/jackson-databind-2.21.4/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java#L731-L735">jackson-databind
+ * 2.21.4 source</a>): properties feeding monomorphic serializers take one branch while properties feeding
+ * polymorphic serializers (Conjure unions, {@code @JsonTypeInfo} types) take the other. The JIT speculates
+ * one branch, hits the other, deopts, recompiles, and repeats - manifesting as kernel/system CPU from
+ * safepoints, code-cache invalidation, and recompilation. Throughput regressions of ~10x have been
+ * observed in production when this fires.
+ *
+ * <p>One might expect C2 to learn the bimorphic profile after a few deopts and stop. It does not: HotSpot
+ * suppresses re-profiling at sites that have already produced an {@code uncommon_trap} (the
+ * {@code too_many_traps} predicate, see Shipilev's
+ * <a href="https://shipilev.net/jvm/anatomy-quarks/29-uncommon-traps/">"Uncommon Traps" article</a>), so the
+ * site stays compiled for the wrong branch and keeps deoptimizing. The upstream fix is
+ * <a href="https://github.com/openjdk/jdk/pull/28966">openjdk/jdk#28966</a>, which switches the predicate to
+ * {@code too_many_traps_or_recompiles}. Until that lands and propagates, this class works around the bug
+ * by feeding C2 a bimorphic profile at startup for the Jackson serialization path.
  *
  * <p>The warmup payloads include both kinds of fields in the same object so each iteration exercises both branches,
  * letting C2 record a bimorphic profile for {@code serializeAsField} during warmup rather than learning it from
- * production traffic.
+ * production traffic. The bimorphic dispatch this leaves behind is essentially free (a single null check plus
+ * an inline cache with two entries), and is many orders of magnitude cheaper than the recompilation storm it
+ * prevents, even on hosts that only ever exercise one branch in steady state.
  *
- * <p>See OpenJDK issues:<ul>
+ * <p>See also OpenJDK issues:<ul>
  * <li> <a href="https://bugs.openjdk.org/browse/JDK-8330258">JDK-8330258</a> </li>
  * <li> <a href="https://bugs.openjdk.org/browse/JDK-8374307">JDK-8374307</a> </li>
  * </ul>
@@ -54,8 +71,12 @@ public final class JacksonWarmup {
 
     private static final SafeLogger log = SafeLoggerFactory.get(JacksonWarmup.class);
 
-    // Comfortably above HotSpot's tiered-compilation threshold (10_000) so C2 compilation completes during warmup.
-    static final int ITERATIONS = 20_000;
+    // Each iteration runs every mapper against every payload once, so per (mapper, payload) we hit ITERATIONS
+    // top-level writeValue invocations and many more invocations of the shared inner methods like
+    // BeanPropertyWriter.serializeAsField (one per field per payload). This is comfortably above HotSpot's
+    // tiered-compilation invocation thresholds (Tier4InvocationThreshold defaults to 5_000) so C2 settles on
+    // the bimorphic profile during warmup. Total warmup wall-clock is O(1s) on modern hardware.
+    static final int ITERATIONS = 10_000;
 
     private JacksonWarmup() {}
 
@@ -89,19 +110,27 @@ public final class JacksonWarmup {
         long count = 0;
         try (OutputStream sink = new DiscardOutputStream()) {
             List<Object> payloads = buildPayloads();
-            for (ObjectMapper mapper : mappers) {
-                try {
-                    for (int i = 0; i < ITERATIONS; i++) {
+            // Iteration is the outer loop and mappers is the inner loop so each iteration exercises every mapper.
+            // The hot methods being warmed (BeanPropertyWriter.serializeAsField, the per-field serializers) are
+            // JVM-wide compiled, so interleaving lets every mapper contribute to the type profile rather than
+            // letting the first mapper dominate and the rest only confirm it.
+            List<ObjectMapper> active = new ArrayList<>(Arrays.asList(mappers));
+            for (int i = 0; i < ITERATIONS && !active.isEmpty(); i++) {
+                for (Iterator<ObjectMapper> it = active.iterator(); it.hasNext(); ) {
+                    ObjectMapper mapper = it.next();
+                    try {
                         for (Object payload : payloads) {
                             mapper.writeValue(sink, payload);
                             count++;
                         }
+                    } catch (IOException | RuntimeException e) {
+                        log.warn(
+                                "Jackson ObjectMapper warmup failed; continuing without it",
+                                SafeArg.of("mapperClass", mapper.getClass().getCanonicalName()),
+                                e);
+                        // Drop the mapper from the active set so we don't spam logs on every subsequent iteration.
+                        it.remove();
                     }
-                } catch (IOException | RuntimeException e) {
-                    log.warn(
-                            "Jackson ObjectMapper warmup failed; continuing without it",
-                            SafeArg.of("mapperClass", mapper.getClass().getCanonicalName()),
-                            e);
                 }
             }
             long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;

--- a/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/JacksonWarmup.java
+++ b/conjure-java-jackson-serialization/src/main/java/com/palantir/conjure/java/serialization/JacksonWarmup.java
@@ -1,0 +1,224 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.serialization;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Synchronously serializes a representative set of payload shapes through both the server and dialogue/client
+ * {@link ObjectMapper}s so the JIT settles on the bimorphic {@code BeanPropertyWriter.serializeAsField} branch
+ * (typed vs untyped serializer) with full type-profile coverage before customer traffic perturbs it.
+ *
+ * <p>Without this warmup, a hot host that gets restarted and then receives a perturbing workload can re-enter
+ * {@code unstable_if} deopt thrash on the JSON serialization path. The bytecode site is
+ * {@code if (_typeSerializer == null)} in {@code BeanPropertyWriter.serializeAsField}: properties feeding
+ * monomorphic serializers take one branch while properties feeding polymorphic serializers (Conjure unions,
+ * {@code @JsonTypeInfo} types) take the other. The JIT speculates one branch, hits the other, deopts, recompiles,
+ * and repeats - manifesting as kernel/system CPU from safepoints, code-cache invalidation, and recompilation.
+ *
+ * <p>The warmup payloads include both kinds of fields in the same object so each iteration exercises both branches,
+ * letting C2 record a bimorphic profile for {@code serializeAsField} during warmup rather than learning it from
+ * production traffic.
+ *
+ * <p>See OpenJDK issues:<ul>
+ * <li> <a href="https://bugs.openjdk.org/browse/JDK-8330258">JDK-8330258</a> </li>
+ * <li> <a href="https://bugs.openjdk.org/browse/JDK-8374307">JDK-8374307</a> </li>
+ * </ul>
+ */
+public final class JacksonWarmup {
+
+    private static final SafeLogger log = SafeLoggerFactory.get(JacksonWarmup.class);
+
+    // Comfortably above HotSpot's tiered-compilation threshold (10_000) so C2 compilation completes during warmup.
+    static final int ITERATIONS = 20_000;
+
+    private JacksonWarmup() {}
+
+    /**
+     * Runs the warmup against fresh server and dialogue/client {@link ObjectMapper}s built via the same
+     * conjure-java factories used at runtime. {@link com.fasterxml.jackson.databind.ser.BeanPropertyWriter} and the
+     * associated serializer classes are loaded once per classloader; compiling them through these mapper instances
+     * settles JIT state that is reused by the production mappers held inside conjure-undertow and dialogue.
+     * @return count of payloads warmed up
+     */
+    public static long run() {
+        return run(
+                ObjectMappers.newServerObjectMapper(),
+                ObjectMappers.newClientObjectMapper(),
+                ObjectMappers.newServerCborMapper(),
+                ObjectMappers.newClientCborMapper(),
+                ObjectMappers.newServerJsonMapper(),
+                ObjectMappers.newClientJsonMapper(),
+                ObjectMappers.newServerSmileMapper(),
+                ObjectMappers.newClientSmileMapper());
+    }
+
+    /**
+     * Runs the warmup against the given mappers. Visible for callers that want to fold additional, application-specific
+     * mappers into the warmup pass.
+     * @param mappers {@link ObjectMapper}s to warm up
+     * @return count of payloads warmed up
+     */
+    public static long run(ObjectMapper... mappers) {
+        long startNanos = System.nanoTime();
+        long count = 0;
+        try (OutputStream sink = new DiscardOutputStream()) {
+            List<Object> payloads = buildPayloads();
+            for (ObjectMapper mapper : mappers) {
+                try {
+                    for (int i = 0; i < ITERATIONS; i++) {
+                        for (Object payload : payloads) {
+                            mapper.writeValue(sink, payload);
+                            count++;
+                        }
+                    }
+                } catch (IOException | RuntimeException e) {
+                    log.warn(
+                            "Jackson ObjectMapper warmup failed; continuing without it",
+                            SafeArg.of("mapperClass", mapper.getClass().getCanonicalName()),
+                            e);
+                }
+            }
+            long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+            log.info(
+                    "Jackson warmup complete",
+                    SafeArg.of("mappers", mappers.length),
+                    SafeArg.of("count", count),
+                    SafeArg.of("elapsedMillis", elapsedMillis));
+        } catch (IOException | RuntimeException | Error e) {
+            // Warmup is best-effort: payloads are static and validated by tests, so a failure here indicates a
+            // classpath/module-version mismatch rather than a runtime input problem.
+            // Log and let the warmup complete for other mappers - a degraded JIT profile is better than
+            // refusing to serve traffic.
+            log.warn("Jackson warmup failed; continuing without it", e);
+        }
+        return count;
+    }
+
+    private static List<Object> buildPayloads() {
+        List<Variant> variants = List.of(
+                new Variant.StringVariant("warmup-string"),
+                new Variant.IntVariant(42),
+                new Variant.LongVariant(123_456_789_012L),
+                new Variant.DoubleVariant(3.14159d),
+                new Variant.BooleanVariant(true),
+                new Variant.ListVariant(List.of("a", "b", "c")),
+                new Variant.MapVariant(Map.of("k1", "v1", "k2", "v2")));
+
+        // A payload that interleaves monomorphic fields (concrete types - _typeSerializer == null) with
+        // polymorphic fields (sealed interface with @JsonTypeInfo - _typeSerializer != null). Both branches of
+        // BeanPropertyWriter.serializeAsField are exercised on every iteration.
+        Payload mixed = new Payload(
+                "warmup-name",
+                42,
+                123_456_789_012L,
+                3.14159d,
+                true,
+                List.of("tag-a", "tag-b"),
+                Map.of("k1", "v1", "k2", "v2"),
+                Optional.of("optional-note"),
+                variants.get(0),
+                variants,
+                Map.of("first", variants.get(1), "second", variants.get(2)),
+                Optional.of(variants.get(3)));
+
+        // A payload that drops the optionals to exercise the null/empty paths through the same writers.
+        Payload sparse = new Payload(
+                "sparse",
+                0,
+                0L,
+                0d,
+                false,
+                List.of(),
+                Map.of(),
+                Optional.empty(),
+                variants.get(4),
+                List.of(variants.get(5)),
+                Map.of(),
+                Optional.empty());
+
+        return Stream.concat(Stream.of(mixed, sparse), variants.stream()).toList();
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Variant.StringVariant.class, name = "string"),
+        @JsonSubTypes.Type(value = Variant.IntVariant.class, name = "int"),
+        @JsonSubTypes.Type(value = Variant.LongVariant.class, name = "long"),
+        @JsonSubTypes.Type(value = Variant.DoubleVariant.class, name = "double"),
+        @JsonSubTypes.Type(value = Variant.BooleanVariant.class, name = "boolean"),
+        @JsonSubTypes.Type(value = Variant.ListVariant.class, name = "list"),
+        @JsonSubTypes.Type(value = Variant.MapVariant.class, name = "map")
+    })
+    sealed interface Variant {
+        record StringVariant(String value) implements Variant {}
+
+        record IntVariant(int value) implements Variant {}
+
+        record LongVariant(long value) implements Variant {}
+
+        record DoubleVariant(double value) implements Variant {}
+
+        record BooleanVariant(boolean value) implements Variant {}
+
+        record ListVariant(List<String> value) implements Variant {}
+
+        record MapVariant(Map<String, String> value) implements Variant {}
+    }
+
+    record Payload(
+            String name,
+            int intField,
+            long longField,
+            double doubleField,
+            boolean booleanField,
+            List<String> tags,
+            Map<String, String> labels,
+            Optional<String> note,
+            Variant primary,
+            List<Variant> variants,
+            Map<String, Variant> namedVariants,
+            Optional<Variant> optionalVariant) {}
+
+    /**
+     * Sink that discards all bytes and ignores {@code close()}. {@link OutputStream#nullOutputStream()} cannot be reused
+     * across {@link ObjectMapper#writeValue(OutputStream, Object)} calls because Jackson closes the target after each
+     * write (per {@code JsonGenerator.Feature.AUTO_CLOSE_TARGET}) and the JDK sink throws {@code IOException("Stream
+     * closed")} on subsequent writes.
+     */
+    private static final class DiscardOutputStream extends OutputStream {
+        @Override
+        public void write(int _byteValue) {}
+
+        @Override
+        public void write(byte[] _buf, int _off, int _len) {}
+
+        @Override
+        public void close() {}
+    }
+}

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/JacksonWarmupReproducerTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/JacksonWarmupReproducerTest.java
@@ -1,0 +1,258 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.conjure.java.serialization.JacksonWarmup.Payload;
+import com.palantir.conjure.java.serialization.JacksonWarmup.Variant;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Reproducer for the JIT deoptimization storm at {@code BeanPropertyWriter.serializeAsField} that
+ * {@link JacksonWarmup} works around. Forks a pair of child JVMs with {@code -XX:+PrintCompilation}, drives a
+ * train-then-perturb workload through the package-protected {@link Variant} and {@link Payload} types in
+ * each, and compares the resulting {@code BeanPropertyWriter.serializeAsField} C2 events.
+ *
+ * <p>The train phase serializes {@link Variant.StringVariant} repeatedly - every property writer it touches
+ * has {@code _typeSerializer == null}, so C2 sees a monomorphic profile and may compile {@code
+ * serializeAsField} with the {@code _typeSerializer != null} branch elided as cold (an {@code uncommon_trap}).
+ * The perturb phase then serializes {@link Payload}, which interleaves typed ({@link Variant} fields, which
+ * have {@code _typeSerializer != null}) and untyped (String, int, ...) property writers. Hitting the
+ * previously-cold branch fires the trap, which PrintCompilation reports as
+ * {@code made not entrant: uncommon trap} on the C2 compilation of serializeAsField. On JDKs that haven't
+ * picked up <a href="https://github.com/openjdk/jdk/pull/28966">openjdk/jdk#28966</a>, C2 then keeps
+ * re-deopting on every recompile - this is the storm. With {@link JacksonWarmup} the bimorphic profile is
+ * established before the perturb, so the trap does not fire.
+ *
+ * <p>Opt-in: skipped by default because forking child JVMs is heavyweight relative to the rest of the suite
+ * and the bug surface depends on the running JDK. Enable with
+ * {@code ./gradlew :conjure-java-jackson-serialization:test --tests JacksonWarmupReproducerTest
+ * -Djackson.warmup.reproducer=true}.
+ *
+ * <p>See OpenJDK issues
+ * <a href="https://bugs.openjdk.org/browse/JDK-8330258">JDK-8330258</a> /
+ * <a href="https://bugs.openjdk.org/browse/JDK-8374307">JDK-8374307</a>.
+ */
+@EnabledIfSystemProperty(named = "jackson.warmup.reproducer", matches = "true")
+class JacksonWarmupReproducerTest {
+
+    private static final SafeLogger log = SafeLoggerFactory.get(JacksonWarmupReproducerTest.class);
+
+    private static final Path JAVA = Paths.get(System.getProperty("java.home"), "bin", "java");
+
+    private static final String SERIALIZE_AS_FIELD =
+            "com.fasterxml.jackson.databind.ser.BeanPropertyWriter::serializeAsField";
+
+    @Test
+    void warmupEliminatesSerializeAsFieldUncommonTrapDeopts() throws IOException, InterruptedException {
+        List<String> withoutWarmup = forkReproducer(false);
+        List<String> withWarmup = forkReproducer(true);
+
+        Counts noWarmupCounts = parse(withoutWarmup);
+        Counts warmupCounts = parse(withWarmup);
+
+        log.info(
+                "BeanPropertyWriter.serializeAsField JIT activity (no warmup)",
+                SafeArg.of("c2Compiled", noWarmupCounts.c2Compiled),
+                SafeArg.of("uncommonTrapDeopts", noWarmupCounts.uncommonTrapDeopts),
+                SafeArg.of("otherMadeNotEntrant", noWarmupCounts.otherMadeNotEntrant),
+                SafeArg.of("printCompilationLines", noWarmupCounts.relevantLines));
+        log.info(
+                "BeanPropertyWriter.serializeAsField JIT activity (with warmup)",
+                SafeArg.of("c2Compiled", warmupCounts.c2Compiled),
+                SafeArg.of("uncommonTrapDeopts", warmupCounts.uncommonTrapDeopts),
+                SafeArg.of("otherMadeNotEntrant", warmupCounts.otherMadeNotEntrant),
+                SafeArg.of("printCompilationLines", warmupCounts.relevantLines));
+
+        // Sanity: C2 (tier 4) should compile serializeAsField in both runs - this verifies the train phase
+        // drove enough invocations to trigger tiered compilation in the first place.
+        assertThat(noWarmupCounts.c2Compiled)
+                .as(
+                        "Expected C2 to compile %s without warmup. Full output:\n%s",
+                        SERIALIZE_AS_FIELD, String.join("\n", withoutWarmup))
+                .isGreaterThan(0);
+        assertThat(warmupCounts.c2Compiled)
+                .as(
+                        "Expected C2 to compile %s with warmup. Full output:\n%s",
+                        SERIALIZE_AS_FIELD, String.join("\n", withWarmup))
+                .isGreaterThan(0);
+
+        // The bug signal: without warmup, C2's monomorphic profile from the train phase doesn't survive the
+        // perturb phase - the previously-cold _typeSerializer != null branch fires an uncommon trap and
+        // PrintCompilation reports "made not entrant: uncommon trap" on the serializeAsField C2 compilation.
+        // If this assertion ever fails (i.e. uncommonTrapDeopts becomes 0 without warmup), the running JDK
+        // likely contains the fix in openjdk/jdk#28966 and JacksonWarmup may no longer be necessary.
+        assertThat(noWarmupCounts.uncommonTrapDeopts)
+                .as(
+                        "Expected at least one 'uncommon trap' deopt on %s without warmup. Without-warmup"
+                                + " output:\n%s",
+                        SERIALIZE_AS_FIELD, String.join("\n", withoutWarmup))
+                .isGreaterThan(0);
+
+        // The fix signal: warmup pre-establishes the bimorphic profile so the trap doesn't fire. If this
+        // ever regresses, warmup payloads have likely drifted away from covering both branches.
+        assertThat(warmupCounts.uncommonTrapDeopts)
+                .as(
+                        "Expected zero 'uncommon trap' deopts on %s with warmup but saw %d. With-warmup"
+                                + " output:\n%s",
+                        SERIALIZE_AS_FIELD, warmupCounts.uncommonTrapDeopts, String.join("\n", withWarmup))
+                .isZero();
+    }
+
+    private static Counts parse(List<String> printCompilation) {
+        List<String> relevant = printCompilation.stream()
+                .filter(line -> line.contains(SERIALIZE_AS_FIELD))
+                .toList();
+        long c2Compiled = relevant.stream()
+                .filter(JacksonWarmupReproducerTest::isTier4Compilation)
+                .filter(line -> !line.contains("made "))
+                .count();
+        long uncommonTrap = relevant.stream()
+                .filter(line -> line.contains("made not entrant"))
+                .filter(line -> line.contains("uncommon trap"))
+                .count();
+        long otherMadeNotEntrant = relevant.stream()
+                .filter(line -> line.contains("made not entrant"))
+                .filter(line -> !line.contains("uncommon trap"))
+                .count();
+        return new Counts(c2Compiled, uncommonTrap, otherMadeNotEntrant, relevant);
+    }
+
+    private static boolean isTier4Compilation(String line) {
+        // PrintCompilation columns: "<timestamp> <compile_id> <flags> <tier> <method> (<bytes>) [<event>]".
+        // Tier 4 is C2. We look for a standalone "4" token before the method name.
+        int methodIdx = line.indexOf(SERIALIZE_AS_FIELD);
+        return methodIdx > 0 && line.substring(0, methodIdx).matches(".*\\b4\\b\\s+$");
+    }
+
+    private static List<String> forkReproducer(boolean withWarmup) throws IOException, InterruptedException {
+        ProcessBuilder builder = new ProcessBuilder(
+                        JAVA.toString(),
+                        "-XX:+PrintCompilation",
+                        "-cp",
+                        System.getProperty("java.class.path"),
+                        Reproducer.class.getName(),
+                        Boolean.toString(withWarmup))
+                .redirectErrorStream(true);
+
+        Process process = builder.start();
+        List<String> lines;
+        try (BufferedReader reader =
+                new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            lines = reader.lines().collect(Collectors.toUnmodifiableList());
+        }
+        if (!process.waitFor(60, TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            throw new IllegalStateException(
+                    "Reproducer JVM timed out after 60s. Captured output:\n" + String.join("\n", lines));
+        }
+        int exitCode = process.exitValue();
+        if (exitCode != 0) {
+            throw new IllegalStateException(
+                    "Reproducer JVM exited " + exitCode + ". Captured output:\n" + String.join("\n", lines));
+        }
+        return lines;
+    }
+
+    private record Counts(
+            long c2Compiled, long uncommonTrapDeopts, long otherMadeNotEntrant, List<String> relevantLines) {}
+
+    /**
+     * Forked child main. Trains the JIT into a monomorphic profile by serializing a record whose property
+     * writers all have {@code _typeSerializer == null}, then perturbs by serializing a {@link Payload} that
+     * interleaves typed and untyped property writers. Designed to be invoked as a separate JVM with
+     * {@code -XX:+PrintCompilation}.
+     */
+    public static final class Reproducer {
+
+        // Far above tiered-compilation thresholds so C2 has settled before we perturb.
+        private static final int TRAIN_ITERATIONS = 200_000;
+        // Enough to give C2 multiple recompile opportunities in the perturb phase.
+        private static final int PERTURB_ITERATIONS = 50_000;
+
+        public static void main(String[] args) throws IOException, InterruptedException {
+            boolean withWarmup = args.length > 0 && Boolean.parseBoolean(args[0]);
+
+            ObjectMapper mapper = ObjectMappers.newServerObjectMapper();
+            if (withWarmup) {
+                JacksonWarmup.run(mapper);
+            }
+
+            OutputStream sink = new DiscardOutputStream();
+
+            // Train: only monomorphic (_typeSerializer == null) property writers.
+            Variant monomorphic = new Variant.StringVariant("train");
+            for (int i = 0; i < TRAIN_ITERATIONS; i++) {
+                mapper.writeValue(sink, monomorphic);
+            }
+            // Let the C2 compiler thread drain before we change the workload shape.
+            Thread.sleep(500);
+
+            // Perturb: bimorphic - Payload has both typed (Variant fields) and untyped (String, int, ...)
+            // property writers, hitting the previously-cold _typeSerializer != null branch.
+            Payload mixed = buildMixedPayload();
+            for (int i = 0; i < PERTURB_ITERATIONS; i++) {
+                mapper.writeValue(sink, mixed);
+            }
+        }
+
+        private static Payload buildMixedPayload() {
+            return new Payload(
+                    "warmup-name",
+                    42,
+                    123_456_789_012L,
+                    3.14159d,
+                    true,
+                    List.of("tag-a", "tag-b"),
+                    Map.of("k1", "v1", "k2", "v2"),
+                    Optional.of("optional-note"),
+                    new Variant.StringVariant("primary"),
+                    List.of(new Variant.IntVariant(1), new Variant.LongVariant(2L)),
+                    Map.of("first", new Variant.BooleanVariant(true)),
+                    Optional.of(new Variant.DoubleVariant(2.71d)));
+        }
+
+        private static final class DiscardOutputStream extends OutputStream {
+            @Override
+            public void write(int _byteValue) {}
+
+            @Override
+            public void write(byte[] _buf, int _off, int _len) {}
+
+            @Override
+            public void close() {}
+        }
+    }
+}

--- a/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/JacksonWarmupTest.java
+++ b/conjure-java-jackson-serialization/src/test/java/com/palantir/conjure/java/serialization/JacksonWarmupTest.java
@@ -1,0 +1,86 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.google.common.base.Stopwatch;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class JacksonWarmupTest {
+    static final long EXPECTED_OBJECT_MAPPERS = 8;
+    static final long EXPECTED_PAYLOADS = 9;
+
+    @Test
+    void runWithoutArgs() {
+        Stopwatch timer = Stopwatch.createStarted();
+        assertThat(JacksonWarmup.run())
+                .isNotZero()
+                .isEqualTo(EXPECTED_OBJECT_MAPPERS * JacksonWarmup.ITERATIONS * EXPECTED_PAYLOADS);
+        Duration elapsed = timer.elapsed();
+        assertThat(elapsed).isLessThan(Duration.ofSeconds(5)); // generous to avoid CI flakiness
+    }
+
+    @Test
+    void runWithObjectMappers() {
+        ObjectMapper[] objectMappers = objectMappers().toArray(ObjectMapper[]::new);
+        // Per-test mappers so the warmup also exercises mapper-construction overhead, not just steady-state writes.
+        Stopwatch timer = Stopwatch.createStarted();
+        assertThat(JacksonWarmup.run(objectMappers))
+                .isNotZero()
+                .isEqualTo(objectMappers.length * JacksonWarmup.ITERATIONS * EXPECTED_PAYLOADS);
+        Duration elapsed = timer.elapsed();
+        assertThat(elapsed).isLessThan(Duration.ofSeconds(5)); // generous to avoid CI flakiness
+    }
+
+    @ParameterizedTest
+    @MethodSource("objectMappers")
+    void runWithObjectMapper(ObjectMapper objectMapper) {
+        Stopwatch timer = Stopwatch.createStarted();
+        assertThat(JacksonWarmup.run(objectMapper)).isNotZero().isEqualTo(JacksonWarmup.ITERATIONS * EXPECTED_PAYLOADS);
+        Duration elapsed = timer.elapsed();
+        assertThat(elapsed).isLessThan(Duration.ofSeconds(2)); // generous to avoid CI flakiness
+    }
+
+    @Test
+    void runNoOpWithMissingModules() {
+        assertThat(JacksonWarmup.run(new ObjectMapper()))
+                .as("ObjectMapper cannot serialize Java 8 optional type `java.util.Optional<java.lang.String>` by"
+                        + " default")
+                .isZero();
+    }
+
+    static Stream<ObjectMapper> objectMappers() {
+        return Stream.of(
+                ObjectMappers.newServerObjectMapper(),
+                ObjectMappers.newClientObjectMapper(),
+                ObjectMappers.newServerCborMapper(),
+                ObjectMappers.newClientCborMapper(),
+                ObjectMappers.newServerJsonMapper(),
+                ObjectMappers.newClientJsonMapper(),
+                ObjectMappers.newServerSmileMapper(),
+                ObjectMappers.newClientSmileMapper(),
+                ObjectMappers.withDefaultModules(new ObjectMapper()),
+                ObjectMappers.withDefaultModules(new YAMLMapper()));
+    }
+}


### PR DESCRIPTION
## Before this PR

OpenJDK could encounter pathological C2 JIT deoptimization storm in Jackson [BeanPropertyWriter.java:731](https://github.com/FasterXML/jackson-databind/blob/3c95742e2db8fbe360e7bedfa900e9d2b996c8d7/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java#L731-L735) leading to ~10x performance degradation and significant increases in CPU utilization.

See https://bugs.openjdk.org/browse/JDK-8330258 & https://bugs.openjdk.org/browse/JDK-8374307

OpenJDK has an open PR https://github.com/openjdk/jdk/pull/28966 that may address this issue by switching from checking `too_many_traps` to `too_many_traps_or_recompiles`.


## After this PR
==COMMIT_MSG==
Adds a JacksonWarmup type that serializes a representative set of payload shapes through fresh server and dialogue/client `ObjectMapper`s (constructed via the same conjure-java factories used at runtime) so the JIT settles on the bimorphic `BeanPropertyWriter.serializeAsField` branch (typed vs untyped serializer) with full type-profile coverage before customer traffic perturbs it.

This works around OpenJDK C2 JIT deoptimization storm where `uncommon_trap` `isnonnull` triggers continuous deoptimization as seen in https://bugs.openjdk.org/browse/JDK-8330258 &
https://bugs.openjdk.org/browse/JDK-8374307 . The repeated deoptimization can be observed by `jdk.Deoptimization` JFR events at `com.fasterxml.jackson.databind.ser.BeanPropertyWriter` `if (_typeSerializer == null)` site, and then re-enters `unstable_if` deopt thrash on the serialization path when a perturbing workload arrives.

The warmup payloads interleave monomorphic fields (concrete types) with polymorphic fields (sealed interface + `@JsonTypeInfo`) in the same object so each iteration exercises both branches, letting C2 record a bimorphic profile during the warmup pass.

Warmup failures are caught and logged rather than aborting as a degraded JIT profile is preferable to refusing to serve traffic.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

