### PR TITLE
Upgrade undertow to 2.3

### DIFF
--- a/undertow-jakarta-testing/build.gradle
+++ b/undertow-jakarta-testing/build.gradle
@@ -7,11 +7,7 @@ versionsLock {
 dependencies {
     api 'org.junit.jupiter:junit-jupiter'
     api 'io.undertow:undertow-core'
-    api 'io.undertow:undertow-servlet-jakarta', {
-        // Use  standard servlet-api instead
-        exclude group: 'org.jboss.spec.javax.servlet', module: 'jboss-servlet-api_4.0_spec'
-        exclude group: 'org.jboss.spec.javax.annotation', module: 'jboss-annotations-api_1.3_spec'
-    }
+    api 'io.undertow:undertow-servlet'
     api 'jakarta.annotation:jakarta.annotation-api'
     api 'jakarta.servlet:jakarta.servlet-api'
     api 'org.apache.httpcomponents.client5:httpclient5'

--- a/versions.lock
+++ b/versions.lock
@@ -136,7 +136,7 @@ io.smallrye.common:smallrye-common-ref:2.4.0 (1 constraints: b10e835a)
 
 jakarta.activation:jakarta.activation-api:2.1.3 (1 constraints: 8f0f4a91)
 
-jakarta.annotation:jakarta.annotation-api:2.1.1 (4 constraints: f4368043)
+jakarta.annotation:jakarta.annotation-api:2.1.1 (4 constraints: eb33a574)
 
 jakarta.el:jakarta.el-api:5.0.1 (1 constraints: fe135c65)
 
@@ -190,9 +190,9 @@ org.immutables:value:2.12.2 (2 constraints: 0215eec1)
 
 org.javassist:javassist:3.30.2-GA (1 constraints: 2811fff0)
 
-org.jboss.logging:jboss-logging:3.6.1.Final (8 constraints: db99a7cb)
+org.jboss.logging:jboss-logging:3.6.1.Final (8 constraints: dd99fbcc)
 
-org.jboss.threads:jboss-threads:3.9.2 (3 constraints: a8285de8)
+org.jboss.threads:jboss-threads:3.9.2 (3 constraints: a9288ee8)
 
 org.jetbrains:annotations:26.1.0 (3 constraints: de2fdf34)
 
@@ -230,11 +230,11 @@ com.squareup.okhttp3:mockwebserver:4.12.0 (1 constraints: 3905413b)
 
 io.reactivex.rxjava2:rxjava:2.2.21 (1 constraints: 3905363b)
 
-io.undertow:undertow-core:2.2.38.Final (2 constraints: ab1911ec)
+io.undertow:undertow-core:2.3.24.Final (2 constraints: a1161718)
 
-io.undertow:undertow-servlet-jakarta:2.2.20.Final (1 constraints: 50071361)
+io.undertow:undertow-servlet:2.3.24.Final (1 constraints: 55073961)
 
-jakarta.servlet:jakarta.servlet-api:5.0.0 (2 constraints: 1015bdac)
+jakarta.servlet:jakarta.servlet-api:6.0.0 (2 constraints: 06124901)
 
 junit:junit:4.13.2 (1 constraints: 690fa77c)
 

--- a/versions.props
+++ b/versions.props
@@ -38,7 +38,6 @@ io.undertow:* = 2.3.24.Final
 # Last version of undertow with both Jakarta+Javax support before 'undertow-servlet' was
 # updated to jakarta only. This should NEVER be done in production code, it is only used
 # here to enable existing test coverage.
-io.undertow:undertow-servlet-jakarta = 2.2.20.Final
 # dependency-upgrader:ON
 com.palantir.refreshable:refreshable = 2.14.0
 org.hibernate.validator:* = 6.2.0.Final

--- a/versions.props
+++ b/versions.props
@@ -33,7 +33,7 @@ org.junit.jupiter:* = 6.1.0
 org.junit.platform:* = 6.1.0
 org.mockito:* = 5.23.0
 org.slf4j:* = 2.0.17
-io.undertow:* = 2.2.38.Final
+io.undertow:* = 2.3.24.Final
 # dependency-upgrader:OFF
 # Last version of undertow with both Jakarta+Javax support before 'undertow-servlet' was
 # updated to jakarta only. This should NEVER be done in production code, it is only used


### PR DESCRIPTION
Removes test-only dependency on undertow-servlet-jakarta in favor of undertow-servlet, which has since migrated to Jakarta. 

Dependent repos will need to switch usages of undertow-servlet-jakarta, but this should be an early and obvious failure because there isn't a -jakarta package in 2.3.